### PR TITLE
Include debug symbols into precompiled PowerAuthCore

### DIFF
--- a/PowerAuthCore.podspec
+++ b/PowerAuthCore.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
     
     # XCFramework  build    
     s.prepare_command = <<-CMD
-        ./scripts/ios-build-sdk.sh buildCore --out-dir Build/PowerAuthCore --optional-tvos
+        ./scripts/ios-build-sdk.sh buildCore --out-dir Build/PowerAuthCore --optional-tvos --include-dsyms
     CMD
     
     # Produced files

--- a/scripts/ios-build-sdk.sh
+++ b/scripts/ios-build-sdk.sh
@@ -59,6 +59,7 @@ DO_COPYSDK=0
 OPT_LEGACY_ARCH=0
 OPT_USE_BITCODE=0
 OPT_WEAK_TVOS=0
+OPT_INCLUDE_DSYMS=0
 
 # -----------------------------------------------------------------------------
 # USAGE prints help and exits the script with error code from provided parameter
@@ -81,6 +82,7 @@ function USAGE
     echo "  -nc | --no-clean  disable 'clean' before 'build'"
     echo "                    also disables temporary data cleanup after build"
     echo "  --optional-tvos   tvOS is not required when SDK is not installed"
+    echo "  --include-dsyms   include debug symbols into final xcframework"
     echo "  -v0               turn off all prints to stdout"
     echo "  -v1               print only basic log about build progress"
     echo "  -v2               print full build log with rich debug info"
@@ -347,8 +349,14 @@ function BUILD_COMMAND
 
     # Add produced platform framework to the list
     local FINAL_FW="${ARCHIVE_PATH}/Products/Library/Frameworks/${OUT_FW}.framework"
+    local FINAL_DSYM="${ARCHIVE_PATH}/dSYMs/${OUT_FW}.framework.dSYM"
     [[ ! -d "${FINAL_FW}" ]] && FAILURE "Xcode build did not produce '${OUT_FW}.framework' for platform ${PLATFORM}"
     ALL_FAT_LIBS+=("${FINAL_FW}")
+    ALL_XCFW_ARGS+=" -framework ${FINAL_FW}"
+    if [ x$OPT_INCLUDE_DSYMS == x1 ]; then
+        [[ ! -d "${FINAL_DSYM}" ]] && FAILURE "Xcode build did not produce dSYMs for '${OUT_FW}.framework' for platform ${PLATFORM}"
+        ALL_XCFW_ARGS+=" -debug-symbols ${FINAL_DSYM}"
+    fi
 }
 
 # -----------------------------------------------------------------------------
@@ -377,6 +385,7 @@ function BUILD_LIB
     PREPARE_OPENSSL
 
     ALL_FAT_LIBS=()
+    ALL_XCFW_ARGS=
     
     BUILD_PATCH_ARCHITECTURES
     
@@ -390,14 +399,12 @@ function BUILD_LIB
     LOG_LINE
     LOG "Creating final ${OUT_FW}.xcframework..."
     local XCFW_PATH="${OUT_DIR}/${OUT_FW}.xcframework"
-    local XCFW_ARGS=
     for ARG in ${ALL_FAT_LIBS[@]}; do
-        XCFW_ARGS+="-framework ${ARG} "
         DEBUG_LOG "  - source fw: ${ARG}"
     done
     DEBUG_LOG "  - target fw: ${XCFW_PATH}"
     
-    xcodebuild -create-xcframework $XCFW_ARGS -output "${XCFW_PATH}"    
+    xcodebuild -create-xcframework $ALL_XCFW_ARGS -output "${XCFW_PATH}"    
 }
 
 # -----------------------------------------------------------------------------
@@ -526,6 +533,9 @@ do
             ;;
         --optional-tvos)
             OPT_WEAK_TVOS=1
+            ;;
+        --include-dsyms)
+            OPT_INCLUDE_DSYMS=1
             ;;
         --legacy-archs)
             OPT_LEGACY_ARCH=1

--- a/scripts/templates/PowerAuth2.podspec
+++ b/scripts/templates/PowerAuth2.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
     s.cocoapods_version = '>= 1.10'
     s.name              = 'PowerAuth2'
     s.version           = '%DEPLOY_VERSION%'
-    s.summary           = 'PowerAuth Mobile SDK for iOS'
+    s.summary           = 'PowerAuth Mobile SDK for iOS and tvOS'
     s.homepage          = 'https://github.com/wultra/powerauth-mobile-sdk'
     s.social_media_url  = 'https://twitter.com/wultra'
     s.documentation_url = 'https://github.com/wultra/powerauth-mobile-sdk/blob/develop/docs/PowerAuth-SDK-for-iOS.md'

--- a/scripts/templates/PowerAuthCore.podspec
+++ b/scripts/templates/PowerAuthCore.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
     s.cocoapods_version = '>= 1.10'
     s.name              = 'PowerAuthCore'
     s.version           = '%DEPLOY_VERSION%'
-    s.summary           = 'PowerAuthCore library for iOS'
+    s.summary           = 'PowerAuthCore library for iOS and tvOS'
     s.homepage          = 'https://github.com/wultra/powerauth-mobile-sdk'
     s.social_media_url  = 'https://twitter.com/wultra'
     s.documentation_url = 'https://github.com/wultra/powerauth-mobile-sdk/blob/develop/docs/PowerAuth-SDK-for-iOS.md'
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
     
     # XCFramework  build    
     s.prepare_command = <<-CMD
-        ./scripts/ios-build-sdk.sh buildCore --out-dir Build/PowerAuthCore --optional-tvos
+        ./scripts/ios-build-sdk.sh buildCore --out-dir Build/PowerAuthCore --optional-tvos --include-dsyms
     CMD
     
     # Produced files


### PR DESCRIPTION
This PR adds feature that allows us to include debug symbols to precompiled xcframework. The feature is also turned-on for PowerAuthCore module, integrated with CocoaPods.