### PR TITLE
Android: HTTP response processing & debug log

### DIFF
--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/exceptions/ErrorResponseApiException.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/exceptions/ErrorResponseApiException.java
@@ -19,17 +19,28 @@ package io.getlime.security.powerauth.networking.exceptions;
 import io.getlime.security.powerauth.rest.api.model.entity.ErrorModel;
 
 /**
- * Created by miroslavmichalec on 12/10/2016.
+ * Signals that a REST connection failed with a known error. You can check
+ * the reason of failure in the attached ErrorModel object.
  */
-
 public class ErrorResponseApiException extends Exception {
 
+    /**
+     * Error response received from the server
+     */
     private ErrorModel mErrorResponse;
 
+    /**
+     * Constructs a new exception with error received from server.
+     *
+     * @param errorResponse error received from server
+     */
     public ErrorResponseApiException(ErrorModel errorResponse) {
         this.mErrorResponse = errorResponse;
     }
 
+    /**
+     * @return ErrorModel with failure reason
+     */
     public ErrorModel getErrorResponse() {
         return mErrorResponse;
     }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/exceptions/FailedApiException.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/exceptions/FailedApiException.java
@@ -17,23 +17,53 @@
 package io.getlime.security.powerauth.networking.exceptions;
 
 /**
- * Created by miroslavmichalec on 20/10/2016.
+ * Signals that a REST connection failed with an unknown response from the server.
+ * You can investigate a received HTTP response code and response body string
+ * for more details.
  */
-
 public class FailedApiException extends Exception {
 
+    /**
+     * HTTP response code
+     */
     private int responseCode;
+    /**
+     * HTTP response body. The value may be null.
+     */
+    private String responseBody;
 
-    public FailedApiException(int responseCode) {
+    /**
+     * Constructs an exception with response code and response body.
+     *
+     * @param responseCode HTTP response code
+     * @param responseBody HTTP response body
+     */
+    public FailedApiException(int responseCode, String responseBody) {
         this.responseCode = responseCode;
+        this.responseBody = responseBody;
     }
 
-    public FailedApiException(String message, int responseCode) {
+
+    /**
+     * Constructs an exception with message, response code and response body.
+     *
+     * @param message message from another exception
+     * @param responseCode HTTP response code
+     * @param responseBody HTTP response body
+     */
+    public FailedApiException(String message, int responseCode, String responseBody) {
         super(message);
         this.responseCode = responseCode;
+        this.responseBody = responseBody;
     }
 
-    public int getResponseCode() {
-        return responseCode;
-    }
+    /**
+     * @return HTTP response code
+     */
+    public int getResponseCode() { return responseCode; }
+
+    /**
+     * @return HTTP response body. The returned value may be null.
+     */
+    public String getResponseBody() { return responseBody; }
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthClientConfiguration.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthClientConfiguration.java
@@ -17,6 +17,7 @@
 package io.getlime.security.powerauth.sdk;
 
 import io.getlime.security.powerauth.networking.ssl.PA2ClientValidationStrategy;
+import io.getlime.security.powerauth.system.PA2Log;
 
 /**
  * Created by miroslavmichalec on 21/10/2016.
@@ -86,6 +87,9 @@ public class PowerAuthClientConfiguration {
 
         public Builder allowUnsecuredConnection(boolean allow) {
             this.allowUnsecuredConnection = allow;
+            if (allow) {
+                 PA2Log.e("Unsecured connection is dangerous for production application.");
+            }
             return this;
         }
 

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/system/PA2Log.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/system/PA2Log.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.system;
+
+/**
+ * Class that provides logging facility for PowerAuth SDK library.
+ *
+ * @author Juraj Durech
+ */
+public class PA2Log {
+
+    /**
+     Controls whether the PowerAuth log is enabled.
+     */
+    private static boolean logIsEnabled = false;
+    /**
+     TAG constant for our messages
+     */
+    private static final String LOG_TAG = "PowerAuthLibrary";
+
+    /**
+     * Controls logging from PowerAuth classes
+     * @param enabled enables or disables debug logs
+     */
+    public static void setEnabled(boolean enabled) {
+        logIsEnabled = enabled;
+        if (enabled) {
+            android.util.Log.d(LOG_TAG, "PA2Log is now turned on");
+        }
+    }
+    /**
+     * @return true if PowerAuth log is enabled
+     */
+    public static boolean isEnabled() { return logIsEnabled; }
+
+    /**
+     * Adds a formatted DEBUG log message if log is enabled.
+     * @param format format string, just like for {@link java.lang.String#format String.format}
+     * @param args Arguments referenced by the format specifiers in the format
+     *        string.
+     */
+    public static void d(String format, Object... args) {
+        if (logIsEnabled) {
+            String message = String.format(format, args);
+            android.util.Log.d(LOG_TAG, message);
+        }
+    }
+
+    /**
+     * Adds a formatted ERROR log message. Unlike DEBUG message calling this method always
+     * produce error record.
+     * @param format format string, just like for {@link java.lang.String#format String.format}
+     * @param args Arguments referenced by the format specifiers in the format
+     *        string.
+     */
+    public static void e(String format, Object... args) {
+        String message = String.format(format, args);
+        android.util.Log.e(LOG_TAG, message);
+    }
+}


### PR DESCRIPTION
This change brings better response processing to PA2Client and address following issues:
1. `NullPointerException` was raised when valid, but semantically wrong JSON was received 
2. `FileNotFound` exception was raised when 400 or 401 status code was received. Now the correct `ErrorResponseApiException` is reported
3. Now it's possible to investigate received body string later, in the user's handling routine

Also PA2Client now supports optional request & response debug logging. You can turn this feature on by calling `PA2Log.setEnabled(true)`

Fix #34, Fix #28 