### PR TITLE
Move from "signature" to "authorization code" terminology

### DIFF
--- a/docs/PowerAuth-SDK-for-Android.md
+++ b/docs/PowerAuth-SDK-for-Android.md
@@ -14,9 +14,9 @@
   - [Validating User Inputs](#validating-user-inputs)
 - [Requesting Device Activation Status](#requesting-activation-status)
 - [Data Signing](#data-signing)
-  - [Symmetric Multi-Factor Signature](#symmetric-multi-factor-signature)
+  - [Symmetric Multi-Factor Authorization Code](#symmetric-multi-factor-authorization-code)
   - [Asymmetric Private Key Signature](#asymmetric-private-key-signature)
-  - [Symmetric Offline Multi-Factor Signature](#symmetric-offline-multi-factor-signature)
+  - [Symmetric Offline Multi-Factor Authorization Code](#symmetric-offline-multi-factor-authorization-code)
   - [Producing Signed JWT with Provided Claims](#producing-signed-jwt-with-provided-claims)
   - [Verify Server-Signed Data](#verify-server-signed-data)
 - [Password Change](#password-change)
@@ -145,7 +145,7 @@ PowerAuthAppLifecycleListener.getInstance().registerForActivityLifecycleCallback
 
 The `PowerAuthConfiguration.Builder` class provides the following additional methods that can alter the configuration:
 
-- `offlineAuthorizationCodeComponentLength()` - Alters the default component length for the [offline signature](#symmetric-offline-multi-factor-signature). The values between 4 and 8 are allowed. The default value is 8.
+- `offlineAuthorizationCodeComponentLength()` - Alters the default component length for the [offline authorization code](#symmetric-offline-multi-factor-authorization-code). The values between 4 and 8 are allowed. The default value is 8.
 - `externalEncryptionKey()` - See [External Encryption Key](#external-encryption-key) chapter for more details.
 - `disableAutomaticProtocolUpgrade()` - Disables the automatic protocol upgrade. This option should be used only for debugging purposes.
 
@@ -809,75 +809,62 @@ The activation record is created, and the key exchange between the client and se
 
 #### `ActivationStatus.State_Active`
 
-The activation record is created and active. It is ready to be used for typical use-cases, such as generating signatures.
+The activation record is created and active. It is ready to be used for typical use-cases, such as generating authorization codes.
 
 #### `ActivationStatus.State_Blocked`
 
-The activation record is blocked and cannot be used for most use-cases, such as generating signatures. While it can be unblocked and activated again, the unblock process cannot be performed locally on the mobile device and requires intervention through an external system, such as internet banking or a back office platform.
+The activation record is blocked and cannot be used for most use-cases, such as generating authorization codes. While it can be unblocked and activated again, the unblock process cannot be performed locally on the mobile device and requires intervention through an external system, such as internet banking or a back office platform.
 
 #### `ActivationStatus.State_Removed`
 
-The activation record is removed and permanently blocked. It cannot be used for generating signatures or ever unblocked. You can inform user about this situation and remove the activation locally.
+The activation record is removed and permanently blocked. It cannot be used for generating authorization codes or ever unblocked. You can inform user about this situation and remove the activation locally.
 
 #### `ActivationStatus.State_Deadlock`
 
-The local activation is technically blocked and can no longer be used for signature calculations. You can inform the user about this situation and remove the activation locally.
+The local activation is technically blocked and can no longer be used for authorization code calculations. You can inform the user about this situation and remove the activation locally.
 
-The reason why the mobile client is no longer capable of calculating valid signatures is that the logical counter is out of sync between the client and the server. This may happen only if the mobile client calculates too many PowerAuth signatures without subsequent validation on the server. For example:
+The reason why the mobile client is no longer capable of calculating valid authorization codes is that the logical counter is out of sync between the client and the server. This may happen only if the mobile client calculates too many PowerAuth authorization codes without subsequent validation on the server. For example:
 
-- If your application repeatedly constructs HTTP requests with a PowerAuth signature while the network is unreachable.
+- If your application repeatedly constructs HTTP requests with a PowerAuth authorization header while the network is unreachable.
 - If your application repeatedly creates authentication tokens while the network is unreachable. For example, when trying to register for push notifications in the background, without user interaction.
-- If you calculate too many offline signatures without subsequent validation.
+- If you calculate too many offline authorization codes without subsequent validation.
 
 In rare situations, this may also happen in development or testing environments, where you’re able to restore the state of the activation on the server from a snapshot.
 
 ## Data Signing
 
-The main feature of the PowerAuth protocol is data signing. PowerAuth has two types of signatures:
+The main feature of the PowerAuth protocol is data signing. PowerAuth has various types of signatures:
 
-- **Symmetric Multi-Factor Signature**: Suitable for most operations, such as login, new payment, or confirming changes in settings.
+- **Symmetric Multi-Factor Authorization Code**: Suitable for most operations, such as login, new payment, or confirming changes in settings.
 - **Asymmetric Private Key Signature**: Suitable for documents where a strong one-sided signature is desired.
-- **Symmetric Offline Multi-Factor Signature**: Suitable for very secure operations, where the signature is validated over the out-of-band channel.
+- **Symmetric Offline Multi-Factor Authorization Code**: Suitable for very secure operations, where the signature is validated over the out-of-band channel.
 - **Verify server signed data**: Suitable for receiving arbitrary data from the server.
 
-### Symmetric Multi-Factor Signature
+### Symmetric Multi-Factor Authorization Code
 
-To sign request data, you need to first obtain user credentials (password, PIN code, biometric image) from the user. The task of obtaining the user credentials is used in more use-cases covered by the SDK. The core class is `PowerAuthAuthentication` that holds information about the used authentication factors:
+To authenticate the request data, you need to first obtain user credentials (password, PIN code, biometric image) from the user. The task of obtaining the user credentials is used in more use-cases covered by the SDK. The core class is `PowerAuthAuthentication` that holds information about the used authentication factors:
 
-<!-- begin codetabs Kotlin Java -->
 ```kotlin
-// 1FA signature, uses device related key only.
+// 1FA authorization code, uses device related key only.
 val oneFactor = PowerAuthAuthentication.possession()
 
-// 2FA signature - uses device related key and user PIN code.
+// 2FA authorization code - uses device related key and user PIN code.
 val twoFactorPassword = PowerAuthAuthentication.possessionWithPassword("1234")
 
-// 2FA signature, uses biometry factor-related key as a 2nd. factor.
+// 2FA authorization code, uses biometry factor-related key as a 2nd. factor.
 // To obtain biometryFactorRelatedKey see "Fetching the Biometry Factor-Related Key for Authentication" chapter.
 val twoFactorBiometry = PowerAuthAuthentication.possessionWithBiometry(biometryFactorRelatedKey)
 ```
-```java
-// 1FA signature, uses device related key only.
-PowerAuthAuthentication oneFactor = PowerAuthAuthentication.possession();
-
-// 2FA signature - uses device related key and user PIN code.
-PowerAuthAuthentication twoFactorPassword = PowerAuthAuthentication.possessionWithPassword("1234");
-
-// 2FA signature, uses biometry factor-related key as a 2nd. factor.
-// To obtain biometryFactorRelatedKey see "Fetching the Biometry Factor-Related Key for Authentication" chapter.
-PowerAuthAuthentication twoFactorBiometry = PowerAuthAuthentication.possessionWithBiometry(biometryFactorRelatedKey);
-```
-<!-- end -->
 
 When signing `POST`, `PUT` or `DELETE` requests, use request body bytes (UTF-8) as request data and the following code:
 
 ```kotlin
-// 2FA signature - uses device related key and user PIN code
+// 2FA authorization code - uses device related key and user PIN code
 val authentication = PowerAuthAuthentication.possessionWithPassword("1234")
 
 // Compute authorization header for POST call with provided data made to URI with custom identifier "/payment/create"
 try {
-    val header = powerAuthSDK.requestSignatureWithAuthentication(context, authentication, "POST", "/payment/create", requestBodyBytes)
+    val header = powerAuthSDK.authorizationHeaderForRequestWithBody(context, authentication, "POST", "/payment/create", requestBodyBytes)
     val httpHeaderKey = header.getKey()
     val httpHeaderValue = header.getValue()
 } catch (e: PowerAuthErrorException) {
@@ -888,7 +875,7 @@ try {
 When signing `GET` or `DELETE` request with query parameters, use the following code:
 
 ```kotlin
-// 2FA signature - uses device-related key and user PIN code
+// 2FA authorization code - uses device-related key and user PIN code
 val authentication = PowerAuthAuthentication.possessionWithPassword("1234")
 
 // Compute authorization header for GET call with provided query parameters made to URI with custom identifier "/payment/create"
@@ -902,7 +889,7 @@ try {
 }
 ```
 
-The result of the signature is appropriate HTTP header - you are responsible for hooking up the header value in your request correctly. The process with libraries like `OkHttp` goes like this:
+The result of the operation is appropriate HTTP header - you are responsible for hooking up the header value in your request correctly. The process with libraries like `OkHttp` goes like this:
 
 ```kotlin
 // Prepare the request builder
@@ -910,7 +897,7 @@ val builder: Request.Builder = Builder().url(endpoint)
 
 // Compute PowerAuth authorization header
 try {
-    val header = powerAuthSDK.authorizationHeaderForRequestWithBody(context, signatureUnlockKeys, "POST", "/session/login", jsonBody)
+    val header = powerAuthSDK.authorizationHeaderForRequestWithBody(context, authentication, "POST", "/session/login", jsonBody)
     // Add HTTP header in the request builder
     builder.header(header.getKey(), header.getValue())
 } catch (e: PowerAuthErrorException) {
@@ -923,34 +910,20 @@ try {
 
 #### Request Synchronization
 
-It is recommended that your application executes only one signed request at the time. The reason for that is that our signature scheme is using a counter as a representation of logical time. In other words, the order of request validation on the server is very important. If you issue more than one signed request at the same time, then the order is not guaranteed, and therefore one of the requests may fail. On top of that, Mobile SDK itself is using this type of signatures for its own purposes. For example, if you ask for token, then the SDK is using signed request to obtain the token's data. To deal with this problem, Mobile SDK is providing a custom serial `Executor`, which can be used for signed requests execution:
+It is recommended that your application executes only one signed request at the time. The reason for that is that our scheme for authorization codes is using a counter as a representation of logical time. In other words, the order of request validation on the server is very important. If you issue more than one signed request at the same time, then the order is not guaranteed, and therefore one of the requests may fail. On top of that, Mobile SDK itself is using this type of authentication for its own purposes. For example, if you ask for token, then the SDK is using authenticated request to obtain the token's data. To deal with this problem, Mobile SDK is providing a custom serial `Executor`, which can be used for signed requests execution:
 
-<!-- begin codetabs Kotlin Java -->
 ```kotlin
 powerAuthSDK.serialExecutor.execute {
     // Recommended practice:
-    // 1. You have to calculate the PowerAuth signature here.
+    // 1. You have to calculate the PowerAuth authorization header here.
     // 2. In case that you start yet another asynchronous operation from run(),
     //    then you have to wait for that operation's execution.
 }
 ```
-```java
-final Executor serialExecutor = powerAuthSDK.getSerialExecutor();
-serialExecutor.execute(new Runnable() {
-    @Override
-    public void run() {
-        // Recommended practice:
-        // 1. You have to calculate the PowerAuth signature here.
-        // 2. In case that you start yet another asynchronous operation from run(),
-        //    then you have to wait for that operation's execution.
-    }
-});
-```
-<!-- end -->
 
 ### Asymmetric Private Key Signature
 
-Asymmetric Private Key Signature uses a private key stored in the PowerAuth secure vault. In order to unlock the secure vault and retrieve the private key, the user has to first authenticate using the symmetric multi-factor signature with at least two factors. This mechanism protects the private key on the device - the server plays a role of a "doorkeeper" and holds the vault unlock key.
+Asymmetric Private Key Signature uses a private key stored in the PowerAuth secure vault. In order to unlock the secure vault and retrieve the private key, the user has to first authenticate using the symmetric multi-factor authorization code with at least two factors. This mechanism protects the private key on the device - the server plays a role of a "doorkeeper" and holds the vault unlock key.
 
 This process is completely transparent on the SDK level. To compute an asymmetric private key signature, request user credentials (password, PIN, biometric image) and use the following code:
 
@@ -1005,7 +978,7 @@ val claims = mapOf(
     "last_name" to "Appleseed"
 )
 
-// 2FA signature - uses device related key and user PIN code
+// 2FA - uses device related key and user PIN code
 val authentication = PowerAuthAuthentication.possessionWithPassword("1234")
 
 // Unlock the secure vault, fetch the private key and perform data signing
@@ -1020,15 +993,15 @@ powerAuthSDK.signJwtWithDevicePrivateKey(context, authentication, claims, object
 })
 ```
 
-### Symmetric Offline Multi-Factor Signature
+### Symmetric Offline Multi-Factor Authorization Code
 
-This type of signature is very similar to [Symmetric Multi-Factor Signature](#symmetric-multi-factor-signature) but the result is provided in the form of a simple, human-readable string (unlike the online version, where the result is an HTTP header). To calculate the signature, you need a typical `PowerAuthAuthentication` object to define all required factors, nonce and data to sign. The `nonce` and `data` should also be transmitted to the application over the OOB channel (for example, by scanning a QR code). Then the signature calculation is straightforward:
+This type of authentication is very similar to [Symmetric Multi-Factor Authorization Code](#symmetric-multi-factor-authorization-code) but the result is provided in the form of a simple, human-readable string (unlike the online version, where the result is an HTTP header). To calculate the code, you need a typical `PowerAuthAuthentication` object to define all required factors, nonce and data to sign. The `nonce` and `data` should also be transmitted to the application over the OOB channel (for example, by scanning a QR code). Then the authorization code calculation is straightforward:
 
 ```kotlin
 // Prepare the authentication object
 val authentication = PowerAuthAuthentication.possessionWithPassword("1234")
 
-powerAuthSDK.offlineSignatureWithAuthentication(context, authentication, "/confirm/offline/operation", data, nonce, object: IOfflineAuthorizationCodeListener {
+powerAuthSDK.offlineAuthorizationCode(context, authentication, "/confirm/offline/operation", data, nonce, object: IOfflineAuthorizationCodeListener {
     override fun onOfflineAuthorizationCodeSucceed(authorizationCode: String) {
         Log.d(TAG, "Offline authorization code is: $authorizationCode")
     }
@@ -1039,10 +1012,10 @@ powerAuthSDK.offlineSignatureWithAuthentication(context, authentication, "/confi
 })
 ```
 
-The application has to show that calculated signature to the user now, and the user has to re-type that code into the web application for the verification.
+The application has to show that calculated code to the user now, and the user has to re-type that code into the web application for the verification.
 
 <!-- begin box info -->
-You can alter the length of the signature components by using `offlineAuthorizationCodeComponentLength()` function of `PowerAuthConfiguration.Builder` class.
+You can alter the length of the code components by using `offlineAuthorizationCodeComponentLength()` function of `PowerAuthConfiguration.Builder` class.
 <!-- end -->
 
 ### Verify Server-Signed Data
@@ -1074,7 +1047,7 @@ if (powerAuthSDK.verifyServerSignedData(data, signature, false)) {
 
 ## Password Change
 
-Since the device does not know the password and is unable to verify the password without the help of the server-side, you need to first call an endpoint that verifies a signature computed with the password. SDK offers two ways to do that.
+Since the device does not know the password and is unable to verify the password without the help of the server-side, you need to first call an endpoint that verifies an authorization code computed with the password. SDK offers two ways to do that.
 
 The safe but typically slower way is to use the following code:
 
@@ -1107,7 +1080,7 @@ powerAuthSDK.changePassword(context, "oldPassword", "newPassword", new IChangePa
 ```
 <!-- end -->
 
-This method calls `/pa/v3/signature/validate` under the hood with a 2FA signature with provided original password to verify the password correctness.
+This method calls `/pa/v3/signature/validate` under the hood with a 2FA authorization code with provided original password to verify the password correctness.
 
 However, using this method does not usually fit the typical UI workflow of a password change. The method may be used in cases where an old password and a new password are on a single screen, and therefore are both available at the same time. In most mobile apps, however, the user first visits a screen to enter an old password, and then (if the password is OK), the user proceeds to the two-screen flow of a new password setup (select password, confirm password). In other words, the workflow works like this:
 
@@ -1878,7 +1851,7 @@ this.httpClient.post(null, "/custom/activation/remove", new ICustomListener() {
 
 ### Removal via Signed Request
 
-PowerAuth Standard RESTful API has a default endpoint `/pa/v3/activation/remove` for an activation removal. This endpoint uses a signature verification for looking up the activation to be removed. The benefit of this method is that it is already present in both PowerAuth SDK for Android and PowerAuth Standard RESTful API - nothing has to be programmed. Also, the user does not have to be logged in to use it. However, the user has to authenticate using 2FA with either password or biometric authentication.
+PowerAuth Standard RESTful API has a default endpoint `/pa/v3/activation/remove` for an activation removal. This endpoint uses a authorization code verification for looking up the activation to be removed. The benefit of this method is that it is already present in both PowerAuth SDK for Android and PowerAuth Standard RESTful API - nothing has to be programmed. Also, the user does not have to be logged in to use it. However, the user has to authenticate using 2FA with either password or biometric authentication.
 
 Use the following code for an activation removal using a signed request:
 
@@ -1920,7 +1893,7 @@ powerAuthSDK.removeActivationWithAuthentication(context, authentication, new IAc
 Currently, PowerAuth SDK supports two basic modes of end-to-end encryption, based on the ECIES scheme:
 
 - In an "application" scope, the encryptor can be acquired and used during the whole lifetime of the application.
-- In an "activation" scope, the encryptor can be acquired only if `PowerAuthSDK` has a valid activation. The encryptor created for this mode is cryptographically bound to the parameters agreed during the activation process. You can combine this encryption with [PowerAuth Symmetric Multi-Factor Signature](#symmetric-multi-factor-signature) in "encrypt-then-sign" mode.
+- In an "activation" scope, the encryptor can be acquired only if `PowerAuthSDK` has a valid activation. The encryptor created for this mode is cryptographically bound to the parameters agreed during the activation process. You can combine this encryption with [PowerAuth Symmetric Multi-Factor Authorization Code](#symmetric-multi-factor-authorization-code) in "encrypt-then-sign" mode.
 
 
 For both scenarios, you need to acquire an `EciesEncryptor` object, which will then provide an interface for the request encryption and the response decryption. The object currently provides only low-level encryption and decryption methods, so you need to implement your own JSON (de)serialization and request and response processing.
@@ -1985,7 +1958,7 @@ The following steps are typically required for a full E2EE request and response 
    val httpHeaderName = metadata.httpHeaderKey
    val httpHeaderValue = metadata.httpHeaderValue
    ```
-   Note, that if an "activation" scoped encryptor is combined with PowerAuth Symmetric Multi-Factor signature, then this step is not required. The signature's header already contains all the information required for proper request decryption on the server.
+   Note, that if an "activation" scoped encryptor is combined with PowerAuth Symmetric Multi-Factor Authorization Code, then this step is not required. The authorization header already contains all the information required for proper request decryption on the server.
 
 1. Fire your HTTP request and wait for a response
    - In case that non-200 HTTP status code is received, then the error processing is identical to a standard RESTful response defined in our protocol. So, you can expect a JSON object with `"error"` and `"message"` properties in the response.
@@ -2032,7 +2005,7 @@ The secure vault mechanism does not support biometry by default. Use PIN code or
 To obtain an encryption key with a given index, use the following code:
 
 ```kotlin
-// 2FA signature. It uses device-related key and user PIN code.
+// 2FA authentication. It uses device-related key and user PIN code.
 val authentication = PowerAuthAuthentication.possessionWithPassword("1234")
 
 // Select custom key index
@@ -2057,9 +2030,9 @@ powerAuthSDK.fetchEncryptionKey(context, authentication, index, object: IFetchEn
 **WARNING:** Before you start using access tokens, please visit our [wiki page for powerauth-crypto](https://github.com/wultra/powerauth-crypto/blob/develop/docs/MAC-Token-Based-Authentication.md) for more information about this feature.
 <!-- end -->
 
-The tokens are simple, locally cached objects, producing timestamp-based authorization headers. Be aware that tokens are NOT a replacement for general PowerAuth signatures. They are helpful in situations when the signatures are too heavy or too complicated for implementation. Each token has the following properties:
+The tokens are simple, locally cached objects, producing timestamp-based authorization headers. Be aware that tokens are NOT a replacement for general PowerAuth Authorization Codes. They are helpful in situations when the codes are too heavy or too complicated for implementation. Each token has the following properties:
 
-- It needs a PowerAuth signature for its creation (e.g., you need to provide a `PowerAuthAuthentication` object)
+- It needs a PowerAuth Authorization Code for its creation (e.g., you need to provide a `PowerAuthAuthentication` object)
 - It has a unique identifier on the server. This identifier is not exposed to the public API, but you can reveal that value in the debugger.
 - It has a symbolic name (e.g., "MyToken") defined by the application programmer to identify already created tokens.
 - It can generate timestamp-based authorization HTTP headers.
@@ -2074,7 +2047,7 @@ To get an access token, you can use the following code:
 
 <!-- begin codetabs Kotlin Java -->
 ```kotlin
-// 1FA signature - uses device-related key
+// 1FA authorization - uses device-related key
 val authentication = PowerAuthAuthentication.possession()
 val cancelableTask = powerAuthSDK.tokenStore.requestAccessToken(context, "MyToken", authentication, object: IGetTokenListener {
     override fun onGetTokenSucceeded(powerAuthToken: PowerAuthToken) {
@@ -2087,7 +2060,7 @@ val cancelableTask = powerAuthSDK.tokenStore.requestAccessToken(context, "MyToke
 })
 ```
 ```java
-// 1FA signature - uses device-related key
+// 1FA authorization - uses device-related key
 final PowerAuthAuthentication authentication = PowerAuthAuthentication.possession();
 final PowerAuthTokenStore tokenStore = powerAuthSDK.getTokenStore();
 final ICancelable task = tokenStore.requestAccessToken(context, "MyToken", authentication, new IGetTokenListener() {
@@ -2194,7 +2167,7 @@ Note that by removing tokens locally, you will lose control of the tokens stored
 
 The `PowerAuthSDK` allows you to specify an external encryption key (called EEK in our terminology) that can additionally protect the knowledge and the biometry factor keys. This feature is typically used to create a chain of activations where one instance of `PowerAuthSDK` is primary and unlocks access to all secondary activations.
 
-The external encryption key has to be set before the activation is created, or can be added later. The internal state of `PowerAuthSDK` contains information that the factor keys are protected with EEK, so EEK must be known at the time of PowerAuth signature is calculated. You have three options on how to configure the key:
+The external encryption key has to be set before the activation is created, or can be added later. The internal state of `PowerAuthSDK` contains information that the factor keys are protected with EEK, so EEK must be known at the time of PowerAuth authorization code is calculated. You have three options on how to configure the key:
 
 1. Assign EEK into `PowerAuthConfiguration.Builder` at the time of `PowerAuthSDK` object creation.
    - This is the most convenient way of using EEK, but the key must be known at the time of the `PowerAuthSDK` instantiation.
@@ -2415,7 +2388,7 @@ Here's the list of important error codes, which the application should properly 
 
 - `BIOMETRY_CANCEL` is reported when the user cancels the biometric authentication dialog
 - `PROTOCOL_UPGRADE` is reported when SDK fails to upgrade itself to a newer protocol version. The code may be reported from `PowerAuthSDK.fetchActivationStatusWithCallback()`. This is an unrecoverable error resulting in the broken activation on the device, so the best situation is to inform the user about the situation and remove the activation locally.
-- `PENDING_PROTOCOL_UPGRADE` is reported when the requested SDK operation cannot be completed due to a pending PowerAuth protocol upgrade. You can retry the operation later. The code is typically reported in situations when SDK is performing protocol upgrade in the background (as a part of activation status fetch), and the application wants to calculate the PowerAuth signature in parallel operation. Such kind of concurrency is forbidden since SDK version `1.0.0`
+- `PENDING_PROTOCOL_UPGRADE` is reported when the requested SDK operation cannot be completed due to a pending PowerAuth protocol upgrade. You can retry the operation later. The code is typically reported in situations when SDK is performing protocol upgrade in the background (as a part of activation status fetch), and the application wants to calculate the PowerAuth authorization code in parallel operation. Such kind of concurrency is forbidden since SDK version `1.0.0`
 
 
 ### Working with Invalid SSL Certificates

--- a/docs/PowerAuth-SDK-for-iOS.md
+++ b/docs/PowerAuth-SDK-for-iOS.md
@@ -19,10 +19,10 @@
   - [Validating User Inputs](#validating-user-inputs)
 - [Requesting Device Activation Status](#requesting-activation-status)
 - [Data Signing](#data-signing)
-  - [Symmetric Multi-Factor Signature](#symmetric-multi-factor-signature)
+  - [Symmetric Multi-Factor Authorization Code](#symmetric-multi-factor-authorization-code)
   - [Asymmetric Private Key Signature](#asymmetric-private-key-signature)
   - [Producing Signed JWT with Provided Claims](#producing-signed-jwt-with-provided-claims)
-  - [Symmetric Offline Multi-Factor Signature](#symmetric-offline-multi-factor-signature)
+  - [Symmetric Offline Multi-Factor Authorization Code](#symmetric-offline-multi-factor-authorization-code)
   - [Verify Server-Signed Data](#verify-server-signed-data)
 - [Password Change](#password-change)
 - [Working with passwords securely](#working-with-passwords-securely)
@@ -154,7 +154,7 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
 
 The `PowerAuthConfiguration` has the following additional properties:
 
-- `offlineSignatureComponentLength` - Alters the default component length for the [offline signature](#symmetric-offline-multi-factor-signature). The values between 4 and 8 are allowed. The default value is 8.
+- `offlineAuthorizationCodeComponentLength` - Alters the default component length for the [offline authorization code](#symmetric-offline-multi-factor-authorization-code). The values between 4 and 8 are allowed. The default value is 8.
 - `externalEncryptionKey` - See [External Encryption Key](#external-encryption-key) chapter for more details.
 - `disableAutomaticProtocolUpgrade` - If set to `true`, then automatic protocol upgrade is disabled. This option should be used only for the debugging purposes.
 - `keychainKey_Biometry` - Specifies the 'key' used to store the `PowerAuthSDK` instance’s biometry-related key in the biometry keychain. If not set, the `instanceId` is applied. Do not alter this configuration unless you have a valid reason to do so.
@@ -523,25 +523,25 @@ The activation record is created, and the key exchange between the client and se
 
 #### `PowerAuthActivationState.active`
 
-The activation record is created and active. It is ready to be used for typical use-cases, such as generating signatures.
+The activation record is created and active. It is ready to be used for typical use-cases, such as generating authorization codes.
 
 #### `PowerAuthActivationState.blocked` 
 
-The activation record is blocked and cannot be used for most use-cases, such as generating signatures. While it can be unblocked and activated again, the unblock process cannot be performed locally on the mobile device and requires intervention through an external system, such as internet banking or a back office platform.
+The activation record is blocked and cannot be used for most use-cases, such as generating authorization codes. While it can be unblocked and activated again, the unblock process cannot be performed locally on the mobile device and requires intervention through an external system, such as internet banking or a back office platform.
 
 #### `PowerAuthActivationState.removed`
 
-The activation record is removed and permanently blocked. It cannot be used for generating signatures or ever unblocked. You can inform user about this situation and remove the activation locally.
+The activation record is removed and permanently blocked. It cannot be used for generating authorization codes or ever unblocked. You can inform user about this situation and remove the activation locally.
 
 #### `PowerAuthActivationState.deadlock` 
 
-The local activation is technically blocked and can no longer be used for signature calculations. You can inform the user about this situation and remove the activation locally.
+The local activation is technically blocked and can no longer be used for authorization code calculations. You can inform the user about this situation and remove the activation locally.
 
-The reason why the mobile client is no longer capable of calculating valid signatures is that the logical counter is out of sync between the client and the server. This may happen only if the mobile client calculates too many PowerAuth signatures without subsequent validation on the server. For example:
+The reason why the mobile client is no longer capable of calculating valid authorization codes is that the logical counter is out of sync between the client and the server. This may happen only if the mobile client calculates too many PowerAuth authorization codes without subsequent validation on the server. For example:
 
-- If your application repeatedly constructs HTTP requests with a PowerAuth signature while the network is unreachable.
+- If your application repeatedly constructs HTTP requests with a PowerAuth authorization code while the network is unreachable.
 - If your application repeatedly creates authentication tokens while the network is unreachable. For example, when trying to register for push notifications in the background, without user interaction.
-- If you calculate too many offline signatures without subsequent validation.
+- If you calculate too many offline authorization codes without subsequent validation.
 
 In rare situations, this may also happen in development or testing environments, where you’re able to restore the state of the activation on the server from a snapshot.
 
@@ -549,26 +549,26 @@ In rare situations, this may also happen in development or testing environments,
 
 The main feature of the PowerAuth protocol is data signing. PowerAuth has three types of signatures:
 
-- **Symmetric Multi-Factor Signature**: Suitable for most operations, such as login, new payment, or confirming changes in settings.
+- **Symmetric Multi-Factor Authorization Code**: Suitable for most operations, such as login, new payment, or confirming changes in settings.
 - **Asymmetric Private Key Signature**: Suitable for documents where a strong one-sided signature is desired.
-- **Symmetric Offline Multi-Factor Signature**: Suitable for very secure operations, where the signature is validated over the out-of-band channel.
+- **Symmetric Offline Multi-Factor Authorization Codee**: Suitable for very secure operations, where the authorization code is validated over the out-of-band channel.
 - **Verify server signed data**: Suitable for receiving arbitrary data from the server.
 
-### Symmetric Multi-Factor Signature
+### Symmetric Multi-Factor Authorization Code
 
 To sign request data, you need to first obtain user credentials (password, PIN code, Touch ID scan) from the user. The task of obtaining the user credentials is used in more use cases covered by the SDK. The core class is `PowerAuthAuthentication` that holds information about the used authentication factors:
 
 ```swift
-// 1FA signature - uses device-related key only.
+// 1FA authorization code - uses device-related key only.
 let oneFactor = PowerAuthAuthentication.possession()
 
-// 2FA signature - uses device-related key and user PIN code.
+// 2FA authorization code - uses device-related key and user PIN code.
 let twoFactorPassword = PowerAuthAuthentication.possessionWithPassword(password: "1234")
 
-// 2FA signature - uses biometry factor-related key as a 2nd. factor.
+// 2FA authorization code - uses biometry factor-related key as a 2nd. factor.
 let task = powerAuthSDK.authenticateUsingBiometry(withPrompt: "Please authenticate with biometry to log-in.") { authentication, error in
     if let authentication {
-        // the returned authentication object is ready to use for the signature calculation
+        // the returned authentication object is ready to use for the authorization code calculation
     } else {
         // Failure, cast object to NSError
         guard let error = error as? NSError else {
@@ -589,23 +589,23 @@ task.cancel()
 When signing `POST`, `PUT`, or `DELETE` requests, use request body bytes (UTF-8) as request data and the following code:
 
 ```swift
-// 2FA signature - uses device-related key and user PIN code
+// 2FA authorization code - uses device-related key and user PIN code
 let auth = PowerAuthAuthentication.possessionWithPassword(password: "1234")
 
 // Sign POST call with provided data made to URI with custom identifier "/payment/create"
 do {
-    let signature = try powerAuthSDK.authorizationHeaderForRequestWithBody(with: auth, method: "POST", uriId: "/payment/create", body: requestBodyData)
-    let httpHeaderKey = signature.key
-    let httpHeaderValue = signature.value
+    let header = try powerAuthSDK.authorizationHeaderForRequestWithBody(with: auth, method: "POST", uriId: "/payment/create", body: requestBodyData)
+    let httpHeaderKey = header.key
+    let httpHeaderValue = header.value
 } catch _ {
     // In case of invalid configuration, invalid activation state, or corrupted state data
 }
 ```
 
-When signing `GET` requests, use the same code as above with normalized request data as described in the specification, or (preferably) use the following helper method:
+When signing `GET` or `DELETE` request with query parameters, use the following code:
 
 ```swift
-// 2FA signature - uses device-related key and user PIN code
+// 2FA authorization code - uses device-related key and user PIN code
 let auth = PowerAuthAuthentication.possessionWithPassword(password: "1234")
 
 // Sign GET call with provided query parameters made to URI with custom identifier "/payment/create"
@@ -615,9 +615,9 @@ let params = [
 ]
 
 do {
-    let signature = try powerAuthSDK.authorizationHeaderForRequestWithParams(with: auth, method: "GET", uriId: "/payment/create", params: params)
-    let httpHeaderKey = signature.key
-    let httpHeaderValue = signature.value
+    let header = try powerAuthSDK.authorizationHeaderForRequestWithParams(with: auth, method: "GET", uriId: "/payment/create", params: params)
+    let httpHeaderKey = header.key
+    let httpHeaderValue = header.value
 } catch _ {
     // In case of invalid configuration, invalid activation state, or corrupted state data
 }
@@ -625,9 +625,9 @@ do {
 
 #### Request Synchronization
 
-It is recommended that your application executes only one signed request at a time. The reason for that is that our signature scheme uses a counter as a representation of logical time. In other words, the order of request validation on the server is very important. If you issue more than one signed request at the same time, then the order is not guaranteed, and therefore one of the requests may fail. On top of that, Mobile SDK itself is using this type of signature for its purposes. For example, if you ask for a token, then the SDK is using a signed request to obtain the token's data. To deal with this problem, Mobile SDK is providing a few methods that help with the signed requests synchronization.
+It is recommended that your application executes only one signed request at a time. The reason for that is that our authorization code scheme uses a counter as a representation of logical time. In other words, the order of request validation on the server is very important. If you issue more than one signed request at the same time, then the order is not guaranteed, and therefore one of the requests may fail. On top of that, Mobile SDK itself is using this type of authentication for its purposes. For example, if you ask for a token, then the SDK is using a signed request to obtain the token's data. To deal with this problem, Mobile SDK is providing a few methods that help with the signed requests synchronization.
 
-If your networking is based on `OperationQueue`, then you can add your own `Operation` objects directly to the internal queue. Be aware that the PowerAuth signature must be calculated as a part of the operation's execution. For example:
+If your networking is based on `OperationQueue`, then you can add your own `Operation` objects directly to the internal queue. Be aware that the PowerAuth authorization code must be calculated as a part of the operation's execution. For example:
 
 ```swift
 let httpOperation: Operation = YourHttpOperation(...)
@@ -636,7 +636,7 @@ guard powerAuthSDK.executeOperation(onSerialQueue: httpOperation) else {
 }
 ```
 
-In the case of custom networking, you can use the method to execute any block on the serial queue. In this case, the PowerAuth signature must be calculated as a part of the block's execution. For example:
+In the case of custom networking, you can use the method to execute any block on the serial queue. In this case, the PowerAuth authorization code must be calculated as a part of the block's execution. For example:
 
 ```swift
 powerAuthSDK.executeBlock(onSerialQueue: { internalTask in
@@ -659,7 +659,7 @@ Asymmetric Private Key Signature uses a private key stored in the PowerAuth secu
 This process is completely transparent on the SDK level. To compute an asymmetric private key signature, request user credentials (password, PIN) and use the following code:
 
 ```swift
-// 2FA signature - uses device-related key and user PIN code
+// 2FA authorization - uses device-related key and user PIN code
 let auth = PowerAuthAuthentication.possessionWithPassword(password: "1234")
 
 // Unlock the secure vault, fetch the private key, and perform data signing
@@ -684,7 +684,7 @@ let claims = [
     "last_name": "Appleseed"
 ]
 
-// 2FA signature - uses device-related key and user PIN code
+// 2FA authorization - uses device-related key and user PIN code
 let auth = PowerAuthAuthentication.possessionWithPassword(password: "1234")
 
 // Unlock the secure vault, fetch the private key, and perform data signing
@@ -697,12 +697,12 @@ powerAuthSDK.signJwt(withDevicePrivateKey: auth, claims: claims) { (jwt, error) 
 }
 ```
 
-### Symmetric Offline Multi-Factor Signature
+### Symmetric Offline Multi-Factor Authorization Code
 
-This type of signature is very similar to [Symmetric Multi-Factor Signature](#symmetric-multi-factor-signature), but the result is provided in the form of a simple, human-readable string (unlike the online version, where the result is an HTTP header). To calculate the signature, you need a typical `PowerAuthAuthentication` object to define all required factors, nonce, and data to sign. The `nonce` and `data` should also be transmitted to the application over the OOB channel (for example, by scanning a QR code). Then the signature calculation is straightforward:
+This type of authentication is very similar to [Symmetric Multi-Factor Authorization Code](#symmetric-multi-factor-authorization-code), but the result is provided in the form of a simple, human-readable string (unlike the online version, where the result is an HTTP header). To calculate the code, you need a typical `PowerAuthAuthentication` object to define all required factors, nonce, and data to sign. The `nonce` and `data` should also be transmitted to the application over the OOB channel (for example, by scanning a QR code). Then the authorization code calculation is straightforward:
 
 ```swift
-// 2FA signature - uses device-related key and user PIN code
+// 2FA authentication - uses device-related key and user PIN code
 let auth = PowerAuthAuthentication.possessionWithPassword(password: "1234")
 
 _ = powerAuthSDK.offlineAuthorizationCode(with: auth, uriId: "/confirm/offline/operation", body: data, nonce: nonce) { authorizationCode, error in 
@@ -712,10 +712,10 @@ _ = powerAuthSDK.offlineAuthorizationCode(with: auth, uriId: "/confirm/offline/o
 }
 ```
 
-The application has to show that calculated signature to the user now, and the user has to re-type that code into the web application for verification. 
+The application has to show that calculated code to the user now, and the user has to re-type that code into the web application for verification. 
 
 <!-- begin box info -->
-You can alter the length of the signature components in the `offlineAuthorizationCodeComponentLength` property of the `PowerAuthConfiguration` object.
+You can alter the length of the code components in the `offlineAuthorizationCodeComponentLength` property of the `PowerAuthConfiguration` object.
 <!-- end -->
 
 ### Verify Server-Signed Data
@@ -735,7 +735,7 @@ if powerAuthSDK.verifyServerSignedData(data, signature: signature, masterKey: fa
 
 ## Password Change
 
-Since the device does not know the password and is unable to verify the password without the help of the server side, you need to first call an endpoint that verifies a signature computed with the password. SDK offers two ways to do that.
+Since the device does not know the password and is unable to verify the password without the help of the server side, you need to first call an endpoint that verifies an authorization code computed with the password. SDK offers two ways to do that.
 
 The safe but typically slower way is to use the following code:
 
@@ -750,7 +750,7 @@ powerAuthSDK.changePassword(from: "oldPassword", to: "newPassword") { (error) in
 }
 ```
 
-This method calls `/pa/v3/signature/validate` under the hood with a 2FA signature with the provided original password to verify the password correctness.
+This method calls `/pa/v3/signature/validate` under the hood with a 2FA authorization code with the provided original password to verify the password correctness.
 
 However, using this method does not usually fit the typical UI workflow of a password change. The method may be used in cases where an old password and a new password are on a single screen, and therefore are both available at the same time. In most mobile apps, however, the user first visits a screen to enter an old password, and then (if the password is OK), the user proceeds to the two-screen flow of a new password setup (select password, confirm password). In other words, the workflow works like this:
 
@@ -1102,17 +1102,17 @@ powerAuthSDK.removeBiometryFactor { error in
 
 ### Fetch Biometry Credentials In Advance
 
-You can acquire biometry credentials in advance in case business processes require computing two or more different PowerAuth biometry signatures in one interaction with the user. To achieve this, the application must acquire the custom-created `PowerAuthAuthentication` object first and then use it for the required signature calculations. It's recommended to keep this instance referenced only for a limited time, required for all future signature calculations.
+You can acquire biometry credentials in advance in case business processes require computing two or more different PowerAuth biometry authorization codes in one interaction with the user. To achieve this, the application must acquire the custom-created `PowerAuthAuthentication` object first and then use it for the required authorization code calculations. It's recommended to keep this instance referenced only for a limited time, required for all future authorization code calculations.
 
 Be aware, that you must not execute the next HTTP request signed with the same credentials when the previous one fails with the 401 HTTP status code. If you do, then you risk blocking the user's activation on the server.
 
-To obtain biometry credentials for the future signature calculation, call the following code:
+To obtain biometry credentials for the future authorization code calculation, call the following code:
 
 ```swift
-// Authenticate user with biometry and obtain PowerAuthAuthentication credentials for future signature calculation.
+// Authenticate user with biometry and obtain PowerAuthAuthentication credentials for future authorization code calculation.
 powerAuthSDK.authenticateUsingBiometry(withPrompt: "Authenticate to sign in") { authentication, error in
     if let authentication {
-        // Success, you can use the provided PowerAuthAuthentication object for the signature calculation.
+        // Success, you can use the provided PowerAuthAuthentication object for the authorization code calculation.
         // The provided authentication object is preconfigured for possession+biometry factors
     }
 }
@@ -1161,7 +1161,7 @@ let powerAuthSDK = PowerAuthSDK(configuration: configuration, biometricConfigura
 Once the configuration above is used, then the `invalidateBiometricFactorAfterChange` option does not affect the biometry factor-related key lifetime. 
 
 <!-- begin box warning -->
-It's not recommended to allow fallback to device passcodes if your application falls under EU banking regulations or your application needs to distinguish between the biometric and the knowledge-factor-based signatures. This is because if the biometry factor-related key is unlocked with the device's passcode, then it's no longer a biometric signature.
+It's not recommended to allow fallback to device passcodes if your application falls under EU banking regulations or your application needs to distinguish between the biometric and the knowledge-factor-based authorization codes. This is because if the biometry factor-related key is unlocked with the device's passcode, then it's no longer a biometric factor.
 <!-- end -->
 
 ### LAContext support
@@ -1195,11 +1195,11 @@ The usage of `LAContext` has the following limitations:
 
 Be aware that PowerAuth automatically invalidates the application provided `LAContext` after use. This is because once the context is successfully evaluated then it can be used for a quite long time to fetch the data protected with the biometry with no prompt displayed. The exact time of validity is undocumented, but our experiments show that iOS prompts for biometric authentication again after more than 5 minutes.
 
-If you plan to pre-authorize `LAContext` and use it for multiple biometry signature calculations in a row, then please consider the following things first:
+If you plan to pre-authorize `LAContext` and use it for multiple biometry authorization code calculations in a row, then please consider the following things first:
 
 - Make sure that you make context invalid once it's no longer needed.
-- Multiple signatures in a row could be problematic if your application falls under EU banking regulations.
-- It would be difficult to prove that the user authorized the request if your application contains a bug and does the signature on the user's behalf or with the wrong context.
+- Multiple authorization codes in a row could be problematic if your application falls under EU banking regulations.
+- It would be difficult to prove that the user authorized the request if your application contains a bug and does the authorization on the user's behalf or with the wrong context.
 
 If you still insist to re-use `LAContext` then you have to alter `PowerAuthBiometricConfiguration` and set `invalidateLocalAuthenticationContextAfterUse` to `false`.
 
@@ -1214,7 +1214,7 @@ Note that if the biometric authentication fails with too many attempts in a row 
 
 ### Thread-blocking operation
 
-Be aware that if you try to calculate PowerAuth Symmetric Signature with a biometric factor, then the call to the SDK function will block the calling thread while the biometric authentication dialog is displayed. So, it's not recommended to do such an operation on the main or the networking thread. For example:
+Be aware that if you try to calculate PowerAuth Symmetric Authorization Code with a biometric factor, then the call to the SDK function will block the calling thread while the biometric authentication dialog is displayed. So, it's not recommended to do such an operation on the main or the networking thread. For example:
 
 ```swift
 let authentication = PowerAuthAuthentication.possessionWithBiometry()
@@ -1228,7 +1228,7 @@ To avoid thread blocking, acquire the biometric key in advance:
 powerAuthSDK.authenticateUsingBiometry(withPrompt: "Authenticate to sign in") { authentication, error in
     // callback is always called from the main thread
     if let authentication {
-        // Success, you can use the provided PowerAuthAuthentication object for the signature calculation.
+        // Success, you can use the provided PowerAuthAuthentication object for the authorization code calculation.
         // The provided authentication object is preconfigured for possession+biometry factors
     }
 }
@@ -1236,7 +1236,7 @@ powerAuthSDK.authenticateUsingBiometry(withPrompt: "Authenticate to sign in") { 
 
 ### Parallel biometric authentications
 
-It's not recommended to calculate more than one signature with the biometric factor at the same time, or in a row at a quick pace. Both scenarios are considered an issue in the application's logic.
+It's not recommended to calculate more than one authorization code with the biometric factor at the same time, or in a row at a quick pace. Both scenarios are considered an issue in the application's logic.
 
 To prevent the first case, PowerAuth mobile SDK is using a global mutex that guarantees that only one attempt to get the biometry-protected data at the time is performed. If your application issues another signing operation while the system dialog is displayed, then this attempt ends with `.biometryCancel` error.
 
@@ -1320,12 +1320,12 @@ self.httpClient.post(null, "/custom/activation/remove") { (error) in
 
 ### Removal via Signed Request
 
-PowerAuth Standard RESTful API has a default endpoint `/pa/v3/activation/remove` for an activation removal. This endpoint uses a signature verification for looking up the activation to be removed. The benefit of this method is that it is already present in both PowerAuth SDK for iOS and PowerAuth Standard RESTful API - nothing has to be programmed. Also, the user does not have to be logged in to use it. However, the user has to authenticate using 2FA with either a password or biometry.
+PowerAuth Standard RESTful API has a default endpoint `/pa/v3/activation/remove` for an activation removal. This endpoint uses a authorization header verification for looking up the activation to be removed. The benefit of this method is that it is already present in both PowerAuth SDK for iOS and PowerAuth Standard RESTful API - nothing has to be programmed. Also, the user does not have to be logged in to use it. However, the user has to authenticate using 2FA with either a password or biometry.
 
 Use the following code for an activation removal using a signed request:
 
 ```swift
-// 2FA signature - uses device-related key and user PIN code
+// 2FA authorization code - uses device-related key and user PIN code
 let auth = PowerAuthAuthentication.possessionWithPassword(password: "1234")
 
 // Remove activation using the provided authentication object
@@ -1343,7 +1343,7 @@ powerAuthSDK.removeActivation(with: auth) { (error) in
 Currently, PowerAuth SDK supports two basic modes of end-to-end encryption, based on the ECIES scheme:
 
 - In an "application" scope, the encryptor can be acquired and used during the whole lifetime of the application.
-- In an "activation" scope, the encryptor can be acquired only if `PowerAuthSDK` has a valid activation. The encryptor created for this mode is cryptographically bound to the parameters agreed during the activation process. You can combine this encryption with [PowerAuth Symmetric Multi-Factor Signature](#symmetric-multi-factor-signature) in "encrypt-then-sign" mode.
+- In an "activation" scope, the encryptor can be acquired only if `PowerAuthSDK` has a valid activation. The encryptor created for this mode is cryptographically bound to the parameters agreed during the activation process. You can combine this encryption with [PowerAuth Symmetric Multi-Factor Authorization Code](#symmetric-multi-factor-authorization-code) in "encrypt-then-sign" mode.
 
 For both scenarios, you need to acquire the `PowerAuthCoreEciesEncryptor` object, which will then provide an interface for the request encryption and the response decryption. The object currently provides only low-level encryption and decryption methods, so you need to implement your own JSON (de)serialization and request and response processing.
 
@@ -1402,7 +1402,7 @@ The following steps are typically required for a full E2EE request and response 
    let httpHeaderName = metadata.httpHeaderKey
    let httpHeaderValue = metadata.httpHeaderValue
    ```
-   Note that if an "activation" scoped encryptor is combined with PowerAuth Symmetric Multi-Factor signature, then this step is not required. The signature's header already contains all the information required for proper request decryption on the server.
+   Note that if an "activation" scoped encryptor is combined with PowerAuth Symmetric Multi-Factor Authorization Code, then this step is not required. The authorization header already contains all the information required for proper request decryption on the server.
 
 1. Fire your HTTP request and wait for a response
    - In case that non-200 HTTP status code is received, then the error processing is identical to a standard RESTful response defined in our protocol. So, you can expect a JSON object with `"error"` and `"message"` properties in the response.
@@ -1442,7 +1442,7 @@ The secure vault mechanism does not support biometry by default. Use PIN code or
 To obtain an encryption key with a given index, use the following code:
 
 ```swift
-// 2FA signature. It uses a device-related key and user PIN code.
+// 2FA authorization code. It uses a device-related key and user PIN code.
 let auth = PowerAuthAuthentication.possessionWithPassword(password: "1234")
 
 // Select custom key index
@@ -1465,9 +1465,9 @@ powerAuthSDK.fetchEncryptionKey(auth, index: index) { (encryptionKey, error) in
 **WARNING:** Before you start using access tokens, please visit our [documentation for powerauth-crypto](https://github.com/wultra/powerauth-crypto/blob/develop/docs/MAC-Token-Based-Authentication.md) for more information about this feature.
 <!-- end -->
 
-The tokens are simple, locally cached objects, producing timestamp-based authorization headers. Be aware that tokens are NOT a replacement for general PowerAuth signatures. They are helpful in situations when the signatures are too heavy or too complicated for implementation. Each token has the following properties:
+The tokens are simple, locally cached objects, producing timestamp-based authorization headers. Be aware that tokens are NOT a replacement for general PowerAuth Authorization Codes. They are helpful in situations when the authorization codes are too heavy or too complicated for implementation. Each token has the following properties:
 
-- It needs a PowerAuth signature for its creation (e.g., you need to provide `PowerAuthAuthentication` object)
+- It needs a PowerAuth authorization code for its creation (e.g., you need to provide `PowerAuthAuthentication` object)
 - It has a unique identifier on the server. This identifier is not exposed to the public API, but the DEBUG version of SDK can reveal that identifier in the debugger (e.g., you can use `po tokenObject` to print the object's description)
 - It has a symbolic name (e.g. "MyToken") defined by the application programmer to identify already created tokens.
 - It can generate timestamp-based authorization HTTP headers.
@@ -1481,7 +1481,7 @@ The tokens are simple, locally cached objects, producing timestamp-based authori
 To get an access token, you can use the following code:
 
 ```swift
-// 1FA signature - uses device-related key
+// 1FA authorization code - uses device-related key
 let auth = PowerAuthAuthentication.possession()
 
 let tokenStore = powerAuthSDK.tokenStore
@@ -1746,7 +1746,7 @@ if let token = tokenStore.localToken(withName: "MyToken") {
 
 The `PowerAuthSDK` allows you to specify an external encryption key (called EEK in our terminology) that can additionally protect the knowledge and the biometry factor keys. This feature is typically used to create a chain of activations where one instance of `PowerAuthSDK` is primary and unlocks access to all secondary activations.
 
-The external encryption key has to be set before the activation is created, or can be added later. The internal state of `PowerAuthSDK` contains information that the factor keys are protected with EEK, so EEK must be known at the time of PowerAuth signature is calculated. You have three options on how to configure the key:
+The external encryption key has to be set before the activation is created, or can be added later. The internal state of `PowerAuthSDK` contains information that the factor keys are protected with EEK, so EEK must be known at the time of PowerAuth authorization code is calculated. You have three options on how to configure the key:
 
 1. Assign EEK into `externalEncryptionKey` property of `PowerAuthConfiguration` at the time of `PowerAuthSDK` object creation.
    - This is the most convenient way of using EEK, but the key must be known at the time of the `PowerAuthSDK` instantiation.
@@ -2046,7 +2046,7 @@ Here's the list of important error codes, which the application should properly 
 - `PowerAuthErrorCode.biometryCancel` is reported when the user cancels the biometric authentication dialog
 - `PowerAuthErrorCode.biometryFallback` is reported when the user cancels the biometric authentication dialog with a fallback button
 - `PowerAuthErrorCode.protocolUpgrade` is reported when SDK fails to upgrade itself to a newer protocol version. The code may be reported from `PowerAuthSDK.fetchActivationStatus()`. This is an unrecoverable error resulting in the broken activation on the device, so the best situation is to inform the user about the situation and remove the activation locally.
-- `PowerAuthErrorCode.pendingProtocolUpgrade` is reported when the requested SDK operation cannot be completed due to a pending PowerAuth protocol upgrade. You can retry the operation later. The code is typically reported in situations when SDK is performing protocol upgrade in the background (as a part of activation status fetch), and the application wants to calculate the PowerAuth signature in parallel operation. Such kind of concurrency is forbidden since SDK version `1.0.0`
+- `PowerAuthErrorCode.pendingProtocolUpgrade` is reported when the requested SDK operation cannot be completed due to a pending PowerAuth protocol upgrade. You can retry the operation later. The code is typically reported in situations when SDK is performing protocol upgrade in the background (as a part of activation status fetch), and the application wants to calculate the PowerAuth authorization code in parallel operation. Such kind of concurrency is forbidden since SDK version `1.0.0`
 - `PowerAuthErrorCode.externalPendingOperation` is reported when the requested operation collides with the same operation type already started in the external application.
 
 ### Working with Invalid SSL Certificates

--- a/docs/PowerAuth-SDK-for-watchOS.md
+++ b/docs/PowerAuth-SDK-for-watchOS.md
@@ -66,7 +66,7 @@ Check [troubleshooting section](#cocoapods-integration-fails) of this document w
 
 ## Configuration
 
-The Watch SDK shares several source codes and configuration principles with the main iOS SDK. So, you can prepare the same set of constants as you're already using in your IOS application. The SDK provides just a limited functionality for the watch app (for example, you cannot create an activation or calculate a full PowerAuth signature from a watch application) and to do that it requires that your application's code will participate in data synchronization.
+The Watch SDK shares several source codes and configuration principles with the main iOS SDK. So, you can prepare the same set of constants as you're already using in your IOS application. The SDK provides just a limited functionality for the watch app (for example, you cannot create an activation or calculate a full PowerAuth authorization code from a watch application) and to do that it requires that your application's code will participate in data synchronization.
 
 ### Prepare Watch Connectivity
 

--- a/include/PowerAuth/PublicTypes.h
+++ b/include/PowerAuth/PublicTypes.h
@@ -138,7 +138,7 @@ namespace powerAuth
      and all E2EE tasks are now implemented by ECIES.
      
      This version of SDK is supporting V2 protol in very limited scope, where only
-     the V2 signature calculations are supported.
+     the V2 authorization code calculations are supported.
      */
     enum Version
     {
@@ -318,8 +318,8 @@ namespace powerAuth
         bool hasValidData() const;
         
         /**
-         Returns true when this signature calculation request is for offline
-         signatuere. This is exclusively affected by the offlineNonce property.
+         Returns true when this authorization code calculation request is for offline
+         code. This is exclusively affected by the offlineNonce property.
          */
         bool isOfflineRequest() const;
     };
@@ -343,7 +343,7 @@ namespace powerAuth
          */
         std::string applicationKey;
         /**
-         NONCE used for the signature calculation.
+         NONCE used for the offline authorization code calculation.
          */
         std::string nonce;
         /**
@@ -661,7 +661,7 @@ namespace powerAuth
          */
         bool isProtocolUpgradeAvailable() const;
         /**
-         Returns true if dummy signature calculation is recommended to prevent
+         Returns true if dummy authorization code calculation is recommended to prevent
          the counter's de-synchronization.
          */
         bool isSignatureCalculationRecommended() const;

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/sdk/PowerAuthAuthenticationTests.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/sdk/PowerAuthAuthenticationTests.java
@@ -23,9 +23,7 @@ import org.junit.runner.RunWith;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.getlime.security.powerauth.core.Password;
-import io.getlime.security.powerauth.integration.support.PowerAuthTestHelper;
 import io.getlime.security.powerauth.integration.support.RandomGenerator;
-import io.getlime.security.powerauth.integration.tests.ActivationHelper;
 import io.getlime.security.powerauth.system.PowerAuthLog;
 
 import static org.junit.Assert.*;
@@ -105,12 +103,12 @@ public class PowerAuthAuthenticationTests {
     public void testPossessionOnly() throws Exception {
         PowerAuthAuthentication authentication = PowerAuthAuthentication.possession();
         assertTrue(authentication.validateAuthenticationUsage(false));
-        assertEquals(1, authentication.getSignatureFactorsMask());
+        assertEquals(1, authentication.getAuthorizationCodeFactorsMask());
         
         authentication = PowerAuthAuthentication.possession(customPossessionKey);
         assertTrue(authentication.validateAuthenticationUsage(false));
         assertEquals(customPossessionKey, authentication.getOverriddenPossessionKey());
-        assertEquals(1, authentication.getSignatureFactorsMask());
+        assertEquals(1, authentication.getAuthorizationCodeFactorsMask());
     }
 
     @Test
@@ -118,24 +116,24 @@ public class PowerAuthAuthenticationTests {
         PowerAuthAuthentication authentication = PowerAuthAuthentication.possessionWithPassword(password);
         assertTrue(authentication.validateAuthenticationUsage(false));
         assertEquals(password, authentication.getPassword());
-        assertEquals(1 + 2, authentication.getSignatureFactorsMask());
+        assertEquals(1 + 2, authentication.getAuthorizationCodeFactorsMask());
 
         authentication = PowerAuthAuthentication.possessionWithPassword(password, customPossessionKey);
         assertTrue(authentication.validateAuthenticationUsage(false));
         assertEquals(password, authentication.getPassword());
         assertEquals(customPossessionKey, authentication.getOverriddenPossessionKey());
-        assertEquals(1 + 2, authentication.getSignatureFactorsMask());
+        assertEquals(1 + 2, authentication.getAuthorizationCodeFactorsMask());
 
         authentication = PowerAuthAuthentication.possessionWithPassword(stringPassword);
         assertTrue(authentication.validateAuthenticationUsage(false));
         assertEquals(password, authentication.getPassword());
-        assertEquals(1 + 2, authentication.getSignatureFactorsMask());
+        assertEquals(1 + 2, authentication.getAuthorizationCodeFactorsMask());
 
         authentication = PowerAuthAuthentication.possessionWithPassword(stringPassword, customPossessionKey);
         assertTrue(authentication.validateAuthenticationUsage(false));
         assertEquals(password, authentication.getPassword());
         assertEquals(customPossessionKey, authentication.getOverriddenPossessionKey());
-        assertEquals(1 + 2, authentication.getSignatureFactorsMask());
+        assertEquals(1 + 2, authentication.getAuthorizationCodeFactorsMask());
     }
 
     @Test
@@ -143,12 +141,12 @@ public class PowerAuthAuthenticationTests {
         PowerAuthAuthentication authentication = PowerAuthAuthentication.possessionWithBiometry(biometryKey);
         assertTrue(authentication.validateAuthenticationUsage(false));
         assertEquals(biometryKey, authentication.getBiometryFactorRelatedKey());
-        assertEquals(1 + 4, authentication.getSignatureFactorsMask());
+        assertEquals(1 + 4, authentication.getAuthorizationCodeFactorsMask());
 
         authentication = PowerAuthAuthentication.possessionWithBiometry(biometryKey, customPossessionKey);
         assertTrue(authentication.validateAuthenticationUsage(false));
         assertEquals(biometryKey, authentication.getBiometryFactorRelatedKey());
         assertEquals(customPossessionKey, authentication.getOverriddenPossessionKey());
-        assertEquals(1 + 4, authentication.getSignatureFactorsMask());
+        assertEquals(1 + 4, authentication.getAuthorizationCodeFactorsMask());
     }
 }

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/sdk/PowerAuthConfigurationBuilderTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/sdk/PowerAuthConfigurationBuilderTest.java
@@ -82,7 +82,7 @@ public class PowerAuthConfigurationBuilderTest {
     }
 
     @Test
-    public void testOfflineSignatureComponentLength() throws Exception {
+    public void testOfflineAuthorizationCodeComponentLength() throws Exception {
         PowerAuthConfiguration configuration = new PowerAuthConfiguration.Builder(
                 null,
                 "http://wultra.com",

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricAuthenticationRequest.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricAuthenticationRequest.java
@@ -151,7 +151,7 @@ public class BiometricAuthenticationRequest {
     /**
      * @return Application provided key which will be protected by the biometric key. The content
      * depends on whether the key is being encrypted (for key setup procedure) or decrypted (for
-     * a signature calculation).
+     * a authorization code calculation).
      */
     public @NonNull SecureData getRawKeyData() {
         return rawKeyData;

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/ActivationStatus.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/ActivationStatus.java
@@ -50,7 +50,7 @@ public class ActivationStatus {
      */
     public static final int State_Removed  = 5;
     /**
-     * The activation is technically blocked. You cannot use it anymore for the signature calculations.
+     * The activation is technically blocked. You cannot use it anymore for the authorization code calculations.
      */
     public static final int State_Deadlock = 128;
 
@@ -107,7 +107,7 @@ public class ActivationStatus {
     // Other status flags
 
     /**
-     * Contains true if dummy signature calculation is recommended to prevent
+     * Contains true if dummy authorization code calculation is recommended to prevent
      * the counter's de-synchronization.
      */
     public final boolean isSignatureCalculationRecommended;

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/ProtocolVersion.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/ProtocolVersion.java
@@ -22,7 +22,7 @@ package io.getlime.security.powerauth.core;
  * and all E2EE tasks are now implemented by ECIES.
  *
  * This version of SDK is supporting V2 protocol in very limited scope, where only
- * the V2 signature calculations are supported. Basically, you cannot connect
+ * the V2 authorization code calculations are supported. Basically, you cannot connect
  * to V2 servers with V3 SDK.
  */
 public enum ProtocolVersion {

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/Session.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/Session.java
@@ -245,7 +245,7 @@ public class Session {
      * <p>
      * <b>WARNING:</b> You have to save Session's state when the activation is completed.
      *
-     * @param lockKeys encryption keys to protect signature factors created during the activation.
+     * @param lockKeys encryption keys to protect authorization code factors created during the activation.
      * @return integer comparable to constants from {@link ErrorCode} class. If {@link ErrorCode#OK}
      *         is returned then the operation succeeded.
      */
@@ -311,7 +311,7 @@ public class Session {
     private native byte[] prepareKeyValueDictionaryForDataSigning(String[] keys, String[] values);
 
     /**
-     * Calculates signature from given data. You have to provide all involved |unlockKeys| required for
+     * Calculates authorization code from given data. You have to provide all involved |unlockKeys| required for
      * the |signatureFactor|. For |request.body| you can provide whole POST body or prepare data with
      * using 'prepareKeyValueDictionaryForDataSigning' method. The |request.method| parameter is the HTML
      * method of signed request. The |request.uri| parameter should be relative URI. Check the original PA2
@@ -332,8 +332,8 @@ public class Session {
      * guard this method with locking. There's possible race condition when the internal signing counter
      * is raised in persistent data structure. The Session doesn't provide locking internally.
      *
-     * @param request {@link SignatureRequest} object with data for signature calculation
-     * @param unlockKeys object with keys to unlock signature factors.
+     * @param request {@link SignatureRequest} object with data for authorization code calculation
+     * @param unlockKeys object with keys to unlock authorization code factor keys.
      * @param signatureFactor integer with bitwise mask of factors. See {@link SignatureFactor} class for details.
      *
      * @return {@link SignatureResult} with signature calculation result. You need to check {@link SignatureResult#errorCode}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/SessionSetup.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/SessionSetup.java
@@ -38,9 +38,9 @@ public class SessionSetup {
      * Optional external encryption key. If the byte array's size is equal to 16 bytes,
      * then the key is considered as valid and will be used during the cryptographic operations.
      * <p>
-     * The additional encryption key is useful in  multibanking applications, where it allows the
-     * application to create chain of trusted PA2 activations. If the key is set, then the session will
-     * perform additional encryption / decryption operations when the signature keys are being used.
+     * The additional encryption key is useful in  multi-banking applications, where it allows the
+     * application to create chain of trusted PowerAuth activations. If the key is set, then the session will
+     * perform additional encryption / decryption operations when the factor keys are being used.
      * <p>
      * The session implements a couple of simple protections against misuse of this feature and therefore
      * once the session is activated with the EEK, then you have to use that EEK for all future cryptographic

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/SignatureFactor.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/SignatureFactor.java
@@ -25,6 +25,8 @@ import static io.getlime.security.powerauth.core.SignatureFactor.Biometry;
 import static io.getlime.security.powerauth.core.SignatureFactor.Knowledge;
 import static io.getlime.security.powerauth.core.SignatureFactor.Possession;
 
+// TODO: Align with "authorization code" naming.
+
 /**
  * The SignatureFactor constants defines factors involved in the signature
  * computation. The factor types are tightly coupled with SignatureUnlockKeys

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/SignatureRequest.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/SignatureRequest.java
@@ -19,13 +19,13 @@ package io.getlime.security.powerauth.core;
 // TODO: Align with "authorization code" naming.
 
 /**
- * Parameters for HTTP signature calculation.
+ * Parameters for HTTP authorization code calculation.
  */
 public class SignatureRequest {
 
     /**
      * A whole POST body or data blob prepared in 'Session.prepareKeyValueDictionaryForDataSigning'
-     * method. You can also calculate signature for an empty request with no body or without
+     * method. You can also calculate authorization code for an empty request with no body or without
      * any GET parameters. In this case the member may be null.
      */
     public final byte[] body;
@@ -34,7 +34,7 @@ public class SignatureRequest {
      */
     public final String method;
     /**
-     * Cryptographic constant for signature calculation. It's recommended to use relative HTTP path.
+     * Cryptographic constant for authorization code calculation. It's recommended to use relative HTTP path.
      */
     public final String uriIdentifier;
     /**
@@ -43,7 +43,7 @@ public class SignatureRequest {
      */
     public final String offlineNonce;
     /**
-     * Length of offline signature component. The value is required and is validated only if
+     * Length of offline authorization code component. The value is required and is validated only if
      * {@link #offlineNonce} is not {@code null}.
      */
     public final int offlineSignatureLength;
@@ -52,7 +52,7 @@ public class SignatureRequest {
      * @param body bytes with HTTP request's body, or normalized bytes for GET requests
      * @param method HTTP method
      * @param uriIdentifier Cryptographic constant representing relative HTTP path
-     * @param offlineNonce Optional nonce, required for offline signatures.
+     * @param offlineNonce Optional nonce, required for offline authorization code.
      * @param offlineSignatureLength Length of offline signature component.
      */
     public SignatureRequest(

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/SignatureResult.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/SignatureResult.java
@@ -21,7 +21,7 @@ import androidx.annotation.NonNull;
 // TODO: Align with "authorization code" naming.
 
 /**
- * Result from signature calculation.
+ * Result from authorization code calculation.
  */
 public class SignatureResult {
 

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/exception/PowerAuthErrorCodes.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/exception/PowerAuthErrorCodes.java
@@ -136,8 +136,8 @@ public @interface PowerAuthErrorCodes {
      * The biometric authentication did not recognize the biometric image (fingerprint, face, etc...)
      * <p>
      * Be aware that this error code is reported only during the biometric factor setup, but is never
-     * reported when PowerAuth signature with biometric factor is requested. This is because the
-     * PowerAuth SDK swallows this error code internally and generates a random biometric signature
+     * reported when PowerAuth authorization code with biometric factor is requested. This is because the
+     * PowerAuth SDK swallows this error code internally and generates a random authorization code
      * and pretends that everything is OK. The result is that a counter of failed attempts on the server
      * is increased, so the attacker has a limited ability to fool the biometric sensor.
      */

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/client/HttpClient.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/client/HttpClient.java
@@ -160,7 +160,7 @@ public class HttpClient {
      * @param object object to be serialized into POST request
      * @param endpoint object defining the endpoint
      * @param helper cryptographic helper
-     * @param authentication optional authentication object, if request has to be signed with PowerAuth signature.
+     * @param authentication optional authentication object, if request payload has to be authenticated with PowerAuth authorization code.
      * @param listener response listener
      * @param <TRequest> type of request object
      * @param <TResponse> type of response object
@@ -244,7 +244,7 @@ public class HttpClient {
      * @param object object to be serialized into POST request
      * @param endpoint object defining the endpoint
      * @param helper cryptographic helper
-     * @param authentication optional authentication object, if request has to be signed with PowerAuth signature
+     * @param authentication optional authentication object, if request payload has to be authenticated with PowerAuth authorization code
      * @param compositeTask composite task reported back to the application
      * @param listener response listener
      * @param <TRequest> type of request object
@@ -287,7 +287,7 @@ public class HttpClient {
      * @param object object to be serialized into POST request
      * @param endpoint object defining the endpoint
      * @param helper cryptographic helper
-     * @param authentication optional authentication object, if request has to be signed with PowerAuth signature.
+     * @param authentication optional authentication object, if request payload has to be authenticated with PowerAuth authorization code
      * @param listener response listener
      * @param <TRequest> type of request object
      * @param <TResponse> type of response object

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/client/HttpRequestHelper.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/client/HttpRequestHelper.java
@@ -63,7 +63,7 @@ class HttpRequestHelper<TRequest, TResponse> {
 
     /**
      * Authentication object. The property may be null for requests which doesn't need to be
-     * signed with PowerAuth signature.
+     * authenticated with PowerAuth authorization code.
      */
     private final PowerAuthAuthentication authentication;
 
@@ -150,7 +150,7 @@ class HttpRequestHelper<TRequest, TResponse> {
      * @param baseUrl String with base URL
      * @param helper Private cryptographic helper
      * @return {@link RequestData} object with all information needed for request execution
-     * @throws PowerAuthErrorException if encryption or signature calculation fails.
+     * @throws PowerAuthErrorException if encryption or authorization code calculation fails.
      * @throws MalformedURLException if cannot construct full request URL
      */
     @NonNull

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/interfaces/IEndpointDefinition.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/interfaces/IEndpointDefinition.java
@@ -42,7 +42,7 @@ public interface IEndpointDefinition<TResponse> {
     }
 
     /**
-     * @return String with "URI Identifier", required for PowerAuth signature calculation.
+     * @return String with "URI Identifier", required for PowerAuth authorization code calculation.
      *         If endpoint is not signed, then returns null. By default, returns null.
      */
     @Nullable

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthAuthentication.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthAuthentication.java
@@ -47,14 +47,14 @@ public class PowerAuthAuthentication {
 
     /**
      * Contains {@code true} if authentication object should be used to persist activation, {@code false}
-     * if object is for signature calculation or {@code null} if this is a legacy object with no usage
+     * if object is for authorization code calculation or {@code null} if this is a legacy object with no usage
      * specified.
      */
     private final Boolean persistActivation;
 
     /**
      * Construct object with desired combination of factors. Such authentication object can be used
-     * either to persist activation and for the signature calculation.
+     * either to persist activation and for the authorization code calculation.
      * <p>
      * Note that you should prefer static construction functions instead of this constructor, unless
      * you have a special reason for it.
@@ -65,8 +65,8 @@ public class PowerAuthAuthentication {
      *
      *
      * @param persistActivation If true, then authentication can be used to persist activation.
-     * @param password If set, then knowledge factor will be used to persist activation or signature calculation.
-     * @param biometryFactorRelatedKey If set, then biometry factor will be used to persist activation or the signature calculation.
+     * @param password If set, then knowledge factor will be used to persist activation or authorization code calculation.
+     * @param biometryFactorRelatedKey If set, then biometry factor will be used to persist activation or the authorization code calculation.
      * @param overriddenPossessionKey Custom possession factor related key.
      */
     PowerAuthAuthentication(
@@ -225,64 +225,64 @@ public class PowerAuthAuthentication {
     // Authenticate
 
     /**
-     * Construct authentication object for signature calculation purposes. The signature is calculated with possession factor only.
-     * @return Authentication object constructed to calculate signature with possession factor only.
+     * Construct authentication object for authorization code calculation purposes. The authorization code is calculated with possession factor only.
+     * @return Authentication object constructed to calculate authorization code with possession factor only.
      */
     public static PowerAuthAuthentication possession() {
         return new PowerAuthAuthentication(false, null, null, null, null);
     }
 
     /**
-     * Construct authentication object for signature calculation purposes. The signature is calculated with possession factor only, with using custom possession key.
-     * @param overriddenPossessionKey Custom possession key to use for the signature calculation.
-     * @return Authentication object constructed to calculate signature with possession factor with custom possession key.
+     * Construct authentication object for authorization code calculation purposes. The authorization code is calculated with possession factor only, with using custom possession key.
+     * @param overriddenPossessionKey Custom possession key to use for the authorization code calculation.
+     * @return Authentication object constructed to calculate authorization code with possession factor with custom possession key.
      */
     public static PowerAuthAuthentication possession(@NonNull SecureData overriddenPossessionKey) {
         return new PowerAuthAuthentication(false, null, null, null, overriddenPossessionKey);
     }
 
     /**
-     * Construct authentication object for signature calculation purposes. The signature is calculated with possession and knowledge factors.
-     * @param password Password to use for the signature calculation.
-     * @return Authentication object constructed to calculate signature with possession and knowledge factors.
+     * Construct authentication object for authorization code calculation purposes. The authorization code is calculated with possession and knowledge factors.
+     * @param password Password to use for the authorization code calculation.
+     * @return Authentication object constructed to calculate authorization code with possession and knowledge factors.
      */
     public static PowerAuthAuthentication possessionWithPassword(@NonNull String password) {
         return new PowerAuthAuthentication(false, new Password(password), null, null, null);
     }
 
     /**
-     * Construct authentication object for signature calculation purposes. The signature is calculated with possession and knowledge factors, with using custom possession key.
-     * @param password Password to use for the signature calculation.
-     * @param overriddenPossessionKey Custom possession key to use for the signature calculation.
-     * @return Authentication object constructed to calculate signature with possession and knowledge factors, with using custom possession key.
+     * Construct authentication object for authorization code calculation purposes. The authorization code is calculated with possession and knowledge factors, with using custom possession key.
+     * @param password Password to use for the authorization code calculation.
+     * @param overriddenPossessionKey Custom possession key to use for the authorization code calculation.
+     * @return Authentication object constructed to calculate authorization code with possession and knowledge factors, with using custom possession key.
      */
     public static PowerAuthAuthentication possessionWithPassword(@NonNull String password, @NonNull SecureData overriddenPossessionKey) {
         return new PowerAuthAuthentication(false, new Password(password), null, null, overriddenPossessionKey);
     }
 
     /**
-     * Construct authentication object for signature calculation purposes. The signature is calculated with possession and biometry factors.
+     * Construct authentication object for authorization code calculation purposes. The authorization code is calculated with possession and biometry factors.
      * @param biometricPrompt Prompt displayed during the biometric authentication.
-     * @return Authentication object constructed to calculate signature with possession and biometry factors
+     * @return Authentication object constructed to calculate authorization code with possession and biometry factors
      */
     public static PowerAuthAuthentication possessionWithBiometry(@NonNull PowerAuthBiometricPrompt biometricPrompt) {
         return new PowerAuthAuthentication(false, null, biometricPrompt, null, null);
     }
 
     /**
-     * Construct authentication object for signature calculation purposes. The signature is calculated with possession and biometry factors.
-     * @param biometryFactorRelatedKey Biometry key data to use for the signature calculation.
-     * @return Authentication object constructed to calculate signature with possession and biometry factors
+     * Construct authentication object for authorization code calculation purposes. The authorization code is calculated with possession and biometry factors.
+     * @param biometryFactorRelatedKey Biometry key data to use for the authorization code calculation.
+     * @return Authentication object constructed to calculate authorization code with possession and biometry factors
      */
     public static PowerAuthAuthentication possessionWithBiometry(@NonNull SecureData biometryFactorRelatedKey) {
         return new PowerAuthAuthentication(false, null, null, biometryFactorRelatedKey, null);
     }
 
     /**
-     * Construct authentication object for signature calculation purposes. The signature is calculated with possession and biometry factors, with using custom possession key.
-     * @param biometryFactorRelatedKey Biometry key data to use for the signature calculation.
-     * @param overriddenPossessionKey Custom possession key to use for the signature calculation.
-     * @return Authentication object constructed to calculate signature with possession and biometry factors, with using custom possession key.
+     * Construct authentication object for authorization code calculation purposes. The authorization code is calculated with possession and biometry factors, with using custom possession key.
+     * @param biometryFactorRelatedKey Biometry key data to use for the authorization code calculation.
+     * @param overriddenPossessionKey Custom possession key to use for the authorization code calculation.
+     * @return Authentication object constructed to calculate authorization code with possession and biometry factors, with using custom possession key.
      */
     public static PowerAuthAuthentication possessionWithBiometry(@NonNull SecureData biometryFactorRelatedKey, @NonNull SecureData overriddenPossessionKey) {
         return new PowerAuthAuthentication(false, null, null, biometryFactorRelatedKey, overriddenPossessionKey);
@@ -291,26 +291,26 @@ public class PowerAuthAuthentication {
     // core/Password variants
     
     /**
-     * Construct authentication object for signature calculation purposes. The signature is calculated with possession and knowledge factors.
-     * @param password Password to use for the signature calculation.
-     * @return Authentication object constructed to calculate signature with possession and knowledge factors.
+     * Construct authentication object for authorization code calculation purposes. The authorization code is calculated with possession and knowledge factors.
+     * @param password Password to use for the authorization code calculation.
+     * @return Authentication object constructed to calculate authorization code with possession and knowledge factors.
      */
     public static PowerAuthAuthentication possessionWithPassword(@NonNull Password password) {
         return new PowerAuthAuthentication(false, password, null, null, null);
     }
 
     /**
-     * Construct authentication object for signature calculation purposes. The signature is calculated with possession and knowledge factors, with using custom possession key.
-     * @param password Password to use for the signature calculation.
-     * @param overriddenPossessionKey Custom possession key to use for the signature calculation.
-     * @return Authentication object constructed to calculate signature with possession and knowledge factors, with using custom possession key.
+     * Construct authentication object for authorization code calculation purposes. The authorization code is calculated with possession and knowledge factors, with using custom possession key.
+     * @param password Password to use for the authorization code calculation.
+     * @param overriddenPossessionKey Custom possession key to use for the authorization code calculation.
+     * @return Authentication object constructed to calculate authorization code with possession and knowledge factors, with using custom possession key.
      */
     public static PowerAuthAuthentication possessionWithPassword(@NonNull Password password, @NonNull SecureData overriddenPossessionKey) {
         return new PowerAuthAuthentication(false, password, null, null, overriddenPossessionKey);
     }
 
     /**
-     * Determines whether the signature should be calculated using the biometric factor.
+     * Determines whether the authorization code should be calculated using the biometric factor.
      * Biometric authentication is required if either a custom biometric key
      * ({@link #getBiometryFactorRelatedKey()}) or biometric prompt data
      * ({@link #getBiometricPrompt()}) is present.
@@ -366,7 +366,7 @@ public class PowerAuthAuthentication {
      * Calculate numeric value representing a combination of used factors.
      * @return Numeric value representing a combination of factors.
      */
-    int getSignatureFactorsMask() {
+    int getAuthorizationCodeFactorsMask() {
         int factors = 1;
         if (password != null) {
             factors |= 2;
@@ -422,7 +422,7 @@ public class PowerAuthAuthentication {
                 if (forPersist) {
                     PowerAuthLog.w("Using PowerAuthAuthentication object for a different purpose. The object to persist activation is expected.");
                 } else {
-                    PowerAuthLog.w("Using PowerAuthAuthentication object for a different purpose. The object for signature calculation is expected.");
+                    PowerAuthLog.w("Using PowerAuthAuthentication object for a different purpose. The object for authorization code calculation is expected.");
                 }
                 return false;
             }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -416,7 +416,7 @@ public class PowerAuthSDK {
      */
     private @NonNull SignatureUnlockKeys signatureKeysForAuthentication(@NonNull Context context, @NonNull PowerAuthAuthentication authentication) {
 
-        // Validate authentication usage for signature calculation.
+        // Validate authentication usage for authorization code calculation.
         authentication.validateAuthenticationUsage(false);
 
         // Generate signature key encryption keys
@@ -439,7 +439,7 @@ public class PowerAuthSDK {
 
     /**
      * Converts signature factors from {@link PowerAuthAuthentication} into numeric constant
-     * usable in low level signature calculation routines.
+     * usable in low level authorization code calculation routines.
      *
      * @param authentication {@link PowerAuthAuthentication} object with signature factors set.
      * @return Integer with an appropriate bits set. Each bit represents one signature factor.
@@ -1825,14 +1825,14 @@ public class PowerAuthSDK {
      * Compute PowerAuth authorization code for given signature request object and authentication.
      * <p>
      * This private method checks most of the session states (except invalid setup) and then performs
-     * the signature calculation. The {@link SignatureRequest} object has to be properly configured,
+     * the authorization code calculation. The {@link SignatureRequest} object has to be properly configured,
      * before the operation. Method always returns a {@link SignatureResult} object or throws
      * an exception in case of failure.
      *
      * @param context android context object
-     * @param signatureRequest data for signature calculation
+     * @param signatureRequest data for authorization code calculation
      * @param authentication authentication object
-     * @param allowInUpgrade if true, then the signature calculation can be performed during the protocol upgrade.
+     * @param allowInUpgrade if true, then the authorization code calculation can be performed during the protocol upgrade.
      * @return {@link SignatureResult}
      * @throws PowerAuthErrorException if calculation fails.
      */
@@ -1868,7 +1868,7 @@ public class PowerAuthSDK {
 
         // Check the result
         if (signatureResult.errorCode != ErrorCode.OK) {
-            throw new PowerAuthErrorException(PowerAuthErrorCodes.SIGNATURE_ERROR, "Signature calculation failed on error " +  signatureResult.errorCode);
+            throw new PowerAuthErrorException(PowerAuthErrorCodes.SIGNATURE_ERROR, "Authorization code calculation failed on error " +  signatureResult.errorCode);
         }
 
         return signatureResult;
@@ -2846,13 +2846,13 @@ public class PowerAuthSDK {
      * <h3>Why this matters</h3>
      *
      * The PowerAuth SDK is using that executor for serialization of signed HTTP requests, to guarantee, that only one request is processed
-     * at the time. The PowerAuth signatures are based on a logical counter, so this technique makes that all requests are delivered
+     * at the time. The PowerAuth authorization codes are based on a logical counter, so this technique makes that all requests are delivered
      * to the server in the right order. So, if the application is creating its own signed requests, then it's recommended to synchronize
      * them with the SDK.
      *
      * <h3>Recommended practices</h3>
      * <ul>
-     *     <li>You should calculate PowerAuth signature from the {@link Runnable#run()} method.
+     *     <li>You should calculate PowerAuth authorization code from the {@link Runnable#run()} method.
      *     <li>{@link Runnable#run()} should return from its execution after the HTTP request is fully processed, or at least after
      *         the response headers are received (e.g. you know that the server already did process the request)
      * </ul>

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthTokenStore.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthTokenStore.java
@@ -154,7 +154,7 @@ public class PowerAuthTokenStore {
     }
 
     /**
-     * Create a new access token with given name for requested signature factors.
+     * Create a new access token with given name for requested authenticating factors.
      * <p>
      * Note that the method is thread safe, but it's not recommended to request for the same token
      * name in parallel when the token is not created yet. If the method returns an asynchronous task,
@@ -230,14 +230,14 @@ public class PowerAuthTokenStore {
     private @Nullable PowerAuthToken createAccessToken(@NonNull Context context, @NonNull PowerAuthPrivateTokenData tokenData, @NonNull PowerAuthAuthentication authentication) {
         if (tokenData.authenticationFactors != 0) {
             // Token data contains information about factors.
-            if (tokenData.authenticationFactors != authentication.getSignatureFactorsMask()) {
+            if (tokenData.authenticationFactors != authentication.getAuthorizationCodeFactorsMask()) {
                 PowerAuthLog.e("Using different PowerAuthAuthentication for token '" + tokenData.name + "' creation is not allowed.");
                 return null;
             }
         } else {
             // Token was created in OLD SDK, so we should upgrade data and assign a currently requested authentication factors.
             PowerAuthLog.d("PowerAuthTokenStore: Upgrading authentication data for token '" + tokenData.name + "'");
-            tokenData = new PowerAuthPrivateTokenData(tokenData.name, tokenData.identifier, tokenData.secret, tokenData.activationId, authentication.getSignatureFactorsMask());
+            tokenData = new PowerAuthPrivateTokenData(tokenData.name, tokenData.identifier, tokenData.secret, tokenData.activationId, authentication.getAuthorizationCodeFactorsMask());
             storeTokenData(context, tokenData, true);
         }
         return new PowerAuthToken(this, sdk.getTimeSynchronizationService(), tokenData);
@@ -271,7 +271,7 @@ public class PowerAuthTokenStore {
         // Try to find grouped task in task map.
         GetAccessTokenTask groupedTask = createTokenRequests.get(tokenName);
         if (groupedTask != null) {
-            if (groupedTask.authenticationFactors != authentication.getSignatureFactorsMask()) {
+            if (groupedTask.authenticationFactors != authentication.getAuthorizationCodeFactorsMask()) {
                 PowerAuthLog.e("Using different PowerAuthAuthentication for token '" + tokenName + "' creation is not allowed.");
                 return null;
             }
@@ -282,10 +282,10 @@ public class PowerAuthTokenStore {
             // Prepare activationID in advance, to do not store null when activation is suddenly
             // removed during the operation.
             final String activationIdentifier = sdk.getActivationIdentifier();
-            final int authenticationFactors = authentication.getSignatureFactorsMask();
+            final int authenticationFactors = authentication.getAuthorizationCodeFactorsMask();
 
             // Create new grouped task
-            groupedTask = new GetAccessTokenTask(authentication.getSignatureFactorsMask(), lock, sdk.getCallbackDispatcher(), new GetAccessTokenTask.Listener() {
+            groupedTask = new GetAccessTokenTask(authentication.getAuthorizationCodeFactorsMask(), lock, sdk.getCallbackDispatcher(), new GetAccessTokenTask.Listener() {
 
                 @Override
                 public void onTaskStart(@NonNull final GetAccessTokenTask groupedTask) {

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/GetActivationStatusTask.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/GetActivationStatusTask.java
@@ -219,7 +219,7 @@ public class GetActivationStatusTask extends GroupedTask<ActivationStatus> {
     //
 
     /**
-     * Continue task with signature counter synchronization. In this case, just {@code /pa/signature/validate}
+     * Continue task with authorization code counter synchronization. In this case, just {@code /pa/signature/validate}
      * endpoint is called, with simple possession-only signature. That will force server to catch up
      * with the local counter.
      *
@@ -414,7 +414,7 @@ public class GetActivationStatusTask extends GroupedTask<ActivationStatus> {
                         final ProtocolUpgradeData upgradeData = ProtocolUpgradeData.version3(response.getCtrData());
                         if (session.applyProtocolUpgradeData(upgradeData) == ErrorCode.OK) {
                             // Everything looks fine, we can continue with commit on server.
-                            // Since this change, we can sign requests with V3 signatures
+                            // Since this change, we can sign requests with V3 authorization codes
                             // and local protocol version is bumped to V3.
                             serializeSessionState();
                             commitUpgradeToV3();

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/IPrivateCryptoHelper.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/IPrivateCryptoHelper.java
@@ -44,15 +44,15 @@ public interface IPrivateCryptoHelper {
     @NonNull EciesEncryptor getEciesEncryptor(@NonNull EciesEncryptorId identifier) throws PowerAuthErrorException;
 
     /**
-     * Calculates PowerAuth signature for given data.
+     * Calculates PowerAuth authorization code for given data.
      *
      * @param availableInProtocolUpgrade true, if request is available during the protocol upgrade
      * @param body data to be authorized
      * @param method http method (typically POST)
-     * @param uriIdentifier URI identifier, required for PowerAuth signature
+     * @param uriIdentifier URI identifier, required for PowerAuth authorization code
      * @param authentication object with credentials
      * @return Authorization header object or null, in case of error.
-     * @throws PowerAuthErrorException is signature cannot be calculated
+     * @throws PowerAuthErrorException if authorization code cannot be calculated
      */
     @NonNull PowerAuthAuthorizationHttpHeader getAuthorizationHeader(
             boolean availableInProtocolUpgrade,

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/PowerAuthPrivateTokenData.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/PowerAuthPrivateTokenData.java
@@ -47,7 +47,7 @@ public class PowerAuthPrivateTokenData {
      */
     public final String activationId;
     /**
-     * Integer represents PowerAuth Symmetric Signature factors used for the token creation.
+     * Integer represents PowerAuth Symmetric Authorization Code factors used for the token creation.
      * If value is equal to 0, then the token was created in older SDKs than 1.7.0.
      */
     public final int authenticationFactors;

--- a/proj-xcode/PowerAuth2/PowerAuthActivationStatus.h
+++ b/proj-xcode/PowerAuth2/PowerAuthActivationStatus.h
@@ -44,7 +44,7 @@ typedef NS_ENUM(NSInteger, PowerAuthActivationState) {
     PowerAuthActivationState_Removed  = 5,
     /**
      The activation is technically blocked. You cannot use it anymore
-     for the signature calculations.
+     for the authorization code calculations.
      */
     PowerAuthActivationState_Deadlock   = 128,
 };

--- a/proj-xcode/PowerAuth2/PowerAuthAuthentication.m
+++ b/proj-xcode/PowerAuth2/PowerAuthAuthentication.m
@@ -383,7 +383,7 @@
         if (forPersist) {
             PowerAuthLog(@"WARNING: Using PowerAuthAuthentication object for a different purpose. The object for activation persist is expected.");
         } else {
-            PowerAuthLog(@"WARNING: Using PowerAuthAuthentication object for a different purpose. The object for signature calculation is expected.");
+            PowerAuthLog(@"WARNING: Using PowerAuthAuthentication object for a different purpose. The object for authorization code calculation is expected.");
         }
         return NO;
     }

--- a/proj-xcode/PowerAuth2/PowerAuthAuthorizationHttpHeader.h
+++ b/proj-xcode/PowerAuth2/PowerAuthAuthorizationHttpHeader.h
@@ -21,7 +21,7 @@
 
 /**
  Class representing authorization HTTP header with the PowerAuth-Authorization
- or PowerAuth-Token signature.
+ or PowerAuth-Token authorization.
  */
 @interface PowerAuthAuthorizationHttpHeader : NSObject
 

--- a/proj-xcode/PowerAuth2/PowerAuthSDK.h
+++ b/proj-xcode/PowerAuth2/PowerAuthSDK.h
@@ -426,7 +426,7 @@
 
 /// MARK: - Deprecated "symmetric signatures"
 
-/** Compute the HTTP signature header for GET HTTP method, URI identifier and HTTP query parameters using provided authentication information.
+/** Compute the HTTP authorization header for GET HTTP method, URI identifier and HTTP query parameters using provided authentication information.
  
  This method may block a main thread - make sure to dispatch it asynchronously.
  
@@ -434,7 +434,7 @@
  @param uriId URI identifier.
  @param params HTTP query params.
  @param error Error reference in case some error occurs.
- @return HTTP header with PowerAuth authorization signature. In case of error, this method return 'nil'.
+ @return HTTP header with PowerAuth authorization code. In case of error, this method return 'nil'.
  @exception NSException thrown in case configuration is not present.
  @deprecated Use `authorizationHeaderForRequestWithParams(with:method:uriId:params:)` as a replacement.
  */
@@ -444,16 +444,16 @@
                                                                                error:(NSError * _Nullable * _Nullable)error
                                                                                 PA2_DEPRECATED(1.10.0);
 
-/** Compute the HTTP signature header for given HTTP method, URI identifier and HTTP request body using provided authentication information.
+/** Compute the HTTP authorization code header for given HTTP method, URI identifier and HTTP request body using provided authentication information.
  
  This method may block a main thread - make sure to dispatch it asynchronously.
  
  @param authentication An authentication instance specifying what factors should be used to sign the request.
- @param method HTTP method used for the signature computation.
+ @param method HTTP method used for the authorization code computation.
  @param uriId URI identifier.
  @param body HTTP request body.
  @param error Error reference in case some error occurs.
- @return HTTP header with PowerAuth authorization signature. In case of error, this method return 'nil'.
+ @return HTTP header with PowerAuth authorization code. In case of error, this method return 'nil'.
  @exception NSException thrown in case configuration is not present.
  @deprecated Use `authorizationHeaderForRequestWithBody(with:method:uriId:body:)` as a replacement.
  */
@@ -464,7 +464,7 @@
                                                                             error:(NSError * _Nullable * _Nullable)error
                                                                                 PA2_DEPRECATED(1.10.0);
 
-/** Compute the offline signature for URI identifier and HTTP request body using provided authentication information.
+/** Compute the offline authorization code for URI identifier and HTTP request body using provided authentication information.
  
  This method may block a main thread - make sure to dispatch it asynchronously.
  
@@ -473,7 +473,7 @@
  @param body HTTP request body.
  @param nonce NONCE in Base64 format.
  @param error Error reference in case some error occurs.
- @return String representing a calculated signature for all involved factors. In case of error, this method return 'nil'.
+ @return String representing a calculated authorization code for all involved factors. In case of error, this method return 'nil'.
  @exception NSException thrown in case configuration is not present.
  @deprecated Use `offlineAuthorizationCode(with:uriId:body:nonce:callback:)` method as a replacement.
  */
@@ -557,7 +557,7 @@
 
 /** Validate a user password.
  
- This method calls PowerAuth Standard RESTful API endpoint '/pa/signature/validate' to validate the signature value.
+ This method calls PowerAuth Standard RESTful API endpoint '/pa/signature/validate' to validate the authorization code value.
  
  @param password Password to be verified.
  @param callback The callback method with error associated with the password validation.
@@ -569,7 +569,7 @@
 
 /** Validate a user password.
  
- This method calls PowerAuth Standard RESTful API endpoint '/pa/signature/validate' to validate the signature value.
+ This method calls PowerAuth Standard RESTful API endpoint '/pa/signature/validate' to validate the authorization code value.
  
  @param password Password to be verified.
  @param callback The callback method with error associated with the password validation.
@@ -627,9 +627,9 @@
  */
 - (nullable id<PowerAuthOperationTask>) removeBiometryFactorWithCallback:(nonnull void(^)(NSError * _Nullable error))callback;
 
-/** Prepare PowerAuthAuthentication object for future PowerAuth signature calculation with a biometry and possession factors involved.
+/** Prepare PowerAuthAuthentication object for future PowerAuth authorization code calculation with a biometry and possession factors involved.
  
- The method is also useful for situations where business processes require compute two or more different PowerAuth biometry signatures in one interaction with the user. To achieve this, the application must acquire the custom-created PowerAuthAuthentication object first and then use it for the required signature calculations. It's recommended to keep this instance referenced only for a limited time, required for all future signature calculations.
+ The method is also useful for situations where business processes require compute two or more different PowerAuth biometry authorization codes in one interaction with the user. To achieve this, the application must acquire the custom-created PowerAuthAuthentication object first and then use it for the required authorization code calculations. It's recommended to keep this instance referenced only for a limited time, required for all future authorization code calculations.
   
  Be aware, that you must not execute the next HTTP request signed with the same credentials when the previous one fails with the 401 HTTP status code. If you do, then you risk blocking the user's activation on the server.
  
@@ -642,9 +642,9 @@
                                                                 NS_SWIFT_NAME(authenticateUsingBiometry(withPrompt:callback:))
                                                                 API_UNAVAILABLE(tvos);
 
-/** Prepare PowerAuthAuthentication object for future PowerAuth signature calculation with a biometry and possession factors involved.
+/** Prepare PowerAuthAuthentication object for future PowerAuth authorization code calculation with a biometry and possession factors involved.
  
- The method is also useful for situations where business processes require compute two or more different PowerAuth biometry signatures in one interaction with the user. To achieve this, the application must acquire the custom-created PowerAuthAuthentication object first and then use it for the required signature calculations. It's recommended to keep this instance referenced only for a limited time, required for all future signature calculations.
+ The method is also useful for situations where business processes require compute two or more different PowerAuth biometry authorization codes in one interaction with the user. To achieve this, the application must acquire the custom-created PowerAuthAuthentication object first and then use it for the required authorization code calculations. It's recommended to keep this instance referenced only for a limited time, required for all future authorization code calculations.
   
  Be aware, that you must not execute the next HTTP request signed with the same credentials when the previous one fails with the 401 HTTP status code. If you do, then you risk blocking the user's activation on the server.
  
@@ -659,7 +659,7 @@
 
 /** Unlock all keys stored in a biometry related keychain and keeps them cached for the scope of the block.
  
- There are situations where biometry related keys from different PowerAuthSDK instances are needed in a single business process. For example, when having a master-child activation pair, computing signature in the child activation requires master activation to use vault unlock first and then, after the request is completed, child activation can compute the signature. This would normally trigger biometry dialog twice. To avoid that, all biometry related keys are fetched at once and cached for a limited amount of time.
+ There are situations where biometry related keys from different PowerAuthSDK instances are needed in a single business process. For example, when having a master-child activation pair, computing authorization code in the child activation requires master activation to use vault unlock first and then, after the request is completed, child activation can compute the authorization code. This would normally trigger biometry dialog twice. To avoid that, all biometry related keys are fetched at once and cached for a limited amount of time.
  */
 - (void) unlockBiometryKeysWithPrompt:(nonnull NSString*)prompt
                             withBlock:(nonnull void(^)(NSDictionary<NSString*, NSData*> * _Nullable keys, BOOL userCanceled))block
@@ -668,7 +668,7 @@
 
 /** Unlock all keys stored in a biometry related keychain and keeps them cached for the scope of the block.
  
- There are situations where biometry related keys from different PowerAuthSDK instances are needed in a single business process. For example, when having a master-child activation pair, computing signature in the child activation requires master activation to use vault unlock first and then, after the request is completed, child activation can compute the signature. This would normally trigger biometry dialog twice. To avoid that, all biometry related keys are fetched at once and cached for a limited amount of time.
+ There are situations where biometry related keys from different PowerAuthSDK instances are needed in a single business process. For example, when having a master-child activation pair, computing authorization code in the child activation requires master activation to use vault unlock first and then, after the request is completed, child activation can compute the authorization code. This would normally trigger biometry dialog twice. To avoid that, all biometry related keys are fetched at once and cached for a limited amount of time.
  */
 - (void) unlockBiometryKeysWithContext:(nonnull LAContext*)context
                              withBlock:(nonnull void(^)(NSDictionary<NSString*, NSData*> * _Nullable keys, BOOL userCanceled))block
@@ -790,13 +790,13 @@
  @b Why this matters
  
  The PowerAuth SDK is using that executor for serialization of signed HTTP requests, to guarantee, that only one request is processed
- at the time. The PowerAuth signatures are based on a logical counter, so this technique makes that all requests are delivered
+ at the time. The PowerAuth authorization codes are based on a logical counter, so this technique makes that all requests are delivered
  to the server in the right order. So, if the application is creating its own signed requests, then it's recommended to synchronize
  them with the SDK.
  
  @b Recommended practices
  
- 1)  You should calculate PowerAuth signature from the execute block method.
+ 1)  You should calculate PowerAuth authorization code from the execute block method.
  
  2)  You have to always call `task.cancel()` on provided `PowerAuthOperationTask` object once the operation is finished,
      otherwise the seriali queue will be blocked indefinitely.
@@ -813,13 +813,13 @@
  @b Why this matters
  
  The PowerAuth SDK is using that executor for serialization of signed HTTP requests, to guarantee, that only one request is processed
- at the time. The PowerAuth signatures are based on a logical counter, so this technique makes that all requests are delivered
+ at the time. The PowerAuth authorization codes are based on a logical counter, so this technique makes that all requests are delivered
  to the server in the right order. So, if the application is creating its own signed requests, then it's recommended to synchronize
  them with the SDK.
  
  @b Recommended practices
  
- You should calculate PowerAuth signature after the operation is started. If you calculate the signature before and after that you add
+ You should calculate PowerAuth authorization code after the operation is started. If you calculate the authorization code before and after that you add
  that operation to the queue, the logical counter may not be synchronized properly.
  
  

--- a/proj-xcode/PowerAuth2/PowerAuthSDK.m
+++ b/proj-xcode/PowerAuth2/PowerAuthSDK.m
@@ -1154,7 +1154,7 @@ static PowerAuthSDK * s_inst;
         id<PowerAuthOperationTask> biometricAuthTask = [self authenticateUsingBiometryImpl:authentication.keychainAuthentication
                                                                                   callback:^(PowerAuthAuthentication *resolvedAuthentication, NSError *error) {
             if (resolvedAuthentication) {
-                // Biometric authentication succeeded, now continue with signature calculation
+                // Biometric authentication succeeded, now continue with authorization code calculation
                 executionFunc(resolvedAuthentication);
             } else {
                 // Biometric authentication failed
@@ -1254,7 +1254,7 @@ static PowerAuthSDK * s_inst;
 
 
 /**
- This private method implements both online & offline signature calculations. Unlike the public interfaces, method accepts
+ This private method implements both online & offline authorization code calculations. Unlike the public interfaces, method accepts
  PA2HTTPRequestData object as a source for data for signing and returns structured PA2HTTPRequestDataSignature object.
  */
 - (PowerAuthCoreHTTPRequestDataSignature*) signHttpRequestData:(PowerAuthCoreHTTPRequestData*)requestData

--- a/proj-xcode/PowerAuth2/PowerAuthToken.h
+++ b/proj-xcode/PowerAuth2/PowerAuthToken.h
@@ -88,7 +88,7 @@
 - (BOOL) canRequestForAccessToken;
 
 /**
- Create a new access token with given name for requested signature factors. The created token objects
+ Create a new access token with given name for requested authentication factors. The created token objects
  always contains valid token data.
  
  Discussion

--- a/proj-xcode/PowerAuth2/private/PA2HttpClient.h
+++ b/proj-xcode/PowerAuth2/private/PA2HttpClient.h
@@ -59,7 +59,7 @@
  each instnace of PowerAuthSDK has its own queue.
  
  Note that the queue may be blocked for an indefinite amount of time, when the biometry
- signature is requested. The reson for that is that the entry, protected by biometry,
+ authentication is requested. The reson for that is that the entry, protected by biometry,
  needs to be acquired from the underlying keychain.
  */
 @property (nonatomic, strong, nonnull, readonly) NSOperationQueue * serialQueue;

--- a/proj-xcode/PowerAuth2/private/PA2PrivateCryptoHelper.h
+++ b/proj-xcode/PowerAuth2/private/PA2PrivateCryptoHelper.h
@@ -36,7 +36,7 @@
                                            error:(NSError**)error;
 
 /**
- Calculates PowerAuth signature for data & endpoint.
+ Calculates PowerAuth authorization code for data & endpoint.
  */
 - (PowerAuthAuthorizationHttpHeader*) authorizationHeaderForData:(NSData*)data
                                                   endpoint:(PA2RestApiEndpoint*)endpoint

--- a/proj-xcode/PowerAuth2/private/PA2RestApiEndpoint.h
+++ b/proj-xcode/PowerAuth2/private/PA2RestApiEndpoint.h
@@ -32,7 +32,7 @@
 /// Encryptor's identifier, in case that request & response is encrypted.
 @property (nonatomic, assign, readonly) PA2EncryptorId encryptor;
 
-/// uriId for PowerAuth signature calculation, in case that request is signed.
+/// uriId for PowerAuth authorization code calculation, in case that request is signed.
 @property (nonatomic, strong, readonly) NSString * authUriId;
 
 /// Object type expected in request body.
@@ -53,7 +53,7 @@
 @property (nonatomic, assign, readonly) BOOL isEncryptedWithApplicationScope;
 
 
-/// Returns YES, if request needs to be signed with PA signature
+/// Returns YES, if request needs to be signed with PA authorization code
 @property (nonatomic, assign, readonly) BOOL isSigned;
 
 /// Returns YES, if endpoint is available during the protocol upgrade.

--- a/proj-xcode/PowerAuth2/private/PowerAuthActivationStatus+Private.h
+++ b/proj-xcode/PowerAuth2/private/PowerAuthActivationStatus+Private.h
@@ -39,7 +39,7 @@
  */
 @property (nonatomic, assign, readonly) BOOL isProtocolUpgradeAvailable;
 /**
- Returns true if dummy signature calculation is recommended to prevent
+ Returns true if dummy authorization code calculation is recommended to prevent
  the counter's de-synchronization.
  */
 @property (nonatomic, assign, readonly) BOOL isSignatureCalculationRecommended;

--- a/proj-xcode/PowerAuth2/private/PowerAuthSDK+Private.h
+++ b/proj-xcode/PowerAuth2/private/PowerAuthSDK+Private.h
@@ -45,7 +45,7 @@
 - (PowerAuthCoreData*) deviceRelatedKey;
 
 /**
- Low level signature calculation. Unlike the high level interface, this method doesn't check
+ Low level authorization code calculation. Unlike the high level interface, this method doesn't check
  the protocol upgrade flag. This is useful for situations, where the flag is validated elsewhere, or
  when the request can be signed during the pending protocol upgrade.
  */

--- a/proj-xcode/PowerAuthCore/PowerAuthCoreTypes.h
+++ b/proj-xcode/PowerAuthCore/PowerAuthCoreTypes.h
@@ -126,7 +126,7 @@ typedef NS_ENUM(int, PowerAuthCoreErrorCode) {
  and all E2EE tasks are now implemented by ECIES.
  
  This version of SDK is supporting V2 protol in very limited scope, where only
- the V2 signature calculations are supported. Basically, you cannot connect
+ the V2 authorization code calculations are supported. Basically, you cannot connect
  to V2 servers with V3 SDK.
  */
 typedef NS_ENUM(int, PowerAuthCoreProtocolVersion) {
@@ -279,7 +279,7 @@ typedef NS_ENUM(int, PowerAuthCoreSignatureFactor) {
  */
 @property (nonatomic, strong, nonnull, readonly) NSString * applicationKey;
 /**
- NONCE used for the signature calculation.
+ NONCE used for the offline authorization code calculation.
  */
 @property (nonatomic, strong, nonnull, readonly) NSString * nonce;
 /**
@@ -478,7 +478,7 @@ typedef NS_ENUM(int, PowerAuthCoreActivationState) {
     PowerAuthCoreActivationState_Removed  = 5,
     /**
      The activation is technically blocked. You cannot use it anymore
-     for the signature calculations.
+     for the authorization code calculations.
      */
     PowerAuthCoreActivationState_Deadlock   = 128,
 };
@@ -544,7 +544,7 @@ typedef NS_ENUM(int, PowerAuthCoreActivationState) {
  */
 @property (nonatomic, assign, readonly) BOOL isProtocolUpgradeAvailable;
 /**
- Returns true if dummy signature calculation is recommended to prevent
+ Returns true if dummy authorization code calculation is recommended to prevent
  the counter's de-synchronization.
  */
 @property (nonatomic, assign, readonly) BOOL isSignatureCalculationRecommended;

--- a/src/PowerAuth/Session.cpp
+++ b/src/PowerAuth/Session.cpp
@@ -513,7 +513,7 @@ namespace powerAuth
                 return ActivationStatus::Counter_Updated;
             }
             // Otherwise it's not possible to determine whether the counter's OK. We have to wait to sync counters
-            // in the next regular signature calculation. In this case, we must pretend that everything's OK.
+            // in the next regular authorization code calculation. In this case, we must pretend that everything's OK.
             return ActivationStatus::Counter_OK;
         }
         
@@ -640,7 +640,7 @@ namespace powerAuth
         const bool base64_sig_format = !request.isOfflineRequest() && _pd->isV3();
         out.signature = protocol::CalculateSignature(plain_keys, signature_factor, ctr_data, data, base64_sig_format, request.offlineSignatureLength);
         if (out.signature.empty()) {
-            CC7_LOG("Session %p: Sign: Signature calculation failed.", this);
+            CC7_LOG("Session %p: Sign: Authorization code calculation failed.", this);
             return EC_Encryption;
         }
         

--- a/src/PowerAuth/protocol/PrivateTypes.h
+++ b/src/PowerAuth/protocol/PrivateTypes.h
@@ -122,11 +122,11 @@ namespace protocol
     struct PersistentData
     {
         /**
-         V2: Counter for signature calculations
+         V2: Counter for authorization code calculations
          */
         cc7::U64        signatureCounter;
         /**
-         V3: Data for hash-based counter for signature calculations
+         V3: Data for hash-based counter for authorization code calculations
          */
         cc7::ByteArray  signatureCounterData;
         /**

--- a/src/PowerAuth/protocol/ProtocolUtils.h
+++ b/src/PowerAuth/protocol/ProtocolUtils.h
@@ -109,7 +109,7 @@ namespace protocol
                                    size_t offline_size);
     
     /**
-     Prepares exact data for signature calculation:
+     Prepares exact data for authorization code calculation:
      REQ = ${method}&${B64(uri)}&${nonceB64}&${B64(body)}&${secret}
      */
     cc7::ByteArray NormalizeDataForSignature(const std::string & method,


### PR DESCRIPTION
This PR changes terminology from "PowerAuth signature" to "PowerAuth authorization code". The low-level interfaces, like PowerAuthCoreSession, or C++ code, are still using "signature" terminology. I would like to update this as a part of Crypto 4 works.