### PR TITLE
Android: Fixed #177: ErrorResponseApiException now contains HTTP status code (obsolete V2 SDK)

### DIFF
--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/client/PA2Client.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/client/PA2Client.java
@@ -223,7 +223,7 @@ public class PA2Client {
                             } else {
                                 // Status is not "OK", try to create ErrorModel object
                                 final Error error = mGson.fromJson(responseElement, TypeToken.get(Error.class).getType());
-                                callOnErrorUi(new ErrorResponseApiException(error, responseBody, responseJson), responseListener);
+                                callOnErrorUi(new ErrorResponseApiException(error, responseCode, responseBody, responseJson), responseListener);
                             }
                             // Return now, because for all other cases, we will report an error...
                             return null;

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/exceptions/ErrorResponseApiException.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/exceptions/ErrorResponseApiException.java
@@ -24,7 +24,7 @@ import io.getlime.core.rest.model.base.entity.Error;
  * Signals that a REST connection failed with a known error. You can check
  * the reason of failure in the attached ErrorModel object.
  */
-public class ErrorResponseApiException extends Exception {
+public class ErrorResponseApiException extends FailedApiException {
 
     /**
      * Error response received from the server
@@ -32,46 +32,23 @@ public class ErrorResponseApiException extends Exception {
     private Error errorResponse;
 
     /**
-     * Full response body received from the server
-     */
-    private String responseBody;
-
-    /**
-     * JSON parsed from response body or null if received content is not JSON
-     */
-    private JsonObject responseJson;
-
-
-    /**
-     * Constructs a new exception with error received from server.
+     * Constructs an exception with {@link Error} model object, response code and response body.
      *
      * @param errorResponse error received from server
+     * @param responseCode HTTP response code
+     * @param responseBody HTTP response body, may be null if it's not available.
+     * @param responseJson {@link JsonObject} with JSON root, received from the server. May be null if response
+     *                     is not in JSON format.
      */
-    public ErrorResponseApiException(Error errorResponse, String responseBody, JsonObject responseJson) {
+    public ErrorResponseApiException(Error errorResponse, int responseCode, String responseBody, JsonObject responseJson) {
+        super(responseCode, responseBody, responseJson);
         this.errorResponse = errorResponse;
-        this.responseBody = responseBody;
-        this.responseJson = responseJson;
     }
 
     /**
-     * @return ErrorModel with failure reason
+     * @return {@link Error} model object with failure reason
      */
     public Error getErrorResponse() {
         return errorResponse;
-    }
-
-    /**
-     * @return Full response body received from the server
-     */
-    public String getResponseBody() {
-        return responseBody;
-    }
-
-
-    /**
-     * @return JsonObject parsed from response body or null if received content is not JSON
-     */
-    public JsonObject getResponseJson() {
-        return responseJson;
     }
 }

--- a/proj-android/build.gradle
+++ b/proj-android/build.gradle
@@ -3,8 +3,8 @@ buildscript {
     repositories {
         mavenLocal()
         mavenCentral()
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.4'
@@ -22,7 +22,7 @@ allprojects {
     repositories {
         mavenLocal()
         mavenCentral()
-        jcenter()
         google()
+        jcenter()
      }
 }


### PR DESCRIPTION
Fixed build order in gradle script (google vs jcenter)

Similar change to #190 but for `release/0.20.x` branch