### PR TITLE
Issue/36 custom activation response

### DIFF
--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/client/PA2Client.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/client/PA2Client.java
@@ -63,6 +63,7 @@ import io.getlime.security.powerauth.rest.api.model.entity.ErrorModel;
 import io.getlime.security.powerauth.rest.api.model.entity.NonPersonalizedEncryptedPayloadModel;
 import io.getlime.security.powerauth.rest.api.model.request.ActivationCreateRequest;
 import io.getlime.security.powerauth.rest.api.model.request.ActivationStatusRequest;
+import io.getlime.security.powerauth.rest.api.model.response.ActivationCreateCustomResponse;
 import io.getlime.security.powerauth.rest.api.model.response.ActivationCreateResponse;
 import io.getlime.security.powerauth.rest.api.model.response.ActivationStatusResponse;
 import io.getlime.security.powerauth.rest.api.model.response.VaultUnlockResponse;
@@ -305,7 +306,7 @@ public class PA2Client {
             @NonNull PowerAuthConfiguration configuration,
             @NonNull PowerAuthClientConfiguration clientConfiguration,
             @NonNull ActivationCreateRequest request,
-            @NonNull INetworkResponseListener<ActivationCreateResponse> listener) {
+            @NonNull INetworkResponseListener<ActivationCreateCustomResponse> listener) {
         return execute(configuration, clientConfiguration, new PA2CreateActivationEndpoint(configuration.getBaseEndpointUrl()), request, null, listener);
     }
 

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/endpoints/PA2CreateActivationEndpoint.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/endpoints/PA2CreateActivationEndpoint.java
@@ -19,13 +19,13 @@ package io.getlime.security.powerauth.networking.endpoints;
 import com.google.gson.reflect.TypeToken;
 
 import io.getlime.security.powerauth.networking.interfaces.IEndpointDefinition;
-import io.getlime.security.powerauth.rest.api.model.response.ActivationCreateResponse;
+import io.getlime.security.powerauth.rest.api.model.response.ActivationCreateCustomResponse;
 
 /**
  * Created by miroslavmichalec on 12/10/2016.
  */
 
