### PR TITLE
Apple: Fixed tests compatibility with latest PAS 2.0 build

### DIFF
--- a/proj-xcode/PowerAuth2.xcodeproj/xcshareddata/xcschemes/PowerAuth2_IntegrationTests_iOS.xcscheme
+++ b/proj-xcode/PowerAuth2.xcodeproj/xcshareddata/xcschemes/PowerAuth2_IntegrationTests_iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1630"
+   LastUpgradeVersion = "2610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/proj-xcode/PowerAuth2.xcodeproj/xcshareddata/xcschemes/PowerAuth2_IntegrationTests_tvOS.xcscheme
+++ b/proj-xcode/PowerAuth2.xcodeproj/xcshareddata/xcschemes/PowerAuth2_IntegrationTests_tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1630"
+   LastUpgradeVersion = "2610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/proj-xcode/PowerAuth2.xcodeproj/xcshareddata/xcschemes/PowerAuth2_TestHostApp_iOS.xcscheme
+++ b/proj-xcode/PowerAuth2.xcodeproj/xcshareddata/xcschemes/PowerAuth2_TestHostApp_iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1630"
+   LastUpgradeVersion = "2610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/proj-xcode/PowerAuth2.xcodeproj/xcshareddata/xcschemes/PowerAuth2_TestHostApp_tvOS.xcscheme
+++ b/proj-xcode/PowerAuth2.xcodeproj/xcshareddata/xcschemes/PowerAuth2_TestHostApp_tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1630"
+   LastUpgradeVersion = "2610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/proj-xcode/PowerAuth2.xcodeproj/xcshareddata/xcschemes/PowerAuth2_iOS.xcscheme
+++ b/proj-xcode/PowerAuth2.xcodeproj/xcshareddata/xcschemes/PowerAuth2_iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1630"
+   LastUpgradeVersion = "2610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/proj-xcode/PowerAuth2.xcodeproj/xcshareddata/xcschemes/PowerAuth2_tvOS.xcscheme
+++ b/proj-xcode/PowerAuth2.xcodeproj/xcshareddata/xcschemes/PowerAuth2_tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1630"
+   LastUpgradeVersion = "2610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServer/PowerAuthTestServerModel.h
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServer/PowerAuthTestServerModel.h
@@ -73,9 +73,10 @@
 @property (nonatomic, strong) NSString * activationOTP;
 @property (nonatomic, strong) NSString * activationCode;
 @property (nonatomic, strong) NSString * activationSignature;
-@property (nonatomic, strong) NSString * activationSignatureEcdsa;
-@property (nonatomic, strong) NSString * activationSignatureMldsa65;
-@property (nonatomic, strong) NSString * activationSignatureMldsa87;
+@property (nonatomic, strong) NSDictionary<NSString*,NSString*> * activationSignatures;
+@property (nonatomic, strong, readonly) NSString * activationSignatureEcdsa;
+@property (nonatomic, strong, readonly) NSString * activationSignatureMldsa65;
+@property (nonatomic, strong, readonly) NSString * activationSignatureMldsa87;
 @property (nonatomic, strong) NSString * userId;
 @property (nonatomic, strong) NSString * applicationId;
 

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServer/PowerAuthTestServerModel.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServer/PowerAuthTestServerModel.m
@@ -46,6 +46,21 @@
     return _activationCode;
 }
 
+- (NSString*) activationSignatureEcdsa
+{
+    return _activationSignatures[@"ES384"];
+}
+
+- (NSString*) activationSignatureMldsa65
+{
+    return _activationSignatures[@"ML-DSA-65"];
+}
+
+- (NSString*) activationSignatureMldsa87
+{
+    return _activationSignatures[@"ML-DSA-87"];
+}
+
 @end
 
 @implementation PATSCommitActivationResponse

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServer/RestEndpoints.bundle/ActivationInit_v20.json
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServer/RestEndpoints.bundle/ActivationInit_v20.json
@@ -12,9 +12,7 @@
             "activationId":               { "class" : "string" },
             "activationCode":             { "class" : "string" },
             "activationSignature":        { "class" : "string" },
-            "activationSignatureMldsa65": { "class" : "string" },
-            "activationSignatureMldsa87": { "class" : "string" },
-            "activationSignatureEcdsa":   { "class" : "string" },
+            "activationSignatures":       { "class" : "dictionary" },
             "userId":                     { "class" : "string" },
             "applicationId":              { "class" : "string" }
         }

--- a/proj-xcode/PowerAuthCore.xcodeproj/xcshareddata/xcschemes/PowerAuthCoreTests_iOS.xcscheme
+++ b/proj-xcode/PowerAuthCore.xcodeproj/xcshareddata/xcschemes/PowerAuthCoreTests_iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1630"
+   LastUpgradeVersion = "2610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/proj-xcode/PowerAuthCore.xcodeproj/xcshareddata/xcschemes/PowerAuthCoreTests_tvOS.xcscheme
+++ b/proj-xcode/PowerAuthCore.xcodeproj/xcshareddata/xcschemes/PowerAuthCoreTests_tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1630"
+   LastUpgradeVersion = "2610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/proj-xcode/PowerAuthCore.xcodeproj/xcshareddata/xcschemes/PowerAuthCore_iOS.xcscheme
+++ b/proj-xcode/PowerAuthCore.xcodeproj/xcshareddata/xcschemes/PowerAuthCore_iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1630"
+   LastUpgradeVersion = "2610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/proj-xcode/PowerAuthCore.xcodeproj/xcshareddata/xcschemes/PowerAuthCore_tvOS.xcscheme
+++ b/proj-xcode/PowerAuthCore.xcodeproj/xcshareddata/xcschemes/PowerAuthCore_tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1630"
+   LastUpgradeVersion = "2610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
- This change reflects recent updates in PAS REST API
- Fixed project migration warning in Xcode 26.1. 