### PR TITLE
Issue/43 reset session state

### DIFF
--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -406,16 +406,6 @@ public class PowerAuthSDK {
     }
 
     /**
-     * Reset the PowerAuthSDK instance - remove pending activations and stored error states.
-     *
-     * @throws PowerAuthMissingConfigException thrown in case configuration is not present.
-     */
-    public void reset() {
-        checkForValidSetup();
-        mSession.resetSession();
-    }
-
-    /**
      * Destroy the PowerAuthSDK instance. Internal objects will be securely destroyed and PowerAuthSDK instance
      * can't be more used after this call.
      */

--- a/proj-xcode/Classes/sdk/PowerAuthSDK.m
+++ b/proj-xcode/Classes/sdk/PowerAuthSDK.m
@@ -405,6 +405,7 @@ static PowerAuthSDK *inst;
 		[task cancel];
 		return task;
 	}
+	// After this point, each error must lead to [_session resetSession];
 	
 	// Perform exchange over PowerAuth 2.0 Standard RESTful API
 	PA2CreateActivationRequest *request = [[PA2CreateActivationRequest alloc] init];
@@ -503,6 +504,7 @@ static PowerAuthSDK *inst;
 		[task cancel];
 		return task;
 	}
+	// After this point, each error must lead to [_session resetSession];
 	
 	// Perform exchange over PowerAuth 2.0 Standard RESTful API
 	PA2CreateActivationRequest *powerauth = [[PA2CreateActivationRequest alloc] init];

--- a/proj-xcode/TestClasses/PowerAuthSDKTests.m
+++ b/proj-xcode/TestClasses/PowerAuthSDKTests.m
@@ -617,7 +617,7 @@
 	// supported and will be used for initiating the activation on the server's side.
 	//
 	
-	[_sdk reset];
+	[_sdk removeActivationLocal];
 	
 	BOOL result;
 	__block NSError * reportedError;


### PR DESCRIPTION
This change resolves:
- **Android:**  Still present `PowerAuthSDK.reset()` - now the method is really removed :) You can use `PowerAuthSDK.removeActivationLocal()` as a replacement.
- **Android:**  now you can control whether the shared biometry is removed in `PowerAuthSDK.removeActivationLocal()`
- Resolves inconsistency of internal Session object during the activation process. Now it's not necessary to reset session when the error occurs during the activation.