### PR TITLE
Deprecate unsafeChangePassword() methods

### DIFF
--- a/docs/Migration-from-1.9-to-1.10.md
+++ b/docs/Migration-from-1.9-to-1.10.md
@@ -13,6 +13,9 @@ PowerAuth Mobile SDK in version `1.10.0` provides the following improvements:
 
 ### API changes
 
+- The following methods in `PowerAuthSDK` class are deprecated:
+  - `changePasswordUnsafe()` - use asynchronous `changePassword()` as a replacement.
+
 - Due to removed support of recovery codes, the following classes and methods are no longer available:
   - Methods removed in `PowerAuthSDK`:
     - `createRecoveryActivation()`
@@ -43,12 +46,15 @@ PowerAuth Mobile SDK in version `1.10.0` provides the following improvements:
 
 ### API changes
 
+- The following methods in `PowerAuthSDK` class are deprecated:
+  - `unsafeChangePassword(from:to:)` - use asynchronous `changePassword(from:to:callback:)` as a replacement.
+
 - Due to removed support of recovery codes, the following classes and methods are no longer available:
   - Methods removed in `PowerAuthSDK`:
-    - `createActivation(withName:, recoveryCode:, recoveryPuk:, extras:, callback:)`
+    - `createActivation(withName:recoveryCode:recoveryPuk:extras:callback:)`
     - `hasActivationRecoveryData()`
-    - `activationRecoveryData(authentication:, callback:)`
-    - `confirm(recoveryCode:, authentication:, callback:)`
+    - `activationRecoveryData(authentication:callback:)`
+    - `confirm(recoveryCode:, authentication:callback:)`
   - Methods removed in `PowerAuthActivationCodeUtil`:
     - `validateRecoveryCode()`
     - `validateRecoveryPuk()`
@@ -56,7 +62,7 @@ PowerAuth Mobile SDK in version `1.10.0` provides the following improvements:
   - Other changes:
     - removed class `PowerAuthActivationRecoveryData`
     - removed property `PowerAuthActivationResult.activationRecovery`