-public class PA2CreateActivationEndpoint implements IEndpointDefinition<ActivationCreateResponse> {
+public class PA2CreateActivationEndpoint implements IEndpointDefinition<ActivationCreateCustomResponse> {
 
     private String baseUrl;
 
@@ -45,7 +45,7 @@ public class PA2CreateActivationEndpoint implements IEndpointDefinition<Activati
     }
 
     @Override
-    public TypeToken<ActivationCreateResponse> getResponseType() {
-        return TypeToken.get(ActivationCreateResponse.class);
+    public TypeToken<ActivationCreateCustomResponse> getResponseType() {
+        return TypeToken.get(ActivationCreateCustomResponse.class);
     }
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/response/ICreateActivationListener.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/response/ICreateActivationListener.java
@@ -16,11 +16,29 @@
 
 package io.getlime.security.powerauth.networking.response;
 
-/**
- * Created by miroslavmichalec on 03/11/2016.
- */
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
+import java.util.Map;
+
+/**
+ * Interface used to allow the initiator of power auth activation to get the result from
+ * the operation.
+ */
 public interface ICreateActivationListener {
-    void onActivationCreateSucceed(String activationFingerprint);
-    void onActivationCreateFailed(Throwable t);
+    /**
+     * Called when activation succeeds.
+     * @param activationFingerprint      decimalized fingerprint calculated from device's public key
+     * @param customActivationAttributes custom attributes received from the server. The value
+     *                                   may be null in case that there are no custom attributes
+     *                                   available.
+     */
+    void onActivationCreateSucceed(@NonNull String activationFingerprint,
+                                   @Nullable Map<String, Object> customActivationAttributes);
+
+    /**
+     * Called when activation fails with an error.
+     * @param t error occurred during the activation
+     */
+    void onActivationCreateFailed(@NonNull Throwable t);
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -483,10 +483,10 @@ public class PowerAuthSDK {
         request.setExtras(extras);
 
         // Perform the server request
-        return mClient.createActivation(mConfiguration, mClientConfiguration, request, new INetworkResponseListener<ActivationCreateResponse>() {
+        return mClient.createActivation(mConfiguration, mClientConfiguration, request, new INetworkResponseListener<ActivationCreateCustomResponse>() {
 
             @Override
-            public void onNetworkResponse(ActivationCreateResponse response) {
+            public void onNetworkResponse(ActivationCreateCustomResponse response) {
                 // Network communication completed correctly
                 final ActivationStep2Param paramStep2 = new ActivationStep2Param(
                         response.getActivationId(),
@@ -499,7 +499,7 @@ public class PowerAuthSDK {
                 final ActivationStep2Result resultStep2 = mSession.validateActivationResponse(paramStep2);
                 if (resultStep2.errorCode == ErrorCode.OK) {
                     // Everything was OK
-                    listener.onActivationCreateSucceed(resultStep2.hkDevicePublicKey);
+                    listener.onActivationCreateSucceed(resultStep2.hkDevicePublicKey, response.getCustomAttributes());
                 } else {
                     // Error occurred
                     mSession.resetSession();
@@ -609,7 +609,7 @@ public class PowerAuthSDK {
                     ActivationStep2Result step2Result = mSession.validateActivationResponse(step2Param);
 
                     if (step2Result != null && step2Result.errorCode == ErrorCode.OK) {
-                        listener.onActivationCreateSucceed(step2Result.hkDevicePublicKey);
+                        listener.onActivationCreateSucceed(step2Result.hkDevicePublicKey, activationCreateResponse.getCustomAttributes());
                     } else {
                         mSession.resetSession();
                         listener.onActivationCreateFailed(new PowerAuthErrorException(PowerAuthErrorCodes.PA2ErrorCodeInvalidActivationData));

--- a/proj-xcode/Classes/networking/entity/PA2ActivationResult.h
+++ b/proj-xcode/Classes/networking/entity/PA2ActivationResult.h
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+/**
+ The PA2ActivationResult object represents successfull result from the activation
+ process.
+ */
+@interface PA2ActivationResult : NSObject
+
+/**
+ Decimalized fingerprint calculated from device's public key.
+ */
+@property (nonatomic, strong, nonnull) NSString * activationFingerprint;
+
+/**
+ Custom attributes received from the server. The value may be nil in case that there 
+ are no custom attributes available.
+ */
+@property (nonatomic, strong, nullable) NSDictionary<NSString*, NSObject*>* customAttributes;
+
+@end

--- a/proj-xcode/Classes/networking/entity/PA2ActivationResult.m
+++ b/proj-xcode/Classes/networking/entity/PA2ActivationResult.m
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "PA2ActivationResult.h"
+
+@implementation PA2ActivationResult
+
+@end

--- a/proj-xcode/Classes/networking/response/PA2CreateActivationResponse.h
+++ b/proj-xcode/Classes/networking/response/PA2CreateActivationResponse.h
@@ -27,4 +27,9 @@
 @property (nonatomic, strong) NSString *encryptedServerPublicKey;
 @property (nonatomic, strong) NSString *encryptedServerPublicKeySignature;
 
+/**
+ Custom attributes received from the server. The value may be nil.
+ */
+@property (nonatomic, strong) NSDictionary<NSString*, NSObject*>* customAttributes;
+
 @end

--- a/proj-xcode/Classes/networking/response/PA2CreateActivationResponse.m
+++ b/proj-xcode/Classes/networking/response/PA2CreateActivationResponse.m
@@ -26,6 +26,7 @@
         _ephemeralPublicKey					= [dictionary objectForKey:@"ephemeralPublicKey"];
         _encryptedServerPublicKey			= [dictionary objectForKey:@"encryptedServerPublicKey"];
         _encryptedServerPublicKeySignature	= [dictionary objectForKey:@"encryptedServerPublicKeySignature"];
+		_customAttributes					= [dictionary objectForKey:@"customAttributes"];
     }
     return self;
 }
@@ -47,6 +48,9 @@
     if (_encryptedServerPublicKeySignature) {
         [dictionary setObject:_encryptedServerPublicKeySignature forKey:@"encryptedServerPublicKeySignature"];
     }
+	if (_customAttributes) {
+		[dictionary setObject:_customAttributes forKey:@"customAttributes"];
+	}
     return dictionary;
 }
 

--- a/proj-xcode/Classes/sdk/PowerAuthSDK.h
+++ b/proj-xcode/Classes/sdk/PowerAuthSDK.h
@@ -28,6 +28,7 @@
 #import "PA2EncryptorFactory.h"
 #import "PA2PasswordUtil.h"
 #import "PA2OtpUtil.h"
+#import "PA2ActivationResult.h"
 
 @interface PowerAuthSDK : NSObject
 
@@ -98,7 +99,7 @@
  */
 - (nonnull PA2OperationTask*) createActivationWithName:(nullable NSString*)name
 										activationCode:(nonnull NSString*)activationCode
-											  callback:(nonnull void(^)(NSString * _Nullable activationFingerprint, NSError * _Nullable error))callback;
+											  callback:(nonnull void(^)(PA2ActivationResult * _Nullable result, NSError * _Nullable error))callback;
 
 /** Create a new activation with given name and activation code by calling a PowerAuth 2.0 Standard RESTful API endpoint '/pa/activation/create'.
  
@@ -112,7 +113,7 @@
 - (nonnull PA2OperationTask*) createActivationWithName:(nullable NSString*)name
 										activationCode:(nonnull NSString*)activationCode
 												extras:(nullable NSString*)extras
-											  callback:(nonnull void(^)(NSString * _Nullable activationFingerprint, NSError * _Nullable error))callback;
+											  callback:(nonnull void(^)(PA2ActivationResult * _Nullable result, NSError * _Nullable error))callback;
 
 /** Create a new activation with given name and custom activation data by calling a custom RESTful API endpoint.
  
@@ -134,7 +135,7 @@
 									  customAttributes:(nullable NSDictionary<NSString*,NSString*>*)customAttributes
 												   url:(nonnull NSURL*)url
 										   httpHeaders:(nullable NSDictionary*)httpHeaders
-											  callback:(nonnull void(^)(NSString * _Nullable activationFingerprint, NSError * _Nullable error))callback;
+											  callback:(nonnull void(^)(PA2ActivationResult * _Nullable result, NSError * _Nullable error))callback;
 
 /** Create a new activation with given name and custom activation data by calling a custom RESTful API endpoint.
  
@@ -148,7 +149,7 @@
 - (nonnull PA2OperationTask*) createActivationWithName:(nullable NSString*)name
 									identityAttributes:(nonnull NSDictionary<NSString*,NSString*>*)identityAttributes
 												   url:(nonnull NSURL*)url
-											  callback:(nonnull void(^)(NSString * _Nullable activationFingerprint, NSError * _Nullable error))callback;
+											  callback:(nonnull void(^)(PA2ActivationResult * _Nullable result, NSError * _Nullable error))callback;
 
 /** Commit activation that was created and store related data using provided authentication instance.
  

--- a/proj-xcode/PowerAuthLib.xcodeproj/project.pbxproj
+++ b/proj-xcode/PowerAuthLib.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		BFB494241CE9120600F8D81B /* pa2ServerPublicKeyDecryption.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BFB494231CE9120600F8D81B /* pa2ServerPublicKeyDecryption.cpp */; };
 		BFB494261CE9138D00F8D81B /* pa2MasterSecretKeyComputation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BFB494251CE9138D00F8D81B /* pa2MasterSecretKeyComputation.cpp */; };
 		BFB494281CE914D800F8D81B /* pa2SignatureCalculationTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BFB494271CE914D800F8D81B /* pa2SignatureCalculationTests.cpp */; };
+		BFF9CE0B1F07DC34001C892B /* PA2ActivationResult.m in Sources */ = {isa = PBXBuildFile; fileRef = BFF9CE0A1F07DC34001C892B /* PA2ActivationResult.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -351,6 +352,8 @@
 		BFB494231CE9120600F8D81B /* pa2ServerPublicKeyDecryption.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pa2ServerPublicKeyDecryption.cpp; sourceTree = "<group>"; };
 		BFB494251CE9138D00F8D81B /* pa2MasterSecretKeyComputation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pa2MasterSecretKeyComputation.cpp; sourceTree = "<group>"; };
 		BFB494271CE914D800F8D81B /* pa2SignatureCalculationTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pa2SignatureCalculationTests.cpp; sourceTree = "<group>"; };
+		BFF9CE091F07DC34001C892B /* PA2ActivationResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PA2ActivationResult.h; sourceTree = "<group>"; };
+		BFF9CE0A1F07DC34001C892B /* PA2ActivationResult.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PA2ActivationResult.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -416,6 +419,8 @@
 				1B789F511E2654170095519E /* PA2PersonalizedEncryptedObject.m */,
 				1B789F441E2640640095519E /* PA2NonPersonalizedEncryptedObject.h */,
 				1B789F451E2640640095519E /* PA2NonPersonalizedEncryptedObject.m */,
+				BFF9CE091F07DC34001C892B /* PA2ActivationResult.h */,
+				BFF9CE0A1F07DC34001C892B /* PA2ActivationResult.m */,
 			);
 			path = entity;
 			sourceTree = "<group>";
@@ -1035,6 +1040,7 @@
 				BF14FE881CF8A4800032B30C /* URLEncoding.cpp in Sources */,
 				1B2EEF711D662CAA0039D92A /* PA2CreateActivationRequest.m in Sources */,
 				BF14FE871CF8A4800032B30C /* DataWriter.cpp in Sources */,
+				BFF9CE0B1F07DC34001C892B /* PA2ActivationResult.m in Sources */,
 				1B968C571E2CDEF800F429E0 /* PA2DirectCreateActivationRequest.m in Sources */,
 				BF234CA01CE5B14C00312A7F /* PrivateTypes.cpp in Sources */,
 				1BCC37011D91380100709311 /* PowerAuthSDK.m in Sources */,

--- a/proj-xcode/TestClasses/PowerAuthSDKTests.m
+++ b/proj-xcode/TestClasses/PowerAuthSDKTests.m
@@ -308,8 +308,8 @@
 	// 2) CLIENT: Start activation on client's side
 	result = [[AsyncHelper synchronizeAsynchronousBlock:^(AsyncHelper *waiting) {
 		
-		PA2OperationTask * task = [_sdk createActivationWithName:_activationName activationCode:activationCode callback:^(NSString * fingerprint, NSError * error) {
-			activationFingerprint = fingerprint;
+		PA2OperationTask * task = [_sdk createActivationWithName:_activationName activationCode:activationCode callback:^(PA2ActivationResult * result, NSError * error) {
+			activationFingerprint = result.activationFingerprint;
 			[waiting reportCompletion:@(error == nil)];
 		}];
 		// Returned task should not be cancelled
@@ -644,8 +644,8 @@
 	// 4) CLIENT: Start activation on client's side
 	result = [[AsyncHelper synchronizeAsynchronousBlock:^(AsyncHelper *waiting) {
 		
-		PA2OperationTask * task = [_sdk createActivationWithName:_activationName activationCode:activationCode callback:^(NSString * fingerprint, NSError * error) {
-			activationFingerprint = fingerprint;
+		PA2OperationTask * task = [_sdk createActivationWithName:_activationName activationCode:activationCode callback:^(PA2ActivationResult * result, NSError * error) {
+			activationFingerprint = result.activationFingerprint;
 			reportedError = error;
 			[waiting reportCompletion:@(error == nil)];
 		}];


### PR DESCRIPTION
This set of changes adds possibility to receive a custom attributes from the server during the activation. The implementation was changed for both platforms.

**Just for note**, the Android implementation is currently using `ActivationCreateCustomResponse` model object, which will be removed in later releases of `io.getlime.security:powerauth-restful-model` package. All this is fortunately an internal change and should not affect the future public interface.  