### PR TITLE
Decrypt biometric key on background

### DIFF
--- a/proj-android/PowerAuthLibrary/src/androidTest/AndroidManifest.xml
+++ b/proj-android/PowerAuthLibrary/src/androidTest/AndroidManifest.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <application android:usesCleartextTraffic="true" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="io.getlime.security.powerauth.test">
+    <application android:usesCleartextTraffic="true">
+        <activity android:name="io.getlime.security.powerauth.integration.support.TestActivity"
+                  android:exported="false"/>
+    </application>
 </manifest>

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/ITestExecution.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/ITestExecution.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.integration.support;
+
+/**
+ * A simple interface that allows us execute arbitrary testing function that may
+ * produce an exception.
+ */
+@FunctionalInterface
+public interface ITestExecution {
+    /**
+     * Function that suppose to contain test case body.
+     * @throws Exception Exception produced in the unit test.
+     */
+    void execute() throws Exception;
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/PowerAuthTestHelper.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/PowerAuthTestHelper.java
@@ -21,6 +21,8 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
 import androidx.test.platform.app.InstrumentationRegistry;
 
 import io.getlime.security.powerauth.integration.support.client.PowerAuthClientFactory;
@@ -28,11 +30,7 @@ import io.getlime.security.powerauth.integration.support.model.Application;
 import io.getlime.security.powerauth.integration.support.model.ApplicationDetail;
 import io.getlime.security.powerauth.integration.support.model.ApplicationVersion;
 import io.getlime.security.powerauth.networking.ssl.HttpClientSslNoValidationStrategy;
-import io.getlime.security.powerauth.sdk.PowerAuthAuthenticationHelper;
-import io.getlime.security.powerauth.sdk.PowerAuthClientConfiguration;
-import io.getlime.security.powerauth.sdk.PowerAuthConfiguration;
-import io.getlime.security.powerauth.sdk.PowerAuthKeychainConfiguration;
-import io.getlime.security.powerauth.sdk.PowerAuthSDK;
+import io.getlime.security.powerauth.sdk.*;
 import io.getlime.security.powerauth.system.PowerAuthLog;
 import io.getlime.security.powerauth.system.PowerAuthSystem;
 
@@ -46,6 +44,8 @@ public class PowerAuthTestHelper {
     private final @NonNull PowerAuthTestConfig testConfig;
     private final @NonNull PowerAuthServerApi serverApi;
     private final @NonNull RandomGenerator randomGenerator;
+    private final @Nullable FragmentActivity testFragmentActivity;
+    private final @Nullable Fragment testFragment;
 
     private @NonNull PowerAuthSDK sharedSdk;
     private final @NonNull PowerAuthConfiguration sharedConfiguration;
@@ -91,6 +91,9 @@ public class PowerAuthTestHelper {
         private PowerAuthConfiguration sharedConfiguration;
         private PowerAuthKeychainConfiguration sharedKeychainConfiguration;
         private PowerAuthClientConfiguration sharedClientConfiguration;
+
+        private FragmentActivity testFragmentActivity;
+        private Fragment testFragment;
 
         private ApplicationDetail sharedApplication;
         private ApplicationVersion sharedApplicationVersion;
@@ -172,6 +175,16 @@ public class PowerAuthTestHelper {
             return this;
         }
 
+        public @NonNull Builder testFragmentActivity(@NonNull FragmentActivity activity) {
+            this.testFragmentActivity = activity;
+            return this;
+        }
+
+        public @NonNull Builder testFragment(@NonNull Fragment fragment) {
+            this.testFragment = fragment;
+            return this;
+        }
+
         /**
          * Build {@link PowerAuthTestHelper} instance. Note that the method does a synchronous communication with
          * PowerAuth Server REST API.
@@ -223,7 +236,9 @@ public class PowerAuthTestHelper {
                     keychainConfiguration,
                     clientConfiguration,
                     sharedApplication,
-                    sharedApplicationVersion);
+                    sharedApplicationVersion,
+                    testFragmentActivity,
+                    testFragment);
         }
 
         /**
@@ -322,7 +337,9 @@ public class PowerAuthTestHelper {
             @NonNull PowerAuthKeychainConfiguration sharedKeychainConfiguration,
             @NonNull PowerAuthClientConfiguration sharedClientConfiguration,
             @NonNull ApplicationDetail sharedApplication,
-            @NonNull ApplicationVersion sharedApplicationVersion) {
+            @NonNull ApplicationVersion sharedApplicationVersion,
+            @Nullable FragmentActivity fragmentActivity,
+            @Nullable Fragment fragment) {
         this.context = context;
         this.testConfig = testConfig;
         this.serverApi = serverApi;
@@ -333,6 +350,8 @@ public class PowerAuthTestHelper {
         this.sharedApplication = sharedApplication;
         this.sharedApplicationVersion = sharedApplicationVersion;
         this.randomGenerator = new RandomGenerator();
+        this.testFragment = fragment;
+        this.testFragmentActivity = fragmentActivity;
     }
 
     /**
@@ -433,6 +452,26 @@ public class PowerAuthTestHelper {
      */
     public @NonNull PowerAuthKeychainConfiguration getSharedPowerAuthKeychainConfiguration() {
         return sharedKeychainConfiguration;
+    }
+
+    /**
+     * @return Fragment activity for tests. If not set, then throws {@link IllegalStateException}.
+     */
+    public @NonNull FragmentActivity getFragmentActivity() {
+        if (testFragmentActivity == null) {
+            throw new IllegalStateException("Fragment activity is not set");
+        }
+        return testFragmentActivity;
+    }
+
+    /**
+     * @return Fragment for tests. If not set, then throws {@link IllegalStateException}.
+     */
+    public @NonNull Fragment getFragment() {
+        if (testFragment == null) {
+            throw new IllegalStateException("Fragment is not set");
+        }
+        return testFragment;
     }
 
     /**

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/TestActivity.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/TestActivity.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.integration.support;
+
+import androidx.fragment.app.FragmentActivity;
+
+/**
+ * Dummy activity used in biometry-related tests.
+ */
+public class TestActivity extends FragmentActivity {
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/TestFragment.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/TestFragment.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.integration.support;
+
+import androidx.fragment.app.Fragment;
+
+/**
+ * Dummy fragment used in biometry-related tests.
+ */
+public class TestFragment extends Fragment {
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BiometricTests.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BiometricTests.java
@@ -95,7 +95,7 @@ public class BiometricTests implements PowerAuthTestHelper.IConfigurationObserve
         powerAuthSDK = testHelper.getSharedSdk();
         activationHelper = new ActivationHelper(testHelper);
 
-        // Tun test in the same thread
+        // Run test in the same thread
         execution.execute();
     }
 

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BiometricTests.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BiometricTests.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.integration.tests;
+
+import androidx.fragment.app.FragmentActivity;
+import androidx.lifecycle.Lifecycle;
+import androidx.test.core.app.ActivityScenario;
+import io.getlime.security.powerauth.biometry.IAddBiometryFactorListener;
+import io.getlime.security.powerauth.biometry.IAuthenticateWithBiometricsListener;
+import io.getlime.security.powerauth.exception.PowerAuthErrorCodes;
+import io.getlime.security.powerauth.exception.PowerAuthErrorException;
+import io.getlime.security.powerauth.integration.support.*;
+import io.getlime.security.powerauth.integration.support.model.SignatureData;
+import io.getlime.security.powerauth.integration.support.model.SignatureInfo;
+import io.getlime.security.powerauth.integration.support.model.SignatureType;
+import io.getlime.security.powerauth.sdk.*;
+import io.getlime.security.powerauth.sdk.impl.MainThreadExecutor;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import androidx.annotation.NonNull;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import java.util.Map;
+import java.util.Objects;
+
+import static org.junit.Assert.*;
+
+@RunWith(AndroidJUnit4.class)
+@Ignore("Require user interaction") // uncomment in case you want to manually test biometry
+public class BiometricTests implements PowerAuthTestHelper.IConfigurationObserver {
+
+    private PowerAuthTestHelper testHelper;
+    private PowerAuthSDK powerAuthSDK;
+    private ActivationHelper activationHelper;
+    private SignatureHelper signatureHelper;
+    private ActivityScenario<TestActivity> activityScenario;
+
+    @Before
+    public void setUp() throws Exception {
+        activityScenario = ActivityScenario.launch(TestActivity.class);
+        signatureHelper = new SignatureHelper();
+    }
+
+    @After
+    public void tearDown() {
+        if (activationHelper != null) {
+            activationHelper.cleanupAfterTest();
+        }
+        activityScenario.close();
+    }
+
+    private void runWithFragmentActivity(final ITestExecution execution) throws Exception {
+        runWithFragmentActivity(this, execution);
+    }
+
+    private void runWithFragmentActivity(final PowerAuthTestHelper.IConfigurationObserver configurationObserver,
+                                         final ITestExecution execution) throws Exception {
+        FragmentActivity[] capturedActivity = new FragmentActivity[1];
+        TestFragment fragment = new TestFragment();
+
+        // Create supporting UI
+        activityScenario.moveToState(Lifecycle.State.STARTED);
+        activityScenario.onActivity(activity -> {
+            capturedActivity[0] = activity;
+            activity.getSupportFragmentManager()
+                    .beginTransaction()
+                    .add(android.R.id.content, fragment)
+                    .commitNow(); // Synchronously attach the fragment
+        });
+        assertNotNull(capturedActivity[0]);
+        // Setup
+        testHelper = new PowerAuthTestHelper.Builder()
+                .configurationObserver(configurationObserver)
+                .testFragmentActivity(capturedActivity[0])
+                .testFragment(fragment)
+                .build();
+        powerAuthSDK = testHelper.getSharedSdk();
+        activationHelper = new ActivationHelper(testHelper);
+
+        // Tun test in the same thread
+        execution.execute();
+    }
+
+    @Test
+    public void testUsingBiometry() throws Exception {
+        runWithFragmentActivity(() -> {
+            activationHelper.createStandardActivation(true, null);
+            AsyncHelper.await(resultCatcher -> {
+                powerAuthSDK.addBiometryFactor(testHelper.getContext(), testHelper.getFragmentActivity(), "Dummy", "Dummy text", activationHelper.getValidPassword(), new IAddBiometryFactorListener() {
+                    @Override
+                    public void onAddBiometryFactorSucceed() {
+                        resultCatcher.completeWithResult(true);
+                    }
+
+                    @Override
+                    public void onAddBiometryFactorFailed(@NonNull PowerAuthErrorException error) {
+                        resultCatcher.completeWithError(error);
+                    }
+                });
+            });
+            PowerAuthAuthentication authentication = AsyncHelper.await(resultCatcher -> {
+                MainThreadExecutor.getInstance().execute(() -> powerAuthSDK.authenticateUsingBiometrics(testHelper.getContext(), testHelper.getFragmentActivity(), "Authenticate", "Authenticate with biometry", new IAuthenticateWithBiometricsListener() {
+                    @Override
+                    public void onBiometricDialogCancelled(boolean userCancel) {
+                        resultCatcher.completeWithResult(null);
+                    }
+
+                    @Override
+                    public void onBiometricDialogSuccess(@NonNull PowerAuthAuthentication authentication) {
+                        resultCatcher.completeWithResult(authentication);
+                    }
+
+                    @Override
+                    public void onBiometricDialogFailed(@NonNull PowerAuthErrorException error) {
+                        resultCatcher.completeWithError(error);
+                    }
+                }));
+            });
+            assertNotNull(authentication);
+            // Now verify signature on the server
+            PowerAuthAuthorizationHttpHeader header = powerAuthSDK.requestSignatureWithAuthentication(testHelper.getContext(), authentication, "POST", "/uri/id", null);
+            assertNotNull(header);
+            assertEquals(0, header.getPowerAuthErrorCode());
+            Map<String, String> sigComponents = signatureHelper.parseAuthorizationHeader(header);
+            final String sigVersion = sigComponents.get("pa_version");
+            final String sigActivationId = sigComponents.get("pa_activation_id");
+            final String sigNonce = Objects.requireNonNull(sigComponents.get("pa_nonce"));
+            final String sigAppKey = sigComponents.get("pa_application_key");
+            final String sigType = Objects.requireNonNull(sigComponents.get("pa_signature_type")).toUpperCase();
+            final String sigValue = sigComponents.get("pa_signature");
+
+            final String dataToVerifySignature = signatureHelper.normalizeOnlineData("", "POST", "/uri/id", sigNonce);
+            SignatureData signatureData = new SignatureData();
+            signatureData.setActivationId(sigActivationId);
+            signatureData.setData(dataToVerifySignature);
+            signatureData.setSignature(sigValue);
+            signatureData.setSignatureType(SignatureType.valueOf(sigType));
+            signatureData.setSignatureVersion(sigVersion);
+            signatureData.setApplicationKey(sigAppKey);
+
+            // Verify on server
+            final SignatureInfo verifyResult = testHelper.getServerApi().verifyOnlineSignature(signatureData);
+            assertTrue(verifyResult.isSignatureValid());
+        });
+    }
+
+    @Override
+    public void adjustPowerAuthConfiguration(@NonNull PowerAuthConfiguration.Builder builder) {
+    }
+
+    @Override
+    public void adjustPowerAuthClientConfiguration(@NonNull PowerAuthClientConfiguration.Builder builder) {
+    }
+
+    @Override
+    public void adjustPowerAuthKeychainConfiguration(@NonNull PowerAuthKeychainConfiguration.Builder builder) {
+        builder.authenticateOnBiometricKeySetup(false);
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricAuthentication.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricAuthentication.java
@@ -199,8 +199,7 @@ public class BiometricAuthentication {
             @NonNull final Context context,
             @NonNull final PrivateRequestData requestData,
             @NonNull final BiometricResultDispatcher dispatcher) {
-        // Prepare an encryption task
-        final Runnable encryptTask = () -> {
+        requestData.getRequest().getBackgroundTaskExecutor().execute(() -> {
             try {
                 // Acquire encryptor and initialize the cipher
                 final IBiometricKeyEncryptor encryptor = requestData.getBiometricKeyEncryptorProvider().getBiometricKeyEncryptor();
@@ -218,20 +217,13 @@ public class BiometricAuthentication {
                     // Application should display reason to the user
                     dispatcher.dispatchError(BiometricErrorInfo.addToException(exception, true));
                 } else {
-                    // Display the error dialog
-                    MainThreadExecutor.getInstance().dispatchCallback(() -> {
+                    // Display the error dialog on main thread
+                    dispatcher.dispatchRunnable(() -> {
                         showErrorDialog(BiometricStatus.NOT_AVAILABLE, BiometricErrorInfo.addToException(exception, false), context, requestData);
                     });
                 }
             }
-        };
-        // Execute the task on the background or on the current thread.
-        final Executor executor = requestData.getRequest().getBackgroundTaskExecutor();
-        if (executor != null) {
-            executor.execute(encryptTask);
-        } else {
-            encryptTask.run();
-        }
+        });
         return dispatcher.getCancelableTask();
     }
 

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricAuthenticationRequest.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricAuthenticationRequest.java
@@ -45,7 +45,7 @@ public class BiometricAuthenticationRequest {
     private final boolean useSymmetricCipher;
     private final @NonNull byte[] rawKeyData;
     private final @Nullable IBiometricKeyEncryptor biometricKeyEncryptor;
-    private final @Nullable Executor backgroundTaskExecutor;
+    private final @NonNull Executor backgroundTaskExecutor;
 
     private BiometricAuthenticationRequest(
             @NonNull CharSequence title,
@@ -60,7 +60,7 @@ public class BiometricAuthenticationRequest {
             boolean useSymmetricCipher,
             @NonNull byte[] rawKeyData,
             @Nullable IBiometricKeyEncryptor biometricKeyEncryptor,
-            @Nullable Executor backgroundTaskExecutor) {
+            @NonNull Executor backgroundTaskExecutor) {
         this.title = title;
         this.subtitle = subtitle;
         this.description = description;
@@ -166,7 +166,7 @@ public class BiometricAuthenticationRequest {
     /**
      * @return {@link Executor} that can execute computational heavy tasks on background thread.
      */
-    public @Nullable Executor getBackgroundTaskExecutor() {
+    public @NonNull Executor getBackgroundTaskExecutor() {
         return backgroundTaskExecutor;
     }
 
@@ -226,6 +226,9 @@ public class BiometricAuthenticationRequest {
             }
             if (fragment != null && fragmentActivity != null) {
                 throw new IllegalArgumentException("Both Fragment and FragmentActivity are set.");
+            }
+            if (backgroundTaskExecutor == null) {
+                throw new IllegalArgumentException("Background task executor must be set.");
             }
             return new BiometricAuthenticationRequest(
                     title,

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricAuthenticator.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricAuthenticator.java
@@ -191,7 +191,7 @@ public class BiometricAuthenticator implements IBiometricAuthenticator {
         } else if (request.getFragmentActivity() != null) {
             prompt = new BiometricPrompt(request.getFragmentActivity(), request.getBackgroundTaskExecutor(), authenticationCallback);
         } else {
-            throw new PowerAuthErrorException(PowerAuthErrorCodes.WRONG_PARAMETER, "Both Fragment and FragmentActivity for biometric prompt presentation are set.");
+            throw new PowerAuthErrorException(PowerAuthErrorCodes.WRONG_PARAMETER, "Neither a Fragment nor a FragmentActivity is set for the biometric prompt.");
         }
 
         // Authenticate with the prompt

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricAuthenticator.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricAuthenticator.java
@@ -284,7 +284,7 @@ public class BiometricAuthenticator implements IBiometricAuthenticator {
             public void onAuthenticationSucceeded(@NonNull BiometricPrompt.AuthenticationResult result) {
                 super.onAuthenticationSucceeded(result);
                 biometricPromptIsProbablyVisible = true;
-                // Acquire cipher from the result. This is a bit over-paranoid, but let's check everything
+                // Acquire cipher from the result. This is a bit over-paranoid, but let us check everything
                 // returned from the system.
                 final Cipher cipher;
                 if (result.getCryptoObject() != null) {

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricAuthenticator.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricAuthenticator.java
@@ -38,7 +38,6 @@ import io.getlime.security.powerauth.exception.PowerAuthErrorCodes;
 import io.getlime.security.powerauth.exception.PowerAuthErrorException;
 import io.getlime.security.powerauth.networking.interfaces.ICancelable;
 import io.getlime.security.powerauth.sdk.impl.CancelableTask;
-import io.getlime.security.powerauth.sdk.impl.MainThreadExecutor;
 import io.getlime.security.powerauth.system.PowerAuthLog;
 
 /**
@@ -182,8 +181,36 @@ public class BiometricAuthenticator implements IBiometricAuthenticator {
         builder.setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG);
         builder.setConfirmationRequired(request.isUserConfirmationRequired());
 
+        // Build prompt's callback
+        final BiometricPrompt.AuthenticationCallback authenticationCallback = buildAuthenticationCallback(requestData, dispatcher);
+
+        // Build prompt
+        final BiometricPrompt prompt;
+        if (request.getFragment() != null) {
+            prompt = new BiometricPrompt(request.getFragment(), request.getBackgroundTaskExecutor(), authenticationCallback);
+        } else if (request.getFragmentActivity() != null) {
+            prompt = new BiometricPrompt(request.getFragmentActivity(), request.getBackgroundTaskExecutor(), authenticationCallback);
+        } else {
+            throw new PowerAuthErrorException(PowerAuthErrorCodes.WRONG_PARAMETER, "Both Fragment and FragmentActivity for biometric prompt presentation are set.");
+        }
+
+        // Authenticate with the prompt
+        prompt.authenticate(builder.build(), cryptoObject);
+        // Handle cancel from application
+        dispatcher.setOnCancelListener(prompt::cancelAuthentication);
+        // Return composite cancelable object, that can handle cancel on various stages of authentication.
+        return dispatcher.getCancelableTask();
+    }
+
+    /**
+     * Create biometric authentication callback.
+     * @param requestData Biometric request data.
+     * @param dispatcher Callback dispatcher.
+     * @return Biometric authentication callback.
+     */
+    private BiometricPrompt.AuthenticationCallback buildAuthenticationCallback(PrivateRequestData requestData, BiometricResultDispatcher dispatcher) {
         // Build authentication callback
-        final BiometricPrompt.AuthenticationCallback authenticationCallback = new BiometricPrompt.AuthenticationCallback() {
+        return new BiometricPrompt.AuthenticationCallback() {
             @Override
             public void onAuthenticationError(int errorCode, @NonNull CharSequence errString) {
                 super.onAuthenticationError(errorCode, errString);
@@ -244,7 +271,9 @@ public class BiometricAuthenticator implements IBiometricAuthenticator {
 
                     // Show error dialog first or dispatch the failure immediately.
                     if (displayError) {
-                        showBiometricErrorDialog(errString, exception, requestData);
+                        // Display error dialog on main thread
+                        final CharSequence failure = errString;
+                        dispatcher.dispatchRunnable(() -> showBiometricErrorDialog(failure, exception, requestData));
                     } else {
                         dispatcher.dispatchError(exception);
                     }
@@ -255,7 +284,7 @@ public class BiometricAuthenticator implements IBiometricAuthenticator {
             public void onAuthenticationSucceeded(@NonNull BiometricPrompt.AuthenticationResult result) {
                 super.onAuthenticationSucceeded(result);
                 biometricPromptIsProbablyVisible = true;
-                // Acquire cipher from the result. This is a bit over-paranoid, but lets check everything
+                // Acquire cipher from the result. This is a bit over-paranoid, but let's check everything
                 // returned from the system.
                 final Cipher cipher;
                 if (result.getCryptoObject() != null) {
@@ -283,10 +312,8 @@ public class BiometricAuthenticator implements IBiometricAuthenticator {
                 final BiometricErrorInfo errorInfo = new BiometricErrorInfo(PowerAuthErrorCodes.BIOMETRY_NOT_AVAILABLE, requestData.isErrorDialogDisabled());
                 final PowerAuthErrorException exception = new PowerAuthErrorException(PowerAuthErrorCodes.BIOMETRY_NOT_AVAILABLE, "Failed to encrypt biometric key.", null, errorInfo);
                 if (!requestData.isErrorDialogDisabled()) {
-                    // Display error dialog
-                    dispatcher.dispatchRunnable(() -> {
-                        showErrorDialogAfterSuccess(requestData, exception);
-                    });
+                    // Display error dialog on main thread
+                    dispatcher.dispatchRunnable(() -> showErrorDialogAfterSuccess(requestData, exception));
                 } else {
                     // Just report the failure
                     dispatcher.dispatchError(exception);
@@ -300,28 +327,64 @@ public class BiometricAuthenticator implements IBiometricAuthenticator {
                 authenticationFailedBefore++;
                 authenticationFailedTimestamp = SystemClock.elapsedRealtime();
             }
-        };
 
-        // Build the prompt
-        final BiometricPrompt prompt;
-        if (request.getFragment() != null) {
-            prompt = new BiometricPrompt(request.getFragment(), MainThreadExecutor.getInstance(), authenticationCallback);
-        } else if (request.getFragmentActivity() != null) {
-            prompt = new BiometricPrompt(request.getFragmentActivity(), MainThreadExecutor.getInstance(), authenticationCallback);
-        } else {
-            throw new PowerAuthErrorException(PowerAuthErrorCodes.WRONG_PARAMETER, "Both Fragment and FragmentActivity for biometric prompt presentation are set.");
-        }
-        // Authenticate with the prompt
-        prompt.authenticate(builder.build(), cryptoObject);
-        // Handle cancel from application
-        dispatcher.setOnCancelListener(new CancelableTask.OnCancelListener() {
-            @Override
-            public void onCancel() {
-                prompt.cancelAuthentication();
+            /**
+             * Property is set to {@code true} in case that there's a high probability, that biometric prompt
+             * is visible on the screen.
+             */
+            private boolean biometricPromptIsProbablyVisible;
+
+            /**
+             * Minimum time in milliseconds that need BiometricPrompt to respond with the error.
+             * Check {@link #shouldDisplayErrorDialog(PrivateRequestData)} documentation for more details.
+             */
+            private static final long PROMPT_API_MIN_RESPONSE_TIME = 2000;
+
+            /**
+             * Tolerance time in milliseconds to {@link #PROMPT_API_MIN_RESPONSE_TIME}.
+             */
+            private static final long PROMPT_API_RESPONSE_TOLERANCE = 200;
+
+            /**
+             * Determine whether we need to display our own error UI. This is required due to fact, that on
+             * Android "P", we never knows whether the BiometricPrompt system UI was displayed or not.
+             * It's also impossible to determine this situation in advance, for example for lock down state.
+             * <p>
+             * So, the only option is to use this crappy hack with elapsed time...
+             *
+             * @param requestData Request data
+             * @return {@code true} when custom error dialog should be displayed.
+             */
+            private boolean shouldDisplayErrorDialog(@NonNull PrivateRequestData requestData) {
+                if (biometricPromptIsProbablyVisible) {
+                    // Looks like that some other callback was called before. That may indicate that dialog
+                    // UI was really visible.
+                    return false;
+                }
+                // Flipping this status guarantees that only one dialog will be displayed. This is prevention
+                // against possible two error reports in one authentication session.
+                biometricPromptIsProbablyVisible = true;
+
+                // Get elapsed time from the request data.
+                long elapsedTime = requestData.getElapsedTime();
+                if (elapsedTime < PROMPT_API_RESPONSE_TOLERANCE) {
+                    // We're under 200ms, so the response was really quick. In this case, we should display
+                    // our own dialog. This typically happens on Android 10s in case that biometry is
+                    // temporarily disabled for too many failed attempts.
+                    return true;
+                }
+                if (elapsedTime >= PROMPT_API_MIN_RESPONSE_TIME &&
+                        elapsedTime < PROMPT_API_MIN_RESPONSE_TIME + PROMPT_API_RESPONSE_TOLERANCE) {
+                    // The response time is between 2000 and 2200ms.
+                    // This is required due to a bug in BiometricPrompt on Android "P", where the error is always
+                    // reported after 2000ms, even if no prompt UI was visible.
+                    return true;
+                }
+                // Looks like that BiometricPrompt UI was really visible, so we don't need to display
+                // our own dialog with error message.
+                return false;
             }
-        });
-        // Return composite cancelable object, that can handle cancel on various stages of authentication.
-        return dispatcher.getCancelableTask();
+        };
     }
 
     /**
@@ -371,63 +434,6 @@ public class BiometricAuthenticator implements IBiometricAuthenticator {
             }
             return processedBiometricKeyData;
         }
-    }
-
-    /**
-     * Property is set to {@code true} in case that there's a high probability, that biometric prompt
-     * is visible on the screen.
-     */
-    private boolean biometricPromptIsProbablyVisible;
-
-    /**
-     * Minimum time in milliseconds that need BiometricPrompt to respond with the error.
-     * Check {@link #shouldDisplayErrorDialog(PrivateRequestData)} documentation for more details.
-     */
-    private static final long PROMPT_API_MIN_RESPONSE_TIME = 2000;
-
-    /**
-     * Tolerance time in milliseconds to {@link #PROMPT_API_MIN_RESPONSE_TIME}.
-     */
-    private static final long PROMPT_API_RESPONSE_TOLERANCE = 200;
-
-    /**
-     * Determine whether we need to display our own error UI. This is required due to fact, that on
-     * Android "P", we never knows whether the BiometricPrompt system UI was displayed or not.
-     * It's also impossible to determine this situation in advance, for example for lock down state.
-     *
-     * So, the only option is to use this crappy hack with elapsed time...
-     *
-     * @param requestData Request data
-     * @return {@code true} when custom error dialog should be displayed.
-     */
-    private boolean shouldDisplayErrorDialog(@NonNull PrivateRequestData requestData) {
-        if (biometricPromptIsProbablyVisible) {
-            // Looks like that some other callback was called before. That may indicate that dialog
-            // UI was really visible.
-            return false;
-        }
-        // Flipping this status guarantees that only one dialog will be displayed. This is prevention
-        // against possible two error reports in one authentication session.
-        biometricPromptIsProbablyVisible = true;
-
-        // Get elapsed time from the request data.
-        long elapsedTime = requestData.getElapsedTime();
-        if (elapsedTime < PROMPT_API_RESPONSE_TOLERANCE) {
-            // We're under 200ms, so the response was really quick. In this case, we should display
-            // our own dialog. This typically happens on Android 10s in case that biometry is
-            // temporarily disabled for too many failed attempts.
-            return true;
-        }
-        if (elapsedTime >= PROMPT_API_MIN_RESPONSE_TIME &&
-                elapsedTime < PROMPT_API_MIN_RESPONSE_TIME + PROMPT_API_RESPONSE_TOLERANCE) {
-            // The response time is between 2000 and 2200ms.
-            // This is required due to a bug in BiometricPrompt on Android "P", where the error is always
-            // reported after 2000ms, even if no prompt UI was visible.
-            return true;
-        }
-        // Looks like that BiometricPrompt UI was really visible, so we don't need to display
-        // our own dialog with error message.
-        return false;
     }
 
     /**

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/interfaces/IExecutorProvider.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/interfaces/IExecutorProvider.java
@@ -35,4 +35,9 @@ public interface IExecutorProvider {
      * @return {@link Executor} for concurrent task execution.
      */
     @NonNull Executor getConcurrentExecutor();
+
+    /**
+     * @return Serial {@link Executor} dedicated for biometric tasks.
+     */
+    @NonNull Executor getBiometricExecutor();
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -2266,7 +2266,7 @@ public class PowerAuthSDK {
                 .setKeystoreAlias(biometricDataMapping.keystoreId)
                 .setForceGenerateNewKey(forceGenerateNewKey, mKeychainConfiguration.isLinkBiometricItemsToCurrentSet(), mKeychainConfiguration.isAuthenticateOnBiometricKeySetup())
                 .setUserConfirmationRequired(mKeychainConfiguration.isConfirmBiometricAuthentication())
-                .setBackgroundTaskExecutor(mExecutorProvider.getConcurrentExecutor());
+                .setBackgroundTaskExecutor(mExecutorProvider.getBiometricExecutor());
         if (fragmentHelper.getFragment() != null) {
             authenticationRequestBuilder.setFragment(fragmentHelper.getFragment());
         } else if (fragmentHelper.getFragmentActivity() != null) {

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/DefaultExecutorProvider.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/DefaultExecutorProvider.java
@@ -33,13 +33,14 @@ import io.getlime.security.powerauth.networking.interfaces.IExecutorProvider;
 public class DefaultExecutorProvider implements IExecutorProvider {
 
     private Executor serialExecutor;
+    private Executor biometricExecutor;
 
     public DefaultExecutorProvider() {
     }
 
     @NonNull
     @Override
-    public Executor getSerialExecutor() {
+    public synchronized Executor getSerialExecutor() {
         if (serialExecutor == null) {
             serialExecutor = new SerialExecutor();
         }
@@ -50,6 +51,15 @@ public class DefaultExecutorProvider implements IExecutorProvider {
     @Override
     public Executor getConcurrentExecutor() {
         return AsyncTask.THREAD_POOL_EXECUTOR;
+    }
+
+    @NonNull
+    @Override
+    public synchronized Executor getBiometricExecutor() {
+        if (null == biometricExecutor) {
+            biometricExecutor = new SerialExecutor();
+        }
+        return biometricExecutor;
     }
 
     /**

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/DefaultExecutorProvider.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/DefaultExecutorProvider.java
@@ -56,7 +56,7 @@ public class DefaultExecutorProvider implements IExecutorProvider {
     @NonNull
     @Override
     public synchronized Executor getBiometricExecutor() {
-        if (null == biometricExecutor) {
+        if (biometricExecutor == null) {
             biometricExecutor = new SerialExecutor();
         }
         return biometricExecutor;


### PR DESCRIPTION
This PR refactors the handling of biometric authentication results to ensure all processing occurs on a background thread, improving responsiveness and stability.

Key changes:
- Introduced a dedicated serial executor to handle all biometric-related operations off the main thread.
- The `prompt.authenticate()` call now takes this dedicated worker thread.
- Moved Android 9-specific quirks and workarounds into the instance of `BiometricPrompt.AuthenticationCallback`, isolating platform-specific logic.
- Extracted the callback creation into a separate function to simplify and clarify the `authenticate()` method.

On top of that, PR contains a simple framework to manually test biometry on Android.