### PR TITLE
Logging improvements

### DIFF
--- a/docs/PowerAuth-SDK-for-iOS.md
+++ b/docs/PowerAuth-SDK-for-iOS.md
@@ -2113,7 +2113,7 @@ class MyClass: PowerAuthLogDelegate {
 If you're handling logs with the `PowerAuthLogDelegate`, you might want to turn off the default console logs. To do so, use:
 
 ```swift
-PowerAuthLogToConsole(false)
+PowerAuthLogToConsoleSetEnabled(false)
 ```
 
 ## Additional Features

--- a/docs/PowerAuth-SDK-for-iOS.md
+++ b/docs/PowerAuth-SDK-for-iOS.md
@@ -2065,9 +2065,13 @@ let powerAuthSDK = PowerAuthSDK(
 )
 ```
 
-### Debugging
+### Logs
 
-The debug log is by default turned off. To turn it on, use the following code:
+<!-- begin box warning -->
+Note that the functions below are effective only if PowerAuth SDK is compiled in the `DEBUG` build configuration or the `ENABLE_PA2_LOG` compilation flag is set.
+<!-- end -->
+
+Logs are turned off by default. To turn it on, use the following code:
 
 ```swift
 PowerAuthLogSetEnabled(true)
@@ -2078,10 +2082,6 @@ To turn on an even more detailed log, use the following code:
 ```swift
 PowerAuthLogSetVerbose(true)
 ```
-
-<!-- begin box warning -->
-Note that the functions above are effective only if PowerAuth SDK is compiled in the `DEBUG` build configuration or `ENABLE_PA2_LOG` compilation flag is set.
-<!-- end -->
 
 You can intercept the log and log it into your own report system, you can do so with `PowerAuthLogDelegate`.
 
@@ -2105,9 +2105,15 @@ class MyClass: PowerAuthLogDelegate {
     // MARK: - PowerAuthLogDelegate implementation
     
     func powerAuthLog(_ log: String) {
-        // Process the log...
+        // Process the log (write to file for example)
     }
 }
+```
+
+If you're handling logs with the `PowerAuthLogDelegate`, you might want to turn off the default console logs. To do so, use:
+
+```swift
+PowerAuthLogToConsole(false)
 ```
 
 ## Additional Features

--- a/proj-xcode/PowerAuth2/PowerAuthLog.h
+++ b/proj-xcode/PowerAuth2/PowerAuthLog.h
@@ -75,6 +75,19 @@ PA2_EXTERN_C void PowerAuthLogSetVerbose(BOOL verbose);
 PA2_EXTERN_C BOOL PowerAuthLogIsVerbose(void);
 
 /**
+ Function enables or disables logging to system console with NSLog.
+ When turned off, you can leverage the `PowerAuthLogSetDelegate` to implement your own logic.
+ Note that it's effective only when library is compiled in `DEBUG` build configuration or `ENABLE_PA2_LOG` compilation flag is set.
+ */
+PA2_EXTERN_C void PowerAuthLogToConsole(BOOL enabled);
+
+/**
+ Function returns YES if internal logging to system console with NSLog is enabled.
+ Note that when library is compiled in `RELEASE` configuration and when `ENABLE_PA2_LOG` compilation flag is missing, then always returns NO.
+ */
+PA2_EXTERN_C BOOL PowerAuthLogToConsoleEnabled(void);
+
+/**
  PA2CriticalWarning(...) function prints a critical warning information into the debug console and
  is used internally in the PowerAuth SDK. This kind of warnings are always printed to the DEBUG
  console and cannot be supressed by configuration.
@@ -88,7 +101,7 @@ PA2_EXTERN_C void PowerAuthCriticalWarning(NSString * _Nonnull format, ...);
  Delegate will be called only when `ENABLE_PA2_LOG` copilation flag is set or the library is compiled
  in the `DEBUG` mode (can be verified with `PowerAuthLogIsEnabled()`.
  
- By default, all logs are also logged via NSLog.
+ By default, all logs are also logged via NSLog (can be turned off with the `PowerAuthLogToConsole`).
  */
 @protocol PowerAuthLogDelegate
 /**

--- a/proj-xcode/PowerAuth2/PowerAuthLog.h
+++ b/proj-xcode/PowerAuth2/PowerAuthLog.h
@@ -79,13 +79,13 @@ PA2_EXTERN_C BOOL PowerAuthLogIsVerbose(void);
  When turned off, you can leverage the `PowerAuthLogSetDelegate` to implement your own logic.
  Note that it's effective only when library is compiled in `DEBUG` build configuration or `ENABLE_PA2_LOG` compilation flag is set.
  */
-PA2_EXTERN_C void PowerAuthLogToConsole(BOOL enabled);
+PA2_EXTERN_C void PowerAuthLogToConsoleSetEnabled(BOOL enabled);
 
 /**
  Function returns YES if internal logging to system console with NSLog is enabled.
  Note that when library is compiled in `RELEASE` configuration and when `ENABLE_PA2_LOG` compilation flag is missing, then always returns NO.
  */
-PA2_EXTERN_C BOOL PowerAuthLogToConsoleEnabled(void);
+PA2_EXTERN_C BOOL PowerAuthLogToConsoleIsEnabled(void);
 
 /**
  PA2CriticalWarning(...) function prints a critical warning information into the debug console and
@@ -101,7 +101,7 @@ PA2_EXTERN_C void PowerAuthCriticalWarning(NSString * _Nonnull format, ...);
  Delegate will be called only when `ENABLE_PA2_LOG` copilation flag is set or the library is compiled
  in the `DEBUG` mode (can be verified with `PowerAuthLogIsEnabled()`.
  
- By default, all logs are also logged via NSLog (can be turned off with the `PowerAuthLogToConsole`).
+ By default, all logs are also logged via NSLog (can be turned off with the `PowerAuthLogToConsoleSetEnabled`).
  */
 @protocol PowerAuthLogDelegate
 /**

--- a/proj-xcode/PowerAuth2/PowerAuthLog.m
+++ b/proj-xcode/PowerAuth2/PowerAuthLog.m
@@ -28,10 +28,11 @@
 #ifdef ENABLE_PA2_LOG
 static BOOL s_log_enabled = NO;
 static BOOL s_log_verbose = NO;
+static BOOL s_log_to_console = YES;
 static id<PowerAuthLogDelegate> s_log_delegate = nil;
 void PowerAuthLogImpl(NSString * format, ...)
 {
-    if (!s_log_enabled) {
+    if (!s_log_enabled || (!s_log_to_console && !s_log_delegate)) {
         return;
     }
     va_list args;
@@ -43,7 +44,9 @@ void PowerAuthLogImpl(NSString * format, ...)
         [s_log_delegate powerAuthLog:message];
     }
     
-    NSLog(@"[PowerAuth] %@", message);
+    if (s_log_to_console) {
+        NSLog(@"[PowerAuth] %@", message);
+    }
 }
 #endif // ENABLE_PA2_LOG
 
@@ -77,6 +80,22 @@ BOOL PowerAuthLogIsVerbose(void)
 {
 #ifdef ENABLE_PA2_LOG
     return s_log_verbose;
+#else
+    return NO;
+#endif
+}
+
+void PowerAuthLogToConsole(BOOL enabled)
+{
+#ifdef ENABLE_PA2_LOG
+    s_log_to_console = enabled;
+#endif
+}
+
+BOOL PowerAuthLogToConsoleEnabled(void)
+{
+#ifdef ENABLE_PA2_LOG
+    return s_log_to_console;
 #else
     return NO;
 #endif

--- a/proj-xcode/PowerAuth2/PowerAuthLog.m
+++ b/proj-xcode/PowerAuth2/PowerAuthLog.m
@@ -85,14 +85,14 @@ BOOL PowerAuthLogIsVerbose(void)
 #endif
 }
 
-void PowerAuthLogToConsole(BOOL enabled)
+void PowerAuthLogToConsoleSetEnabled(BOOL enabled)
 {
 #ifdef ENABLE_PA2_LOG
     s_log_to_console = enabled;
 #endif
 }
 
-BOOL PowerAuthLogToConsoleEnabled(void)
+BOOL PowerAuthLogToConsoleIsEnabled(void)
 {
 #ifdef ENABLE_PA2_LOG
     return s_log_to_console;

--- a/proj-xcode/PowerAuth2/PowerAuthSystem.m
+++ b/proj-xcode/PowerAuth2/PowerAuthSystem.m
@@ -34,7 +34,7 @@
 
 + (BOOL) isInDebug {
     BOOL result = _CoreModuleIsDebug();
-#if defined(ENABLE_PA2_LOG) || defined(DEBUG)
+#if defined(DEBUG)
     result |= YES;
 #endif
     return result;


### PR DESCRIPTION
## Improved logging setup

### Added `PowerAuthLogToConsole`

This is because we provide a logging delegate - there might be cases when the integrator wants to process the log on its own without logging into `NSLog`

----

### `ENABLE_PA2_LOG` no longer affects `PowerAuthSystem.isInDebug`

It was undocumented and kinda unexpected that turning on the log also means that this helper returns true. We put enough obstacles to turn logs (compilation flag, enabling + verbose enabling) and enough documentation that the integrator should understand what is doing.

---

+ updated docs