-    - removed constructor `PowerAuthActivation(recoveryCode:, recoveryPuk:, name:)`
+    - removed constructor `PowerAuthActivation(recoveryCode:recoveryPuk:name:)`
 
 - Removed all interfaces deprecated in release `1.9.x`
 

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -1632,7 +1632,7 @@ public class PowerAuthSDK {
 
     /**
      * Change the password using local re-encryption, do not validate old password by calling any endpoint.
-     *
+     * <p>
      * You are responsible for validating the old password against some server endpoint yourself before using it in this method.
      * If you do not validate the old password to make sure it is correct, calling this method will corrupt the local data, since
      * existing data will be decrypted using invalid PIN code and re-encrypted with a new one.
@@ -1641,14 +1641,16 @@ public class PowerAuthSDK {
      * @param newPassword New password to be set to store the data.
      * @return Returns 'true' in case password was changed without error, 'false' otherwise.
      * @throws PowerAuthMissingConfigException thrown in case configuration is not present.
+     * @deprecated Method is deprecated, use {@link #changePassword(Context, String, String, IChangePasswordListener)} as a replacement.
      */
+    @Deprecated // 1.10.0
     public boolean changePasswordUnsafe(@NonNull final String oldPassword, @NonNull final String newPassword) {
-        return changePasswordUnsafe(new Password(oldPassword), new Password(newPassword));
+        return changePasswordUnsafeImpl(new Password(oldPassword), new Password(newPassword));
     }
 
     /**
      * Change the password using local re-encryption, do not validate old password by calling any endpoint.
-     *
+     * <p>
      * You are responsible for validating the old password against some server endpoint yourself before using it in this method.
      * If you do not validate the old password to make sure it is correct, calling this method will corrupt the local data, since
      * existing data will be decrypted using invalid PIN code and re-encrypted with a new one.
@@ -1657,8 +1659,23 @@ public class PowerAuthSDK {
      * @param newPassword New password to be set to store the data.
      * @return Returns 'true' in case password was changed without error, 'false' otherwise.
      * @throws PowerAuthMissingConfigException thrown in case configuration is not present.
+     * @deprecated Method is deprecated, use {@link #changePassword(Context, Password, Password, IChangePasswordListener)} as a replacement.
      */
+    @Deprecated // 1.10.0
     public boolean changePasswordUnsafe(@NonNull final Password oldPassword, @NonNull final Password newPassword) {
+        return changePasswordUnsafeImpl(oldPassword, newPassword);
+    }
+
+    /**
+     * Change the password using local re-encryption. This is private implementation of deprecated function.
+     *
+     * @param oldPassword Old password, currently set to store the data.
+     * @param newPassword New password to be set to store the data.
+     * @return Returns 'true' in case password was changed without error, 'false' otherwise.
+     * @throws PowerAuthMissingConfigException thrown in case configuration is not present.
+     */
+    //@Deprecated // 1.10.0
+    private boolean changePasswordUnsafeImpl(@NonNull final Password oldPassword, @NonNull final Password newPassword) {
         final int result = mSession.changeUserPassword(oldPassword, newPassword);
         if (result == ErrorCode.OK) {
             saveSerializedState();

--- a/proj-xcode/PowerAuth2/PowerAuthSDK.h
+++ b/proj-xcode/PowerAuth2/PowerAuthSDK.h
@@ -333,6 +333,8 @@
  If you do not validate the old password to make sure it is correct, calling this method will corrupt the local data, since
  existing data will be decrypted using invalid PIN code and re-encrypted with a new one.
  
+ Method is deprecated and you should use `changePassword(from:to:callback:)` as a replacement.
+ 
  @param oldPassword Old password, currently set to store the data.
  @param newPassword New password, to be set in case authentication with old password passes.
  @return Returns YES in case password was changed without error, NO otherwise.
@@ -340,13 +342,16 @@
  */
 - (BOOL) unsafeChangePasswordFrom:(nonnull NSString*)oldPassword
                                to:(nonnull NSString*)newPassword
-                        NS_SWIFT_NAME(unsafeChangePassword(from:to:));
+                        NS_SWIFT_NAME(unsafeChangePassword(from:to:))
+                        PA2_DEPRECATED(1.10.0);
 
 /** Change the password using local re-encryption, do not validate old password by calling any endpoint.
  
  You are responsible for validating the old password against some server endpoint yourself before using it in this method.
  If you do not validate the old password to make sure it is correct, calling this method will corrupt the local data, since
  existing data will be decrypted using invalid PIN code and re-encrypted with a new one.
+ 
+ Method is deprecated and you should use `changePassword(from:to:callback:)` as a replacement.
  
  @param oldPassword Old password, currently set to store the data.
  @param newPassword New password, to be set in case authentication with old password passes.
@@ -355,7 +360,8 @@
  */
 - (BOOL) unsafeChangeCorePasswordFrom:(nonnull PowerAuthCorePassword*)oldPassword
                                    to:(nonnull PowerAuthCorePassword*)newPassword
-                        NS_SWIFT_NAME(unsafeChangePassword(from:to:));
+                        NS_SWIFT_NAME(unsafeChangePassword(from:to:))
+                        PA2_DEPRECATED(1.10.0);
 
 /** Change the password, validate old password by calling a PowerAuth Standard RESTful API endpoint '/pa/signature/validate'.
  

--- a/proj-xcode/PowerAuth2/PowerAuthSDK.m
+++ b/proj-xcode/PowerAuth2/PowerAuthSDK.m
@@ -1144,8 +1144,10 @@ static PowerAuthSDK * s_inst;
 - (BOOL) unsafeChangePasswordFrom:(NSString*)oldPassword
                                to:(NSString*)newPassword
 {
-    return [self unsafeChangeCorePasswordFrom:[PowerAuthCorePassword passwordWithString:oldPassword]
-                                           to:[PowerAuthCorePassword passwordWithString:newPassword]];
+    return [_sessionInterface writeBoolTaskWithSession:^BOOL(PowerAuthCoreSession * session) {
+        return [session changeUserPassword:[PowerAuthCorePassword passwordWithString:oldPassword]
+                               newPassword:[PowerAuthCorePassword passwordWithString:newPassword]];
+    }];
 }
 
 - (id<PowerAuthOperationTask>) changePasswordFrom:(NSString*)oldPassword


### PR DESCRIPTION
This PR deprecates synchronous methods that change the password locally on the device. This is due to fact that this kind of interfaces will no longer be available in Crypto4 protocol version.