### PR TITLE
Android: Add new "core" types and classes

### DIFF
--- a/docs/Migration-from-1.9-to-2.0.md
+++ b/docs/Migration-from-1.9-to-2.0.md
@@ -40,9 +40,11 @@ Notable changes on Android:
 
   - `PowerAuthConfiguration` class:
     - `getOfflineSignatureComponentLength()` - use `getOfflineAuthenticationCodeComponentLength()` instead.
+    - `isAutomaticProtocolUpgradeDisabled()` - always returns `false`.
 
   - `PowerAuthConfiguration.Builder` class:
     - `offlineSignatureComponentLength()` - use `offlineAuthenticationCodeComponentLength()` instead.
+    - `disableAutomaticProtocolUpgrade()` - has no effect.
 
   - `PowerAuthKeychainConfiguration` class:
     - `isLinkBiometricItemsToCurrentSet()` - use `PowerAuthBiometricConfiguration.isInvalidateBiometricFactorAfterChange()` instead.
@@ -137,6 +139,7 @@ Notable changes on iOS:
 
   - `PowerAuthConfiguration` class:
     - `offlineSignatureComponentLength` property is now replaced with `offlineAuthenticationCodeComponentLength`
+    - `disableAutomaticProtocolUpgrade` property is deprecated and has no effect in SDK.
   - `PowerAuthTokenStore` protocol:
     - `generateAuthorizationHeader(withName:completion:)` is replaced with `generateAuthenticationHeader(withName:completion:)`
   - `PowerAuthAuthorizationHttpHeader` is deprecated and replaced with `PowerAuthHttpHeader`

--- a/include/PowerAuth/Request.h
+++ b/include/PowerAuth/Request.h
@@ -111,6 +111,11 @@ public:
     /// Returns `true` if request is authenticated with authentication header.
     bool isAuthenticated() const noexcept;
     
+    /// Returns `true` if response data in JSON representation is publicly available for
+    /// processing in Objective-C or Java layer. If `false` is returned, then appropriate
+    /// wrapper should not marshal response data to managed environment.
+    bool isPublicResponseJson() const noexcept;
+    
     /// Returns scope of temporary key required for proper processing. If request is not
     /// encrypted, then throws exception.
     EncryptorScope encryptorScope() const;

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/ActivationHelper.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/ActivationHelper.java
@@ -80,7 +80,7 @@ public class ActivationHelper {
     /**
      * Alternate method that persist activation with deprecated functions.
      */
-    // @Deprecated // 1.10.0
+    // @Deprecated // 2.0.0
     public static final int TF_PERSIST_WITH_DEPRECATED          = 0x0100;
 
     /**
@@ -349,7 +349,7 @@ public class ActivationHelper {
                 }
             };
             if (!persistWithDeprecated) {
-                // New asynchronous persist (1.10.0)
+                // New asynchronous persist (2.0.0)
                 // If biometry (in any form) is required, then we have to use auth object.
                 boolean useAuthObject = persistWithBiometryAct || persistWithBiometryFrag;
                 if (!useAuthObject) {
@@ -384,7 +384,7 @@ public class ActivationHelper {
                     powerAuthSDK.persistActivationWithAuthentication(testHelper.getContext(), authentication, persistActivationListener);
                 }
             } else {
-                // @Deprecated // 1.10.0 - Remove in 2.0.0
+                // @Deprecated // 2.0.0 - Remove in 2.1.0
                 if (persistWithBiometryAct || persistWithBiometryFrag) {
                     //noinspection deprecation
                     IPersistActivationWithBiometricsListener deprecatedListener = new IPersistActivationWithBiometricsListener() {

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IPersistActivationWithBiometricsListener.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/IPersistActivationWithBiometricsListener.java
@@ -24,7 +24,7 @@ import io.getlime.security.powerauth.exception.PowerAuthErrorException;
  *
  * @deprecated Interface is deprecated, use {@link io.getlime.security.powerauth.networking.response.IPersistActivationListener} as replacement.
  */
-@Deprecated // 1.10.0
+@Deprecated // 2.0.0
 public interface IPersistActivationWithBiometricsListener {
     /**
      * Biometric dialog was cancelled.

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreAlgorithm.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreAlgorithm.java
@@ -21,24 +21,21 @@ import androidx.annotation.IntDef;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
-import static io.getlime.security.powerauth.core.Algorithm.*;
-
-import io.getlime.security.powerauth.sdk.PowerAuthConfiguration;
-import io.getlime.security.powerauth.sdk.PowerAuthSDK;
+import static io.getlime.security.powerauth.core.CoreAlgorithm.*;
 
 /**
- * The {@code Algorithm} enumeration defines algorithms available for PowerAuth
+ * The {@code CoreAlgorithm} enumeration defines algorithms available for PowerAuth
  * initialization. The algorithm specifies also the protocol version used for communication
  * with the server.
  */
 @Retention(RetentionPolicy.SOURCE)
-@IntDef({LEGACY_P256, EC_P384, EC_P384_ML_L3, EC_P384_ML_L5, DEFAULT})
-public @interface Algorithm {
+@IntDef({LEGACY_P256, EC_P384, EC_P384_ML_L3, EC_P384_ML_L5})
+public @interface CoreAlgorithm {
     /**
      * Algorithm identifier for legacy protocol V3.3.
      * <p>
-     * If used in {@link PowerAuthConfiguration}, then the protocol upgrade is automatically disabled
-     * and instance of {@link PowerAuthSDK} will use legacy protocol only for communicating with the server.
+     * If used in {@link CoreConfig}, then the protocol upgrade is automatically disabled
+     * and instance of {@code PowerAuthSDK} will use legacy protocol only for communicating with the server.
      */
     int LEGACY_P256 = 0;
 
@@ -71,9 +68,4 @@ public @interface Algorithm {
      * </ul>
      */
     int EC_P384_ML_L5 = 3;
-
-    /**
-     * Default algorithm. Value is identical to {@link #EC_P384_ML_L3}.
-     */
-    int DEFAULT = EC_P384_ML_L3;
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreConfig.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreConfig.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.core;
+
+import androidx.annotation.NonNull;
+
+/**
+ * The {@code CoreConfig} object contains configuration for {@link CoreSession} object.
+ */
+public class CoreConfig extends NativeObject {
+
+    /**
+     * Construct object with handle to native object. This is a designated constructor used from JNI,
+     * when C++ object is being wrapped into Java object.
+     *
+     * @param nativeObjectHandle Handle to native object.
+     */
+    protected CoreConfig(long nativeObjectHandle) {
+        super(nativeObjectHandle);
+    }
+
+    /**
+     * Validate SDK configuration string.
+     * @param configuration SDK configuration string to validate.
+     * @param algorithm Algorithm to use in the PowerAuth instance.
+     * @return {@code true} if configuration string is valid.
+     */
+    public static native boolean validateConfiguration(@NonNull String configuration, @CoreAlgorithm int algorithm);
+
+    /**
+     * Create instance of {@code CoreConfig} object from the provided parameters.
+     * @param configuration SDK configuration string.
+     * @param deviceSpecificData Device specific data.
+     * @param instanceId Instance identifier.
+     * @param algorithm Algorithm to use in the PowerAuth instance.
+     * @return New {@link CoreConfig} instance.
+     * @throws CoreException with {@link CoreErrorCode#WRONG_PARAMETER} if required parameter is null or empty.
+     * @throws CoreException with {@link CoreErrorCode#INVALID_DATA} if SDK configuration string is not valid.
+     */
+    @NonNull
+    public static native CoreConfig build(@NonNull String configuration,
+                                          @NonNull byte[] deviceSpecificData,
+                                          @NonNull String instanceId,
+                                          @CoreAlgorithm int algorithm) throws CoreException;
+
+    /**
+     * @return Instance identifier provided in the configuration construction.
+     */
+    @NonNull
+    public native String getInstanceId();
+
+    /**
+     * @return Device specific data provided in the configuration construction.
+     */
+    @NonNull
+    public native byte[] getDeviceSpecificData();
+
+    /**
+     * @return Algorithm provided in the configuration construction.
+     */
+    @CoreAlgorithm
+    public native int getAlgorithm();
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreCredentials.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreCredentials.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.core;
+
+import androidx.annotation.NonNull;
+
+/**
+ * The {@code CoreCredentials} object represents user's credentials for authentication.
+ */
+public class CoreCredentials extends NativeObject {
+    /**
+     * Construct object with handle to native object. This is a designated constructor used from JNI,
+     * when C++ object is being wrapped into Java object.
+     *
+     * @param nativeObjectHandle Handle to native object.
+     */
+    protected CoreCredentials(long nativeObjectHandle) {
+        super(nativeObjectHandle);
+    }
+
+    /**
+     * Create credentials with possession factor only.
+     * @return {@link CoreCredentials} configured for possession factor only.
+     */
+    @NonNull
+    public static native CoreCredentials possession();
+
+    /**
+     * Create credentials with possession and knowledge factors.
+     * @return {@link CoreCredentials} configured for possession and knowledge factors.
+     */
+    @NonNull
+    public static native CoreCredentials knowledge(@NonNull Password password);
+
+    /**
+     * Create credentials with possession and biometry factors.
+     * @return {@link CoreCredentials} configured for possession and biometry factors.
+     */
+    @NonNull
+    public static native CoreCredentials biometry(@NonNull SecureData secureData);
+
+    /**
+     * Destroys underlying native C++ object. You can call this method
+     * if you want to be sure that internal object is properly destroyed.
+     * You can't use instance of this java object anymore after this call.
+     */
+    public void destroy() {
+        safeNativeDestroy(nativeObjectHandle);
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreDevicePublicKeyData.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreDevicePublicKeyData.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.core;
+
+import androidx.annotation.NonNull;
+
+/**
+ * The {@code CoreDevicePublicKeyData} class represents exported device public key data.
+ */
+public class CoreDevicePublicKeyData {
+    @CoreSignatureKeyType
+    private final int keyType;
+    @NonNull
+    private final String keyAlgorithm;
+    @NonNull
+    private final byte[] keyData;
+
+    /**
+     * Construct object with public key type, algorithm and data.
+     * @param keyType Type of the public key.
+     * @param keyAlgorithm Information about the key algorithm (e.g., "P-256", "P-384", "ML-DSA-65", etc.).
+     * @param keyData Public key data.
+     */
+    public CoreDevicePublicKeyData(@CoreSignatureKeyType int keyType, @NonNull String keyAlgorithm, @NonNull byte[] keyData) {
+        this.keyType = keyType;
+        this.keyAlgorithm = keyAlgorithm;
+        this.keyData = keyData;
+    }
+
+    /**
+     * @return Type of the public key.
+     */
+    @CoreSignatureKeyType
+    public int getKeyType() {
+        return keyType;
+    }
+
+    /**
+     * @return Information about the key algorithm (e.g., "P-256", "P-384", "ML-DSA-65", etc.).
+     */
+    @NonNull
+    public String getKeyAlgorithm() {
+        return keyAlgorithm;
+    }
+
+    /**
+     * @return Public key data.
+     */
+    @NonNull
+    public byte[] getKeyData() {
+        return keyData;
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreDevicePublicKeyFormat.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreDevicePublicKeyFormat.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.core;
+
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+import static io.getlime.security.powerauth.core.CoreDevicePublicKeyFormat.*;
+
+import androidx.annotation.IntDef;
+
+import java.lang.annotation.Retention;
+
+/**
+ * The {@code CoreDevicePublicKeyFormat} enumeration defines the output format used when exporting
+ * the device public key.
+ */
+@Retention(SOURCE)
+@IntDef({DER, RAW})
+public @interface CoreDevicePublicKeyFormat {
+    /**
+     * DER key format, which corresponds to the SPKI or X.509 structure.
+     */
+    int DER = 0;
+    /**
+     * RAW key format. The actual output depends on the key type:
+     * <ul>
+     *  <li>For EC-based keys, the output data is ASN.1 encoded, as specified in ANSI X9.63.</li>
+     *  <li>For ML-DSA-based keys, the output data is obtained using the OpenSSL
+     *   {@code EVP_PKEY_get_raw_public_key()} function.</li>
+     * </ul>
+     */
+    int RAW = 1;
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreEncryptor.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreEncryptor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.core;
+
+public class CoreEncryptor extends NativeObject {
+    /**
+     * Construct object with handle to native object. This is a designated constructor used from JNI,
+     * when C++ object is being wrapped into Java object.
+     *
+     * @param nativeObjectHandle Handle to native object.
+     */
+    protected CoreEncryptor(long nativeObjectHandle) {
+        super(nativeObjectHandle);
+    }
+
+    /**
+     * Destroys underlying native C++ object. You can call this method
+     * if you want to be sure that internal object is properly destroyed.
+     * You can't use instance of this java object anymore after this call.
+     */
+    public void destroy() {
+        safeNativeDestroy(nativeObjectHandle);
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreEncryptorFactory.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreEncryptorFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.core;
+
+public class CoreEncryptorFactory extends NativeObject {
+    /**
+     * Construct object with handle to native object. This is a designated constructor used from JNI,
+     * when C++ object is being wrapped into Java object.
+     *
+     * @param nativeObjectHandle Handle to native object.
+     */
+    protected CoreEncryptorFactory(long nativeObjectHandle) {
+        super(nativeObjectHandle);
+    }
+
+    /**
+     * Destroys underlying native C++ object. You can call this method
+     * if you want to be sure that internal object is properly destroyed.
+     * You can't use instance of this java object anymore after this call.
+     */
+    public void destroy() {
+        safeNativeDestroy(nativeObjectHandle);
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreEncryptorScope.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreEncryptorScope.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.core;
+
+/**
+ * The {@code CoreEncryptorScope} enumeration defines how {@link CoreEncryptor} encryptor
+ * is configured.
+ */
+public @interface CoreEncryptorScope {
+    /**
+     * No encryptor is specified in core request.
+     */
+    int NONE = 0;
+    /**
+     * An application scope means that encryptor can be constructed also when
+     * the session has no valid activation.
+     */
+    int APPLICATION = 1;
+
+    /**
+     * An activation scope means that the encryptor can be constructed only when
+     * the session has a valid activation.
+     */
+    int ACTIVATION = 2;
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreHttpHeader.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreHttpHeader.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.core;
+
+import androidx.annotation.NonNull;
+
+/**
+ * Class representing HTTP header generated in PowerAuth mobile SDK.
+ */
+public class CoreHttpHeader {
+    @NonNull
+    private final String key;
+    @NonNull
+    private final String value;
+
+    /**
+     * Construct HTTP header object with header's name and value.
+     * @param key Header's name.
+     * @param value Header's value.
+     */
+    public CoreHttpHeader(@NonNull String key, @NonNull String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    /**
+     * @return HTTP header's key.
+     */
+    @NonNull
+    public String getKey() {
+        return key;
+    }
+
+    /**
+     * @return HTTP header's value.
+     */
+    @NonNull
+    public String getValue() {
+        return value;
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreRequest.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreRequest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.core;
+
+public class CoreRequest extends NativeObject {
+    /**
+     * Construct object with handle to native object. This is a designated constructor used from JNI,
+     * when C++ object is being wrapped into Java object.
+     *
+     * @param nativeObjectHandle Handle to native object.
+     */
+    protected CoreRequest(long nativeObjectHandle) {
+        super(nativeObjectHandle);
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreRequest.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreRequest.java
@@ -16,7 +16,37 @@
 
 package io.getlime.security.powerauth.core;
 
-public class CoreRequest extends NativeObject {
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * The {@link CoreRequest} object represents a HTTP request created in core module.
+ *
+ * @param <TResponse> Type of response.
+ */
+public class CoreRequest<TResponse> extends NativeObject {
+
+    /**
+     * Contains last failure produced in the request object.
+     */
+    private CoreException failure;
+
+    /**
+     * Contains response object if this kind of request provide some response object.
+     */
+    private TResponse responseObject;
+
+    /**
+     * Contains response in JSON representation.
+     */
+    private Object responseJson;
+
+    /**
+     * Handle containing handle to native C++ object translating response into Java model object.
+     * The handle is released by calling {@link #processResponse(byte[])} method, or in {@link #finalize()}.
+     */
+    private long responseBuilderHandle;
+
     /**
      * Construct object with handle to native object. This is a designated constructor used from JNI,
      * when C++ object is being wrapped into Java object.
@@ -26,4 +56,184 @@ public class CoreRequest extends NativeObject {
     protected CoreRequest(long nativeObjectHandle) {
         super(nativeObjectHandle);
     }
+
+    @Override
+    protected void finalize() {
+        super.finalize();
+        NativeObject.safeNativeDestroy(responseBuilderHandle);
+    }
+
+    /**
+     * @return Information whether this request require time synchronized with the server.
+     */
+    public native boolean isRequireSynchronizedTime();
+
+    /**
+     * @return Information whether this request require serial queue for its execution.
+     */
+    public native boolean isRequireSerialQueue();
+
+    /**
+     * @return Information whether this request is allowed during the protocol upgrade.
+     */
+    public native boolean isAllowedInUpgrade();
+
+    /**
+     * @return Scope of the temporary encryption key required for the request processing.
+     *         If {@link CoreEncryptorScope#NONE} is used, then request has no encryption.
+     */
+    @CoreEncryptorScope
+    public native int getEncryptorScope();
+
+    /**
+     * @return Information whether this request is authenticated with authentication header.
+     */
+    public native boolean isAuthenticated();
+
+    /**
+     * @return Relative path to endpoint.
+     */
+    @NonNull
+    public native String getRelativePath();
+
+    /**
+     * @return HTTP method.
+     */
+    @NonNull
+    public native String getHttpMethod();
+
+    /**
+     * Get HTTP request body. Be aware, that you have to call {@link #prepareRequest()} method
+     * to prepare the content of the body.
+     * @return HTTP request body.
+     * @throws CoreException With {@link CoreErrorCode#NOT_ALLOWED} in case the request is not prepared.
+     */
+    @NonNull
+    public native byte[] getRequestBody() throws CoreException;
+
+    /**
+     * Get HTTP request headers. Be aware, that you have to call {@link #prepareRequest()} method
+     * to prepare the content of the body.
+     * @return HTTP request headers.
+     * @throws CoreException With {@link CoreErrorCode#NOT_ALLOWED} in case the request is not prepared.
+     */
+    @NonNull
+    public native CoreHttpHeader[] getRequestHeaders() throws CoreException;
+
+    /**
+     * @return {@code true} if the request is finished no matter of the result. Use {@link #isCompleted()},
+     *         {@link #isCanceled()}  or {@link #isFailed()} to determine the exact result.
+     */
+    public native boolean isDone();
+
+    /**
+     * @return {@code true} if the request is completed and successfully processed.
+     */
+    public native boolean isCompleted();
+
+    /**
+     * @return {@code true} if the request has been canceled.
+     */
+    public native boolean isCanceled();
+
+    /**
+     * @return {@code true} if the request processing failed.
+     */
+    public native boolean isFailed();
+
+    /**
+     * @return Exception with reason of request or response processing failure.
+     */
+    @Nullable
+    public CoreException getFailure() {
+        return failure;
+    }
+
+    /**
+     * @return Response object if this kind of request provide some response object or null
+     *         if response is not yet available.
+     */
+    @Nullable
+    public TResponse getResponseObject() {
+        if (isCompleted()) {
+            return responseObject;
+        }
+        return null;
+    }
+
+    /**
+     * @return Response in JSON representation or null if response is not yet available.
+     */
+    @Nullable
+    public Object getResponseJson() {
+        if(isCompleted()) {
+            return responseJson;
+        }
+        return null;
+    }
+
+    /**
+     * Prepare request body and headers. It's recommended to call this method on background
+     * execution queue to avoid main thread disruptions.
+     * <p>
+     * If execution of this function fails, then the function will notify all its listeners.
+     * @throws CoreException In case the operation fails.
+     */
+    public void prepareRequest() throws CoreException {
+        try {
+            prepareRequestImpl();
+            failure = null;
+        } catch (CoreException e) {
+            failure = e;
+            throw e;
+        }
+    }
+
+    /**
+     * Process response received from the server. It's recommended to call this method on background
+     * execution queue to avoid main thread disruptions.
+     * <p>
+     * Function also notify all its listeners about successful or failure result of the call.
+     * <p>
+     * <b>Note:</b> Be aware that the method doesn't handle standard PowerAuth error response. You
+     * suppose to call this method only if successful response is received from the server.
+     *
+     * @param response Response data received from the server.
+     * @throws CoreException In case the operation fails.
+     */
+    public void processResponse(@Nullable byte[] response) throws CoreException {
+        try {
+            processResponseImpl(response);
+            failure = null;
+        } catch (CoreException e) {
+            failure = e;
+            throw e;
+        }
+    }
+
+    /**
+     * Cancel the request and release underlying resources. You have to call this method
+     * when the operation is canceled by the application.
+     */
+    public native void cancel();
+
+    /**
+     * Set request as failed. You have to call this method when the HTTP request ends with
+     * external failure, such as non-200 status code is received.
+     */
+    public native void setFailed();
+
+
+    /**
+     * Native request preparation function.
+     * @throws CoreException In case the operation fails.
+     */
+    private native void prepareRequestImpl() throws CoreException;
+
+    /**
+     * Native response processing function.
+     * @param response Response data.
+     * @throws CoreException In case the operation fails.
+     */
+    private native void processResponseImpl(byte[] response) throws CoreException;
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreSession.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreSession.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.core;
+
+public class CoreSession extends NativeObject {
+    /**
+     * Construct object with handle to native object. This is a designated constructor used from JNI,
+     * when C++ object is being wrapped into Java object.
+     *
+     * @param nativeObjectHandle Handle to native object.
+     */
+    protected CoreSession(long nativeObjectHandle) {
+        super(nativeObjectHandle);
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreSignatureKeyId.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreSignatureKeyId.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.core;
+
+
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+import static io.getlime.security.powerauth.core.CoreSignatureKeyId.*;
+
+import androidx.annotation.IntDef;
+
+import java.lang.annotation.Retention;
+
+/**
+ * The {@code CoreSignatureKeyId} enumeration defines keys available for
+ * signature calculation or verification.
+ * <p>
+ * The following key categories are available:
+ * <ul>
+ *  <li><b>"master"</b> keys are used to verify data signed on the server.
+ *      These keys can be used with or without an activation present in `PowerAuthSDK`.</li>
+ *
+ *  <li><b>"server"</b> keys are personalized keys uniquely associated with an activation.
+ *      You can use these keys to verify data signed on the server.</li>
+ *
+ *  </li><b>"device"</b> keys are unique keys stored locally on the device and associated with an activation.
+ *       You can use these keys to sign data and to verify previously signed data.</li>
+ *  </ul>
+ * If the {@link CoreAlgorithm} specified in {@link CoreConfig} includes more than one algorithm,
+ * you can choose a specific key type or use all keys for the operation.
+ * Note that currently, only the API for JWS signatures supports hybrid signatures.
+ */
+@Retention(SOURCE)
+@IntDef({MASTER, MASTER_EC, MASTER_ML_DSA, SERVER, SERVER_EC, SERVER_ML_DSA,
+        DEVICE, DEVICE_EC, DEVICE_ML_DSA, MAC_PERSONALIZED})
+public @interface CoreSignatureKeyId {
+    /**
+     * Use all available "master" keys for signature verification.
+     */
+    int MASTER = 0x00;
+    /**
+     * Use only the EC-based "master" key for ECDSA signature verification.
+     */
+    int MASTER_EC = 0x01;
+    /**
+     * Use only the ML-DSA-based "master" key for ML-DSA signature verification.
+     */
+    int MASTER_ML_DSA = 0x02;
+    /**
+     * Use all available "server" keys for signature verification.
+     */
+    int SERVER = 0x10;
+    /**
+     * Use only the EC-based "server" key for ECDSA signature verification.
+     */
+    int SERVER_EC = 0x11;
+    /**
+     * Use only the ML-DSA-based "server" key for ML-DSA signature verification.
+     */
+    int SERVER_ML_DSA = 0x12;
+    /**
+     * Use all available "device" keys for signature computation or verification.
+     */
+    int DEVICE = 0x20;
+    /**
+     * Use only the EC-based "device" key for ECDSA signature computation or verification.
+     */
+    int DEVICE_EC = 0x21;
+    /**
+     * Use only the ML-DSA-based "device" key for ML-DSA signature computation or verification.
+     */
+    int DEVICE_ML_DSA = 0x22;
+    /**
+     * Use the KMAC-based symmetric key for MAC verification.
+     * <p>
+     * This key is available only when an activation is present.
+     * <p>
+     * Note that the key is not supported in JWS routines.
+     */
+    int MAC_PERSONALIZED = 0x30;
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreSignatureKeyType.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreSignatureKeyType.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.core;
+
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+import static io.getlime.security.powerauth.core.CoreSignatureKeyType.*;
+
+import androidx.annotation.IntDef;
+
+import java.lang.annotation.Retention;
+
+/**
+ * The {@code CoreSignatureKeyType} enumeration defines the types of keys used for signing or verifying operations.
+ */
+@Retention(SOURCE)
+@IntDef({EC, ML_DSA})
+public @interface CoreSignatureKeyType {
+    /**
+     * Elliptic Curve–based key.
+     */
+    int EC = 0;
+    /**
+     * ML-DSA–based key.
+     */
+    int ML_DSA = 1;
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreTask.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreTask.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.core;
+
+public class CoreTask extends NativeObject {
+    /**
+     * Construct object with handle to native object. This is a designated constructor used from JNI,
+     * when C++ object is being wrapped into Java object.
+     *
+     * @param nativeObjectHandle Handle to native object.
+     */
+    protected CoreTask(long nativeObjectHandle) {
+        super(nativeObjectHandle);
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreTask.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreTask.java
@@ -16,7 +16,14 @@
 
 package io.getlime.security.powerauth.core;
 
-public class CoreTask extends NativeObject {
+import androidx.annotation.Nullable;
+
+/**
+ * The {@code CoreTask} object represents a task that covers execution of complex operations
+ * composed from multiple HTTP requests.
+ * @param <TResponse> Type of response object.
+ */
+public class CoreTask<TResponse> extends NativeObject {
     /**
      * Construct object with handle to native object. This is a designated constructor used from JNI,
      * when C++ object is being wrapped into Java object.
@@ -26,4 +33,128 @@ public class CoreTask extends NativeObject {
     protected CoreTask(long nativeObjectHandle) {
         super(nativeObjectHandle);
     }
+
+    /**
+     * Contains information whether response object is already captured in object's properties.
+     * Property is modified from JNI.
+     */
+    boolean responseIsCaptured;
+
+    /**
+     * Contains last failure produced in the request object.
+     */
+    private CoreException failure;
+
+    /**
+     * Contains response object if this kind of task provide some response object.
+     * Property is modified from JNI.
+     */
+    private TResponse responseObject;
+
+    /**
+     * Contains response in JSON representation.
+     * Property is modified from JNI.
+     */
+    private Object responseJson;
+
+    /**
+     * Handle containing handle to native C++ object translating response into Java model object.
+     * The handle is released by calling {@link #updateResponse()} method, or in {@link #finalize()}.
+     */
+    private long responseBuilderHandle;
+
+    @Override
+    protected void finalize() {
+        super.finalize();
+        NativeObject.safeNativeDestroy(responseBuilderHandle);
+    }
+
+    /**
+     * @return Name of the task. The value can be used only for the debugging purposes.
+     */
+    public native String getTaskName();
+
+    /**
+     * @return {@code true} if the request is finished no matter of the result. Use {@link #isCompleted()},
+     *         {@link #isCanceled()} or {@link #isFailed()} to determine the exact result.
+     */
+    public native boolean isDone();
+
+    /**
+     * @return {@code true} if task is completed with success
+     */
+    public native boolean isCompleted();
+    /**
+     * @return {@code true} if task is completed with failure.
+     */
+    public native boolean isFailed();
+    /**
+     * @return {@code true} if task is canceled.
+     */
+    public native boolean isCanceled();
+
+    /**
+     * @return Response object if such object was produced in the task.
+     */
+    @Nullable
+    public TResponse getResponseObject() throws CoreException {
+        try {
+            updateResponse();
+            return responseObject;
+        } catch (CoreException e) {
+            failure = e;
+            throw e;
+        }
+    }
+
+    /**
+     * @return Response in JSON representation, if available.
+     */
+    @Nullable
+    public Object getResponseJson() throws CoreException {
+        try {
+            updateResponse();
+            return responseJson;
+        } catch (CoreException e) {
+            failure = e;
+            throw e;
+        }
+    }
+
+
+    /**
+     * Updates response object from the received data.
+     * @throws CoreException In case of failure.
+     */
+    private native void updateResponse() throws CoreException;
+
+    /**
+     * Cancel the task.
+     */
+    public native void cancel();
+
+    /**
+     * Get the next request to execute as a part of this task.
+     * @return Next request or {@code null} if there's no request scheduled or operation failed.
+     *         Check error pointer to distinguish between this states.
+     * @throws CoreException In case of failure.
+     */
+    @Nullable
+    public CoreRequest<Object> getNextRequest() throws CoreException {
+        try {
+            return getNextRequestImpl();
+        } catch (CoreException e) {
+            failure = e;
+            throw e;
+        }
+    }
+
+    /**
+     * Native implementation of getting the next request.
+     * @return Next request or {@code null} if there's no request scheduled or operation failed.
+     *         Check error pointer to distinguish between this states.
+     * @throws CoreException In case of failure.
+     */
+    @Nullable
+    private native CoreRequest<Object> getNextRequestImpl() throws CoreException;
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/EcPrivateKey.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/EcPrivateKey.java
@@ -42,6 +42,15 @@ public class EcPrivateKey extends NativeObject {
     }
 
     /**
+     * Destroys underlying native C++ object. You can call this method
+     * if you want to be sure that internal object is properly destroyed.
+     * You can't use instance of this java object anymore after this call.
+     */
+    public void destroy() {
+        safeNativeDestroy(nativeObjectHandle);
+    }
+
+    /**
      * Internal JNI initialization.
      *
      * @param privateKeyData EC private key.

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/EcPublicKey.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/EcPublicKey.java
@@ -42,6 +42,15 @@ public class EcPublicKey extends NativeObject {
     }
 
     /**
+     * Destroys underlying native C++ object. You can call this method
+     * if you want to be sure that internal object is properly destroyed.
+     * You can't use instance of this java object anymore after this call.
+     */
+    public void destroy() {
+        safeNativeDestroy(nativeObjectHandle);
+    }
+
+    /**
      * Internal JNI initialization.
      *
      * @param publicKeyData EC public key bytes.

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/ErrorCode.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/ErrorCode.java
@@ -35,6 +35,7 @@ import static io.getlime.security.powerauth.core.ErrorCode.WrongState;
  * For example, if the operation fails at WrongState or WrongParam,
  * then it's usually your fault and you're using Session in wrong way.
  */
+@Deprecated // 2.0.0
 @Retention(RetentionPolicy.SOURCE)
 @IntDef({OK, Encryption, WrongState, WrongParam})
 public @interface ErrorCode

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/NativeObject.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/NativeObject.java
@@ -45,15 +45,6 @@ public class NativeObject {
     }
 
     /**
-     * Destroys underlying native C++ object. You can call this method
-     * if you want to be sure that internal object is properly destroyed.
-     * You can't use instance of this java object anymore after this call.
-     */
-    public void destroy() {
-        safeNativeDestroy(nativeObjectHandle);
-    }
-
-    /**
      * Get information whether the underlying native object is already destroyed.
      * @return {@code true} if underlying native object is already destroyed, {@code false} otherwise.
      */
@@ -70,12 +61,12 @@ public class NativeObject {
      * Safe destroy underlying native object.
      * @param handle Handle to native object.
      */
-    private native static void safeNativeDestroy(long handle);
+    protected native static void safeNativeDestroy(long handle);
 
     /**
      * Get information whether the underlying native object is already destroyed.
      * @param handle Handle to native object.
      * @return {@code true} if underlying native object is already destroyed, {@code false} otherwise.
      */
-    private native static boolean isNativeDestroyed(long handle);
+    protected native static boolean isNativeDestroyed(long handle);
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/Password.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/Password.java
@@ -113,6 +113,15 @@ public class Password extends NativeObject {
     }
 
     /**
+     * Destroys underlying native C++ object. You can call this method
+     * if you want to be sure that internal object is properly destroyed.
+     * You can't use instance of this java object anymore after this call.
+     */
+    public void destroy() {
+        safeNativeDestroy(nativeObjectHandle);
+    }
+
+    /**
      * Initializes internal passphrase with given string or byte array based passphrase.
      * You cannot pass a both parameters at the same time, but both parameters can be
      * null. In this case, the mutable Password is initialized.

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/Session.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/Session.java
@@ -39,6 +39,15 @@ public class Session extends NativeObject {
         this.setup = setup;
         this.timeService = timeService;
     }
+
+    /**
+     * Destroys underlying native C++ object. You can call this method
+     * if you want to be sure that internal object is properly destroyed.
+     * You can't use instance of this java object anymore after this call.
+     */
+    public void destroy() {
+        safeNativeDestroy(nativeObjectHandle);
+    }
     
     /**
      * Internal JNI initialization.

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthAlgorithm.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthAlgorithm.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.sdk;
+
+import static io.getlime.security.powerauth.sdk.PowerAuthAlgorithm.*;
+
+import androidx.annotation.IntDef;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import io.getlime.security.powerauth.core.CoreAlgorithm;
+
+/**
+ * The {@code PowerAuthAlgorithm} enumeration defines algorithms available for PowerAuth
+ * initialization. The algorithm specifies also the protocol version used for communication
+ * with the server.
+ */
+@Retention(RetentionPolicy.SOURCE)
+@IntDef({LEGACY_P256, EC_P384, EC_P384_ML_L3, EC_P384_ML_L5})
+public @interface PowerAuthAlgorithm {
+    /**
+     * Algorithm identifier for legacy protocol V3.3.
+     * <p>
+     * If used in {@link PowerAuthConfiguration}, then the protocol upgrade is automatically disabled
+     * and instance of {@link PowerAuthSDK} will use legacy protocol only for communicating with the server.
+     */
+    int LEGACY_P256 = CoreAlgorithm.LEGACY_P256;
+
+    /**
+     * Algorithm identifier for V4 protocol, using only cryptography based on elliptic curves.
+     * The following algorithms are used:
+     * <ul>
+     * <li>Key agreement: ECDHE with P-384</li>
+     * <li>Signatures: ECDSA with P-384</li>
+     * </ul>
+     */
+    int EC_P384 = CoreAlgorithm.EC_P384;
+
+    /**
+     * Algorithm identifier for V4 protocol, using quantum resistant algorithms combined with
+     * elliptic curves. The following algorithms are used:
+     * <ul>
+     * <li>Key agreement: ECDHE with P-384 combined with ML-KEM-768</li>
+     * <li>Signatures: ECDSA with P-384 combined with ML-DSA-65</li>
+     * </ul>
+     */
+    int EC_P384_ML_L3 = CoreAlgorithm.EC_P384_ML_L3;
+
+    /**
+     * Algorithm identifier for V4 protocol, using quantum resistant algorithms combined with
+     * elliptic curves. The following algorithms are used:
+     * <ul>
+     * <li>Key agreement: ECDHE with P-384 combined with ML-KEM-1024</li>
+     * <li>Signatures: ECDSA with P-384 combined with ML-DSA-87</li>
+     * </ul>
+     */
+    int EC_P384_ML_L5 = CoreAlgorithm.EC_P384_ML_L5;
+
+    /**
+     * Default algorithm. Value is identical to {@link #EC_P384_ML_L3}.
+     */
+    int DEFAULT = EC_P384_ML_L3;
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthAuthorizationHttpHeader.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthAuthorizationHttpHeader.java
@@ -37,7 +37,7 @@ public class PowerAuthAuthorizationHttpHeader {
      * The property is deprecated and is only effective if header is calculated in deprecated methods from
      * {@link PowerAuthSDK} or {@link PowerAuthToken}.
      */
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     @PowerAuthErrorCodes
     public final int powerAuthErrorCode;
 
@@ -76,7 +76,7 @@ public class PowerAuthAuthorizationHttpHeader {
      * @deprecated The new methods for calculating authorization headers throws an exception in case of failure, and
      *             therefore the returned header is always valid.
      */
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     public boolean isValid() {
         return powerAuthErrorCode == PowerAuthErrorCodes.SUCCEED &&
                 key != null &&
@@ -102,7 +102,7 @@ public class PowerAuthAuthorizationHttpHeader {
     // final public properties to access the elements.
     //
 
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     @PowerAuthErrorCodes
     public int getPowerAuthErrorCode() {
         return powerAuthErrorCode;

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthBiometricConfiguration.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthBiometricConfiguration.java
@@ -102,7 +102,7 @@ public class PowerAuthBiometricConfiguration {
      * Internal constructor that create the biometric configuration from provided keychain configuration.
      * @noinspection deprecation
      */
-    // @Deprecated // 1.10.0
+    // @Deprecated // 2.0.0
     PowerAuthBiometricConfiguration(@NonNull PowerAuthKeychainConfiguration keychainConfiguration) {
         this.invalidateBiometricFactorAfterChange = keychainConfiguration.isLinkBiometricItemsToCurrentSet();
         this.confirmBiometricAuthentication = keychainConfiguration.isConfirmBiometricAuthentication();

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthConfiguration.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthConfiguration.java
@@ -19,6 +19,7 @@ package io.getlime.security.powerauth.sdk;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import io.getlime.security.powerauth.core.Algorithm;
 import io.getlime.security.powerauth.core.SecureData;
 import io.getlime.security.powerauth.core.SessionSetup;
 
@@ -30,8 +31,8 @@ public class PowerAuthConfiguration {
     private final @NonNull String instanceId;
     private final @NonNull String baseEndpointUrl;
     private final @NonNull SessionSetup sessionSetup;
-    private final boolean disableAutomaticProtocolUpgrade;
     private final int offlineAuthorizationCodeComponentLength;
+    private final @Algorithm int algorithm;
 
     /**
      * Constant for default PowerAuthSDK instance identifier.
@@ -74,13 +75,12 @@ public class PowerAuthConfiguration {
     }
 
     /**
-     * If set to true, then PowerAuthSDK will not automatically upgrade activation to a newer protocol version.
-     * This option should be used only for the testing purposes.
-     *
-     * @return If set to {@code true}, then PowerAuthSDK will not automatically upgrade activation to a newer protocol version.
+     * Property is deprecated. Disabling protocol upgrade has no effect in this version of SDK.
+     * @return Always {@code false}.
      */
+    @Deprecated // 2.0.0
     public boolean isAutomaticProtocolUpgradeDisabled() {
-        return disableAutomaticProtocolUpgrade;
+        return false;
     }
 
     /**
@@ -93,7 +93,7 @@ public class PowerAuthConfiguration {
     /**
      * @return Length of offline authorization code component.
      */
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     public int getOfflineSignatureComponentLength() {
         return offlineAuthorizationCodeComponentLength;
     }
@@ -128,19 +128,19 @@ public class PowerAuthConfiguration {
      * @param instanceId Identifier of the PowerAuthSDK instance, used as a 'key' to store session state.
      * @param baseEndpointUrl Base URL to the PowerAuth Standard REST API (the URL part before {@code "/pa/..."}).
      * @param sessionSetup Setup for core/Session object.
-     * @param disableAutomaticProtocolUpgrade If set to {@code true}, then PowerAuthSDK will not automatically upgrade activation to a newer protocol version.
+     * @param algorithm Algorithm selected for communication with the server.
      */
     private PowerAuthConfiguration(
             @NonNull String instanceId,
             @NonNull String baseEndpointUrl,
             @NonNull SessionSetup sessionSetup,
-            boolean disableAutomaticProtocolUpgrade,
-            int offlineSignatureComponentLength) {
+            int offlineSignatureComponentLength,
+            @Algorithm int algorithm) {
         this.instanceId = instanceId;
         this.baseEndpointUrl = baseEndpointUrl;
         this.sessionSetup = sessionSetup;
-        this.disableAutomaticProtocolUpgrade = disableAutomaticProtocolUpgrade;
         this.offlineAuthorizationCodeComponentLength = offlineSignatureComponentLength;
+        this.algorithm = algorithm;
     }
 
     /**
@@ -155,6 +155,7 @@ public class PowerAuthConfiguration {
         private SecureData externalEncryptionKey = null;
         private boolean disableAutomaticProtocolUpgrade = false;
         private int offlineAuthorizationCodeComponentLength = MAX_OFFLINE_AUTHORIZATION_CODE_COMPONENT_LENGTH;
+        private @Algorithm int algorithm = Algorithm.DEFAULT;
 
         /**
          * Creates a builder for {@link PowerAuthConfiguration}.
@@ -185,6 +186,16 @@ public class PowerAuthConfiguration {
         }
 
         /**
+         * Set algorithm for communication with the server.
+         * @param algorithm Algorithm for communication.
+         * @return {@link Builder}
+         */
+        public @NonNull Builder algorithm(@Algorithm int algorithm) {
+            this.algorithm = algorithm;
+            return this;
+        }
+
+        /**
          * Set external encryption key provided by an external context, used to encrypt possession and biometry related factor keys under the hood.
          * @param externalEncryptionKey Encryption key provided by an external context, used to encrypt possession and biometry related factor keys under the hood.
          * @return {@link Builder}
@@ -195,11 +206,12 @@ public class PowerAuthConfiguration {
         }
 
         /**
-         * Disable automatic protocol upgrade. This option should be used only for the testing purposes.
+         * Disable automatic protocol upgrade.
+         * @deprecated Option is deprecated and has no effect in PowerAuth Mobile SDK 2.0+.
          * @return {@link Builder}
          */
+        @Deprecated // 2.0.0
         public @NonNull Builder disableAutomaticProtocolUpgrade() {
-            this.disableAutomaticProtocolUpgrade = true;
             return this;
         }
 
@@ -219,7 +231,7 @@ public class PowerAuthConfiguration {
          * @return {@link Builder}
          * @deprecated Use {@link #offlineAuthorizationCodeComponentLength(int)} as replacement.
          */
-        @Deprecated // 1.10.0
+        @Deprecated // 2.0.0
         public @NonNull Builder offlineSignatureComponentLength(int length) {
             this.offlineAuthorizationCodeComponentLength = length;
             return this;
@@ -235,8 +247,8 @@ public class PowerAuthConfiguration {
                     instanceId != null ? instanceId : DEFAULT_INSTANCE_ID,
                     baseEndpointUrl,
                     sessionSetup,
-                    disableAutomaticProtocolUpgrade,
-                    offlineAuthorizationCodeComponentLength);
+                    offlineAuthorizationCodeComponentLength,
+                    algorithm);
         }
     }
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthConfiguration.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthConfiguration.java
@@ -16,10 +16,12 @@
 
 package io.getlime.security.powerauth.sdk;
 
+import android.health.connect.datatypes.units.Power;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import io.getlime.security.powerauth.core.Algorithm;
+import io.getlime.security.powerauth.core.CoreAlgorithm;
 import io.getlime.security.powerauth.core.SecureData;
 import io.getlime.security.powerauth.core.SessionSetup;
 
@@ -32,7 +34,7 @@ public class PowerAuthConfiguration {
     private final @NonNull String baseEndpointUrl;
     private final @NonNull SessionSetup sessionSetup;
     private final int offlineAuthorizationCodeComponentLength;
-    private final @Algorithm int algorithm;
+    private final @PowerAuthAlgorithm int algorithm;
 
     /**
      * Constant for default PowerAuthSDK instance identifier.
@@ -44,6 +46,13 @@ public class PowerAuthConfiguration {
      */
     public @NonNull String getInstanceId() {
         return instanceId;
+    }
+
+    /**
+     * @return Algorithm specified for communication with the server.
+     */
+    public @PowerAuthAlgorithm int getAlgorithm() {
+        return algorithm;
     }
 
     /**
@@ -135,7 +144,7 @@ public class PowerAuthConfiguration {
             @NonNull String baseEndpointUrl,
             @NonNull SessionSetup sessionSetup,
             int offlineSignatureComponentLength,
-            @Algorithm int algorithm) {
+            @PowerAuthAlgorithm int algorithm) {
         this.instanceId = instanceId;
         this.baseEndpointUrl = baseEndpointUrl;
         this.sessionSetup = sessionSetup;
@@ -153,9 +162,8 @@ public class PowerAuthConfiguration {
         // optional
         private String instanceId;
         private SecureData externalEncryptionKey = null;
-        private boolean disableAutomaticProtocolUpgrade = false;
         private int offlineAuthorizationCodeComponentLength = MAX_OFFLINE_AUTHORIZATION_CODE_COMPONENT_LENGTH;
-        private @Algorithm int algorithm = Algorithm.DEFAULT;
+        private @PowerAuthAlgorithm int algorithm = PowerAuthAlgorithm.DEFAULT;
 
         /**
          * Creates a builder for {@link PowerAuthConfiguration}.
@@ -190,7 +198,7 @@ public class PowerAuthConfiguration {
          * @param algorithm Algorithm for communication.
          * @return {@link Builder}
          */
-        public @NonNull Builder algorithm(@Algorithm int algorithm) {
+        public @NonNull Builder algorithm(@PowerAuthAlgorithm int algorithm) {
             this.algorithm = algorithm;
             return this;
         }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthDevicePublicKeyData.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthDevicePublicKeyData.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.sdk;
+
+import androidx.annotation.NonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.getlime.security.powerauth.core.CoreDevicePublicKeyData;
+import io.getlime.security.powerauth.core.CoreSignatureKeyType;
+
+/**
+ * The {@code PowerAuthDevicePublicKeyData} class represents exported device public key data.
+ */
+public class PowerAuthDevicePublicKeyData {
+    @PowerAuthSignatureKeyType
+    private final int keyType;
+    @NonNull
+    private final String keyAlgorithm;
+    @NonNull
+    private final byte[] keyData;
+
+    /**
+     * Construct object with public key type, algorithm and data.
+     * @param keyType Type of the public key.
+     * @param keyAlgorithm Information about the key algorithm (e.g., "P-256", "P-384", "ML-DSA-65", etc.).
+     * @param keyData Public key data.
+     */
+    public PowerAuthDevicePublicKeyData(@PowerAuthSignatureKeyType int keyType, @NonNull String keyAlgorithm, @NonNull byte[] keyData) {
+        this.keyType = keyType;
+        this.keyAlgorithm = keyAlgorithm;
+        this.keyData = keyData;
+    }
+
+    /**
+     * @return Type of the public key.
+     */
+    @PowerAuthSignatureKeyType
+    public int getKeyType() {
+        return keyType;
+    }
+
+    /**
+     * @return Information about the key algorithm (e.g., "P-256", "P-384", "ML-DSA-65", etc.).
+     */
+    @NonNull
+    public String getKeyAlgorithm() {
+        return keyAlgorithm;
+    }
+
+    /**
+     * @return Public key data.
+     */
+    @NonNull
+    public byte[] getKeyData() {
+        return keyData;
+    }
+
+    /**
+     * Convert instance of {@link CoreDevicePublicKeyData} into {@link PowerAuthDevicePublicKeyData}.
+     * @param publicKey Object to convert.
+     * @return {@link PowerAuthDevicePublicKeyData}
+     */
+    @NonNull
+    public static PowerAuthDevicePublicKeyData fromCoreObject(@NonNull CoreDevicePublicKeyData publicKey) {
+
+        @PowerAuthSignatureKeyType final int keyType;
+        switch (publicKey.getKeyType()) {
+            case CoreSignatureKeyType.EC:
+                keyType = PowerAuthSignatureKeyType.EC;
+                break;
+            case CoreSignatureKeyType.ML_DSA:
+                keyType = PowerAuthSignatureKeyType.ML_DSA;
+                break;
+            default:
+                throw new IllegalStateException("PowerAuthSignatureKeyType doesn't match values in CoreSignatureKeyType");
+        }
+        return new PowerAuthDevicePublicKeyData(keyType, publicKey.getKeyAlgorithm(), publicKey.getKeyData());
+    }
+
+    /**
+     * Convert array of {@link CoreDevicePublicKeyData} objects into list of {@link PowerAuthDevicePublicKeyData}.
+     * @param publicKeys Array of {@link CoreDevicePublicKeyData} objects
+     * @return List of {@link PowerAuthDevicePublicKeyData}.
+     */
+    @NonNull
+    public static List<PowerAuthDevicePublicKeyData> fromCoreObject(@NonNull CoreDevicePublicKeyData[] publicKeys) {
+        ArrayList<PowerAuthDevicePublicKeyData> result = new ArrayList<>(publicKeys.length);
+        for (CoreDevicePublicKeyData publicKey : publicKeys) {
+            result.add(fromCoreObject(publicKey));
+        }
+        return result;
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthDevicePublicKeyFormat.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthDevicePublicKeyFormat.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.sdk;
+
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+import static io.getlime.security.powerauth.sdk.PowerAuthDevicePublicKeyFormat.*;
+
+import androidx.annotation.IntDef;
+
+import java.lang.annotation.Retention;
+
+import io.getlime.security.powerauth.core.CoreDevicePublicKeyFormat;
+
+/**
+ * The {@code PowerAuthDevicePublicKeyFormat} enumeration defines the output format used when exporting
+ * the device public key.
+ */
+@Retention(SOURCE)
+@IntDef({DER, RAW})
+public @interface PowerAuthDevicePublicKeyFormat {
+    /**
+     * DER key format, which corresponds to the SPKI or X.509 structure.
+     */
+    int DER = CoreDevicePublicKeyFormat.DER;
+    /**
+     * RAW key format. The actual output depends on the key type:
+     * <ul>
+     *  <li>For EC-based keys, the output data is ASN.1 encoded, as specified in ANSI X9.63.</li>
+     *  <li>For ML-DSA-based keys, the output data is obtained using the OpenSSL
+     *   {@code EVP_PKEY_get_raw_public_key()} function.</li>
+     * </ul>
+     */
+    int RAW = CoreDevicePublicKeyFormat.RAW;
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthHttpHeader.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthHttpHeader.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.sdk;
+
+import androidx.annotation.NonNull;
+
+import io.getlime.security.powerauth.core.CoreHttpHeader;
+
+/**
+ * Class representing HTTP header generated in PowerAuth mobile SDK.
+ */
+public class PowerAuthHttpHeader {
+    @NonNull
+    private final String key;
+    @NonNull
+    private final String value;
+
+    /**
+     * Construct HTTP header object with header's name and value.
+     * @param key Header's name.
+     * @param value Header's value.
+     */
+    public PowerAuthHttpHeader(@NonNull String key, @NonNull String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    /**
+     * @return HTTP header's key.
+     */
+    @NonNull
+    public String getKey() {
+        return key;
+    }
+
+    /**
+     * @return HTTP header's value.
+     */
+    @NonNull
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Convert instance of {@link CoreHttpHeader} into {@link PowerAuthHttpHeader}.
+     * @param header Core header object.
+     * @return {@link PowerAuthHttpHeader}
+     */
+    public static PowerAuthHttpHeader fromCoreObject(CoreHttpHeader header) {
+        return new PowerAuthHttpHeader(header.getKey(), header.getValue());
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthKeychainConfiguration.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthKeychainConfiguration.java
@@ -68,7 +68,7 @@ public class PowerAuthKeychainConfiguration {
      * @return Name of the default biometry Keychain key.
      * @deprecated Use {@link #getKeychainKeyBiometry()} method instead.
      */
-    @Deprecated // 1.7.10 - remove in 1.10.0
+    @Deprecated // 1.7.10 - remove in 2.0.0
     public @NonNull String getKeychainBiometryDefaultKey() {
        return keychainKeyBiometry == null ? KEYCHAIN_KEY_SHARED_BIOMETRY_KEY : keychainKeyBiometry;
     }
@@ -103,7 +103,7 @@ public class PowerAuthKeychainConfiguration {
      *
      * @deprecated Use {@link PowerAuthBiometricConfiguration#isInvalidateBiometricFactorAfterChange()} instead.
      */
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     public boolean isLinkBiometricItemsToCurrentSet() {
         return linkBiometricItemsToCurrentSet;
     }
@@ -117,7 +117,7 @@ public class PowerAuthKeychainConfiguration {
      *
      * @deprecated Use {@link PowerAuthBiometricConfiguration#isConfirmBiometricAuthentication()} instead.
      */
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     public boolean isConfirmBiometricAuthentication() {
         return confirmBiometricAuthentication;
     }
@@ -129,7 +129,7 @@ public class PowerAuthKeychainConfiguration {
      *
      * @deprecated Use {@link PowerAuthBiometricConfiguration#isAuthenticateOnBiometricKeySetup()} instead.
      */
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     public boolean isAuthenticateOnBiometricKeySetup() {
         return authenticateOnBiometricKeySetup;
     }
@@ -143,7 +143,7 @@ public class PowerAuthKeychainConfiguration {
      *
      * @deprecated Use {@link PowerAuthBiometricConfiguration#isFallbackToSharedBiometryKeyEnabled()} instead.
      */
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     public boolean isFallbackToSharedBiometryKeyEnabled() {
         return enableFallbackToSharedBiometryKey;
     }
@@ -262,7 +262,7 @@ public class PowerAuthKeychainConfiguration {
          * @return {@link Builder}
          * @deprecated Use {@link #keychainKeyBiometry(String)} as a replacement.
          */
-        @Deprecated // 1.7.10 - remove in 1.10.0
+        @Deprecated // 1.7.10 - remove in 2.0.0
         public @NonNull Builder keychainBiometryDefaultKey(@NonNull String keychainKeyBiometry) {
             this.keychainKeyBiometry = keychainKeyBiometry;
             return this;
@@ -288,7 +288,7 @@ public class PowerAuthKeychainConfiguration {
          *
          * @deprecated Use {@link PowerAuthBiometricConfiguration.Builder#invalidateBiometricFactorAfterChange(boolean)} instead.
          */
-        @Deprecated // 1.10.0
+        @Deprecated // 2.0.0
         public @NonNull Builder linkBiometricItemsToCurrentSet(boolean linkBiometricItemsToCurrentSet) {
             this.linkBiometricItemsToCurrentSet = linkBiometricItemsToCurrentSet;
             return this;
@@ -304,7 +304,7 @@ public class PowerAuthKeychainConfiguration {
          *
          * @deprecated Use {@link PowerAuthBiometricConfiguration.Builder#confirmBiometricAuthentication(boolean)} instead.
          */
-        @Deprecated // 1.10.0
+        @Deprecated // 2.0.0
         public @NonNull Builder confirmBiometricAuthentication(boolean confirmBiometricAuthentication) {
             this.confirmBiometricAuthentication = confirmBiometricAuthentication;
             return this;
@@ -329,7 +329,7 @@ public class PowerAuthKeychainConfiguration {
          *
          * @deprecated Use {@link PowerAuthBiometricConfiguration.Builder#authenticateOnBiometricKeySetup(boolean)} instead.
          */
-        @Deprecated // 1.10.0
+        @Deprecated // 2.0.0
         public @NonNull Builder authenticateOnBiometricKeySetup(boolean authenticate) {
             this.authenticateOnBiometricKeySetup = authenticate;
             return this;
@@ -346,7 +346,7 @@ public class PowerAuthKeychainConfiguration {
          *
          * @deprecated Use {@link PowerAuthBiometricConfiguration.Builder#enableFallbackToSharedBiometryKey(boolean)} instead.
          */
-        @Deprecated // 1.10.0
+        @Deprecated // 2.0.0
         public @NonNull Builder enableFallbackToSharedBiometryKey(boolean enable) {
             this.enableFallbackToSharedBiometryKey = enable;
             return this;

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -188,7 +188,7 @@ public class PowerAuthSDK {
                     mBiometricConfiguration = new PowerAuthBiometricConfiguration.Builder().build();
                 } else {
                     // As fallback, construct biometric configuration from the keychain configuration.
-                    // @Deprecated // 1.10.0
+                    // @Deprecated // 2.0.0
                     mBiometricConfiguration = new PowerAuthBiometricConfiguration(mKeychainConfiguration);
                 }
             }
@@ -1047,7 +1047,7 @@ public class PowerAuthSDK {
      */
     @CheckResult
     @PowerAuthErrorCodes
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     public int persistActivationWithPassword(@NonNull Context context, @NonNull String password) {
         return persistActivationWithAuthentication(context, PowerAuthAuthentication.persistWithPassword(password));
     }
@@ -1064,7 +1064,7 @@ public class PowerAuthSDK {
      */
     @CheckResult
     @PowerAuthErrorCodes
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     public int persistActivationWithPassword(@NonNull Context context, @NonNull Password password) {
         return persistActivationWithAuthentication(context, PowerAuthAuthentication.persistWithPassword(password));
     }
@@ -1083,7 +1083,7 @@ public class PowerAuthSDK {
      */
     @UiThread
     @NonNull
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     public ICancelable persistActivation(
             final @NonNull Context context,
             @NonNull FragmentActivity fragmentActivity,
@@ -1108,7 +1108,7 @@ public class PowerAuthSDK {
      */
     @UiThread
     @NonNull
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     public ICancelable persistActivation(
             final @NonNull Context context,
             @NonNull FragmentActivity fragmentActivity,
@@ -1133,7 +1133,7 @@ public class PowerAuthSDK {
      */
     @UiThread
     @NonNull
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     public ICancelable persistActivation(
             final @NonNull Context context,
             @NonNull Fragment fragment,
@@ -1158,7 +1158,7 @@ public class PowerAuthSDK {
      */
     @UiThread
     @NonNull
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     public ICancelable persistActivation(
             final @NonNull Context context,
             @NonNull Fragment fragment,
@@ -1181,7 +1181,7 @@ public class PowerAuthSDK {
      */
     @UiThread
     @NonNull
-    // @Deprecated // 1.10.0 - remove in 2.0
+    // @Deprecated // 2.0.0 - remove in 2.1.0
     private ICancelable persistActivationWithBiometricsImpl(
             final @NonNull Context context,
             @NonNull PowerAuthBiometricPrompt prompt,
@@ -1228,7 +1228,7 @@ public class PowerAuthSDK {
      */
     @CheckResult
     @PowerAuthErrorCodes
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     public int persistActivationWithPassword(@NonNull Context context, @NonNull String password, @Nullable SecureData encryptedBiometryKey) {
         return persistActivationWithPassword(context, new Password(password), encryptedBiometryKey);
     }
@@ -1247,7 +1247,7 @@ public class PowerAuthSDK {
      */
     @CheckResult
     @PowerAuthErrorCodes
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     public int persistActivationWithPassword(@NonNull Context context, @NonNull Password password, @Nullable SecureData encryptedBiometryKey) {
         return persistActivationWithAuthentication(context, new PowerAuthAuthentication(true, password, null, encryptedBiometryKey, null));
     }
@@ -1264,7 +1264,7 @@ public class PowerAuthSDK {
      */
     @CheckResult
     @PowerAuthErrorCodes
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     public int persistActivationWithAuthentication(@NonNull Context context, @NonNull PowerAuthAuthentication authentication) {
         try {
             persistActivationImpl(context, authentication);
@@ -1578,7 +1578,7 @@ public class PowerAuthSDK {
      * @throws PowerAuthMissingConfigException thrown in case configuration is not present.
      * @deprecated Use {@link #removeActivationLocal(Context)} as a replacement.
      */
-    @Deprecated // 1.7.10 - remove in 1.10.0
+    @Deprecated // 1.7.10 - remove in 2.0.0
     public void removeActivationLocal(@NonNull Context context, boolean removeSharedBiometryKey) {
         removeActivationLocal(context);
     }
@@ -1757,7 +1757,7 @@ public class PowerAuthSDK {
      * @throws PowerAuthMissingConfigException thrown in case configuration is not present.
      * @deprecated Use {@link #authorizationHeaderForRequestWithParams(Context, PowerAuthAuthentication, String, String, Map)} for replacement.
      */
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     public @NonNull PowerAuthAuthorizationHttpHeader requestGetSignatureWithAuthentication(@NonNull Context context, @NonNull PowerAuthAuthentication authentication, String uriId, Map<String, String> params) {
         try {
             return authorizationHeaderForRequestWithParams(context, authentication, "GET", uriId, params);
@@ -1778,7 +1778,7 @@ public class PowerAuthSDK {
      * @throws PowerAuthMissingConfigException thrown in case configuration is not present.
      * @deprecated Use {@link #authorizationHeaderForRequestWithBody(Context, PowerAuthAuthentication, String, String, byte[])} for replacement.
      */
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     public @NonNull PowerAuthAuthorizationHttpHeader requestSignatureWithAuthentication(@NonNull Context context, @NonNull PowerAuthAuthentication authentication, String method, String uriId, byte[] body) {
         try {
             return authorizationHeaderForRequestWithBody(context, authentication, method, uriId, body);
@@ -1799,7 +1799,7 @@ public class PowerAuthSDK {
      * @throws PowerAuthMissingConfigException thrown in case configuration is not present.
      * @deprecated Use {@link #offlineAuthorizationCode(Context, PowerAuthAuthentication, String, byte[], String, IOfflineAuthorizationCodeListener)}
      */
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     public @Nullable String offlineSignatureWithAuthentication(@NonNull Context context, @NonNull PowerAuthAuthentication authentication, String uriId, byte[] body, String nonce) {
 
         checkForValidSetup();
@@ -1957,7 +1957,7 @@ public class PowerAuthSDK {
      * @throws PowerAuthMissingConfigException thrown in case configuration is not present.
      * @deprecated Method is deprecated, use {@link #changePassword(Context, String, String, IChangePasswordListener)} as a replacement.
      */
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     public boolean changePasswordUnsafe(@NonNull final String oldPassword, @NonNull final String newPassword) {
         return changePasswordUnsafeImpl(new Password(oldPassword), new Password(newPassword));
     }
@@ -1975,7 +1975,7 @@ public class PowerAuthSDK {
      * @throws PowerAuthMissingConfigException thrown in case configuration is not present.
      * @deprecated Method is deprecated, use {@link #changePassword(Context, Password, Password, IChangePasswordListener)} as a replacement.
      */
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     public boolean changePasswordUnsafe(@NonNull final Password oldPassword, @NonNull final Password newPassword) {
         return changePasswordUnsafeImpl(oldPassword, newPassword);
     }
@@ -1988,7 +1988,7 @@ public class PowerAuthSDK {
      * @return Returns 'true' in case password was changed without error, 'false' otherwise.
      * @throws PowerAuthMissingConfigException thrown in case configuration is not present.
      */
-    //@Deprecated // 1.10.0
+    //@Deprecated // 2.0.0
     private boolean changePasswordUnsafeImpl(@NonNull final Password oldPassword, @NonNull final Password newPassword) {
         final int result = mSession.changeUserPassword(oldPassword, newPassword);
         if (result == ErrorCode.OK) {
@@ -2126,7 +2126,7 @@ public class PowerAuthSDK {
      */
     @UiThread
     @Nullable
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     public ICancelable addBiometryFactor(
             @NonNull final Context context,
             final @NonNull Fragment fragment,
@@ -2153,7 +2153,7 @@ public class PowerAuthSDK {
      */
     @UiThread
     @Nullable
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     public ICancelable addBiometryFactor(
             @NonNull final Context context,
             final @NonNull Fragment fragment,
@@ -2180,7 +2180,7 @@ public class PowerAuthSDK {
      */
     @UiThread
     @Nullable
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     public ICancelable addBiometryFactor(
             @NonNull final Context context,
             final @NonNull FragmentActivity fragmentActivity,
@@ -2207,7 +2207,7 @@ public class PowerAuthSDK {
      */
     @UiThread
     @Nullable
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     public ICancelable addBiometryFactor(
             @NonNull final Context context,
             final @NonNull FragmentActivity fragmentActivity,
@@ -2384,7 +2384,7 @@ public class PowerAuthSDK {
      * @return TRUE if the key was successfully removed, FALSE otherwise.
      * @deprecated Please use asynchronous variant {@link #removeBiometryFactor(Context, IRemoveBiometryFactorListener)}.
      */
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     public boolean removeBiometryFactor(@NonNull Context context) {
         try {
             removeBiometryFactorImpl(context);
@@ -2571,7 +2571,7 @@ public class PowerAuthSDK {
      */
     @UiThread
     @NonNull
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     public ICancelable authenticateUsingBiometrics(
             @NonNull Context context,
             @NonNull Fragment fragment,
@@ -2595,7 +2595,7 @@ public class PowerAuthSDK {
      */
     @UiThread
     @NonNull
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     public ICancelable authenticateUsingBiometrics(
             @NonNull Context context,
             @NonNull FragmentActivity fragmentActivity,

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSignatureKeyId.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSignatureKeyId.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.sdk;
+
+
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+import static io.getlime.security.powerauth.sdk.PowerAuthSignatureKeyId.*;
+
+import androidx.annotation.IntDef;
+
+import java.lang.annotation.Retention;
+
+import io.getlime.security.powerauth.core.CoreSignatureKeyId;
+
+/**
+ * The {@code PowerAuthCoreSignatureKeyId} enumeration defines keys available for
+ * signature calculation or verification.
+ * <p>
+ * The following key categories are available:
+ * <ul>
+ *  <li><b>"master"</b> keys are used to verify data signed on the server.
+ *      These keys can be used with or without an activation present in {@link PowerAuthSDK}.</li>
+ *
+ *  <li><b>"server"</b> keys are personalized keys uniquely associated with an activation.
+ *      You can use these keys to verify data signed on the server.</li>
+ *
+ *  </li><b>"device"</b> keys are unique keys stored locally on the device and associated with an activation.
+ *       You can use these keys to sign data and to verify previously signed data.</li>
+ *  </ul>
+ * If the {@link PowerAuthAlgorithm} specified in {@link PowerAuthConfiguration} includes more than one algorithm,
+ * you can choose a specific key type or use all keys for the operation.
+ * Note that currently, only the API for JWS signatures supports hybrid signatures.
+ */
+@Retention(SOURCE)
+@IntDef({MASTER, MASTER_EC, MASTER_ML_DSA, SERVER, SERVER_EC, SERVER_ML_DSA,
+        DEVICE, DEVICE_EC, DEVICE_ML_DSA, MAC_PERSONALIZED})
+public @interface PowerAuthSignatureKeyId {
+    /**
+     * Use all available "master" keys for signature verification.
+     */
+    int MASTER = CoreSignatureKeyId.MASTER;
+    /**
+     * Use only the EC-based "master" key for ECDSA signature verification.
+     */
+    int MASTER_EC = CoreSignatureKeyId.MASTER_EC;
+    /**
+     * Use only the ML-DSA-based "master" key for ML-DSA signature verification.
+     */
+    int MASTER_ML_DSA = CoreSignatureKeyId.MASTER_ML_DSA;
+    /**
+     * Use all available "server" keys for signature verification.
+     */
+    int SERVER = CoreSignatureKeyId.SERVER;
+    /**
+     * Use only the EC-based "server" key for ECDSA signature verification.
+     */
+    int SERVER_EC = CoreSignatureKeyId.SERVER_EC;
+    /**
+     * Use only the ML-DSA-based "server" key for ML-DSA signature verification.
+     */
+    int SERVER_ML_DSA = CoreSignatureKeyId.SERVER_ML_DSA;
+    /**
+     * Use all available "device" keys for signature computation or verification.
+     */
+    int DEVICE = CoreSignatureKeyId.DEVICE;
+    /**
+     * Use only the EC-based "device" key for ECDSA signature computation or verification.
+     */
+    int DEVICE_EC = CoreSignatureKeyId.DEVICE_EC;
+    /**
+     * Use only the ML-DSA-based "device" key for ML-DSA signature computation or verification.
+     */
+    int DEVICE_ML_DSA = CoreSignatureKeyId.DEVICE_ML_DSA;
+    /**
+     * Use the KMAC-based symmetric key for MAC verification.
+     * <p>
+     * This key is available only when an activation is present.
+     * <p>
+     * Note that the key is not supported in JWS routines.
+     */
+    int MAC_PERSONALIZED = CoreSignatureKeyId.MAC_PERSONALIZED;
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSignatureKeyType.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSignatureKeyType.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.sdk;
+
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+import static io.getlime.security.powerauth.sdk.PowerAuthSignatureKeyType.*;
+
+import androidx.annotation.IntDef;
+
+import java.lang.annotation.Retention;
+
+import io.getlime.security.powerauth.core.CoreSignatureKeyType;
+
+/**
+ * The {@code PowerAuthSignatureKeyType} enumeration defines the types of keys used for signing
+ * or verifying operations.
+ */
+@Retention(SOURCE)
+@IntDef({EC, ML_DSA})
+public @interface PowerAuthSignatureKeyType {
+    /**
+     * Elliptic Curve–based key.
+     */
+    int EC = CoreSignatureKeyType.EC;
+    /**
+     * ML-DSA–based key.
+     */
+    int ML_DSA = CoreSignatureKeyType.ML_DSA;
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthToken.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthToken.java
@@ -121,7 +121,7 @@ public class PowerAuthToken {
      *
      * @deprecated Use {@link #generateTokenHeader()} instead.
      */
-    @Deprecated // 1.10.0
+    @Deprecated // 2.0.0
     public @NonNull PowerAuthAuthorizationHttpHeader generateHeader() {
         try {
             return generateTokenHeader();

--- a/proj-xcode/PowerAuth2/PowerAuthConfiguration.h
+++ b/proj-xcode/PowerAuth2/PowerAuthConfiguration.h
@@ -98,12 +98,9 @@ typedef NS_ENUM(NSInteger, PowerAuthAlgorithm) {
 @property (nonatomic, assign) PowerAuthAlgorithm algorithm;
 
 /**
- If set to YES, then PowerAuthSDK will not automatically upgrade activation to a newer protocol version.
- This option should be used only for the testing purposes.
- 
- Default and recommended value is `NO`.
+ Property is deprecated and has no effect in PowerAuth Mobile SDK version 2.0+.
  */
-@property (nonatomic, assign) BOOL disableAutomaticProtocolUpgrade;
+@property (nonatomic, assign) BOOL disableAutomaticProtocolUpgrade PA2_DEPRECATED(2.0.0);
 
 /**
  Length of offline authentication code component. The value between 4 and 8 is allowed.

--- a/proj-xcode/PowerAuth2/PowerAuthConfiguration.m
+++ b/proj-xcode/PowerAuth2/PowerAuthConfiguration.m
@@ -44,7 +44,6 @@
         _configuration = configuration;
         _algorithm = algorithm;
         _offlineAuthenticationCodeComponentLength = MAX_OFFLINE_AUTH_CODE_COMPONENT_LEN;
-        _disableAutomaticProtocolUpgrade = algorithm == PowerAuthAlgorithm_LEGACY_P256;
     }
     return self;
 }

--- a/proj-xcode/PowerAuth2/PowerAuthSDK.m
+++ b/proj-xcode/PowerAuth2/PowerAuthSDK.m
@@ -860,8 +860,7 @@ static PowerAuthSDK * s_inst;
         _getActivationStatusTask = [[PA2GetActivationStatusTask alloc] initWithHttpClient:_client
                                                                           sessionProvider:_sessionInterface
                                                                                  delegate:self
-                                                                               sharedLock:_lock
-                                                                           disableUpgrade:_configuration.disableAutomaticProtocolUpgrade];
+                                                                               sharedLock:_lock];
         task = [_getActivationStatusTask createChildTask:callback];
     }
     //

--- a/proj-xcode/PowerAuth2/private/PA2GetActivationStatusTask.h
+++ b/proj-xcode/PowerAuth2/private/PA2GetActivationStatusTask.h
@@ -48,14 +48,12 @@
  @param sessionProvider PowerAuthCoreSession provider.
  @param delegate Delegate to be called once the task is finished. The weak reference is used internally.
  @param sharedLock Shared lock with recursive locking capability.
- @param disableUpgrade Set to true whether the protocol upgrade should be disabled.
  @return initialized object
  */
 - (id) initWithHttpClient:(PA2CoreHttpClient*)httpClient
           sessionProvider:(id<PowerAuthCoreSessionProvider>)sessionProvider
                  delegate:(id<PA2GetActivationStatusTaskDelegate>)delegate
-               sharedLock:(id<NSLocking>)sharedLock
-           disableUpgrade:(BOOL)disableUpgrade;
+               sharedLock:(id<NSLocking>)sharedLock;
 
 
 @end

--- a/proj-xcode/PowerAuth2/private/PA2GetActivationStatusTask.m
+++ b/proj-xcode/PowerAuth2/private/PA2GetActivationStatusTask.m
@@ -32,7 +32,6 @@
     PA2CoreHttpClient * _client;
     id<PowerAuthCoreSessionProvider> _sessionProvider;
     __weak id<PA2GetActivationStatusTaskDelegate> _delegate;
-    BOOL _disableUpgrade;
     
     // Runtime variables
     NSInteger _upgradeAttempts;
@@ -44,14 +43,12 @@
           sessionProvider:(id<PowerAuthCoreSessionProvider>)sessionProvider
                  delegate:(id<PA2GetActivationStatusTaskDelegate>)delegate
                sharedLock:(id<NSLocking>)sharedLock
-           disableUpgrade:(BOOL)disableUpgrade
 {
     self = [super initWithSharedLock:sharedLock taskName:@"GetActivationStatus"];
     if (self) {
         _client = httpClient;
         _sessionProvider = sessionProvider;
         _delegate = delegate;
-        _disableUpgrade = disableUpgrade;
         
         _upgradeAttempts = 3;
         _disableAutoCancel = NO;

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKBaseTests.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKBaseTests.m
@@ -2120,6 +2120,7 @@
         }];
         XCTAssertNotNil(operation);
     }];
+    XCTAssertNotNil(header);
     result = [_helper validateTokenHeader:header activationId:activationData.activationId expectedResult:YES];
     
     // Now ask for the same token

--- a/proj-xcode/PowerAuthCore/PowerAuthCoreConfig.h
+++ b/proj-xcode/PowerAuthCore/PowerAuthCoreConfig.h
@@ -43,6 +43,8 @@ typedef NS_ENUM(int, PowerAuthCoreAlgorithm) {
 @property (nonatomic, strong, readonly, nonnull) NSString * instanceId;
 /// Contains device specific data provided in the configuration construction.
 @property (nonatomic, strong, readonly, nonnull) NSData * deviceSpecificData;
+/// Contains algorithm provided in the configuration construction.
+@property (nonatomic, readonly) PowerAuthCoreAlgorithm algorithm;
 
 /// Create instance of `PowerAuthCoreConfig` object from the provided parameters.
 ///

--- a/proj-xcode/PowerAuthCore/PowerAuthCoreConfig.mm
+++ b/proj-xcode/PowerAuthCore/PowerAuthCoreConfig.mm
@@ -49,6 +49,11 @@
     return cc7::objc::CopyToNSData(_config->deviceSpecificData());
 }
 
+- (PowerAuthCoreAlgorithm) algorithm
+{
+    return static_cast<PowerAuthCoreAlgorithm>(_config->algorithm());
+}
+
 + (BOOL) validateConfiguration:(nonnull NSString*)configuration
                      algorithm:(PowerAuthCoreAlgorithm)algorithm
 {

--- a/proj-xcode/PowerAuthCore/PowerAuthCoreCredentials.h
+++ b/proj-xcode/PowerAuthCore/PowerAuthCoreCredentials.h
@@ -17,6 +17,7 @@
 #import <PowerAuthCore/PowerAuthCorePassword.h>
 #import <PowerAuthCore/PowerAuthCoreData.h>
 
+/// Object representing user's credentials for authentication.
 @interface PowerAuthCoreCredentials : NSObject
 
 /// Default construction is unavailable

--- a/proj-xcode/PowerAuthCore/PowerAuthCorePrivateImpl.h
+++ b/proj-xcode/PowerAuthCore/PowerAuthCorePrivateImpl.h
@@ -60,8 +60,8 @@
 typedef id(^PowerAuthCoreResponseBuilder)(const powerAuth::ResponseObjectPtr& response);
 
 @interface PowerAuthCoreRequest (Private)
-- (id) initWithRequest:(powerAuth::RequestPtr&)request;
-- (id) initWithRequest:(powerAuth::RequestPtr&)request
+- (id) initWithRequest:(const powerAuth::RequestPtr&)request;
+- (id) initWithRequest:(const powerAuth::RequestPtr&)request
            withBuilder:(PowerAuthCoreResponseBuilder)builder;
 @end
 

--- a/proj-xcode/PowerAuthCore/PowerAuthCoreRequest.h
+++ b/proj-xcode/PowerAuthCore/PowerAuthCoreRequest.h
@@ -51,7 +51,7 @@ typedef void(^PowerAuthCoreRequestCallback)(id _Nullable response, NSError * _Nu
 /// and `failure` property is updated with the error.
 @property (nonatomic, readonly, strong, nonnull) NSData* requestBody;
 
-/// Contains HTTP request body. Be aware, that you have to call `prepareRequest()` method
+/// Contains HTTP request headers. Be aware, that you have to call `prepareRequest()` method
 /// to prepare the headers. If the request is not prepared, then contains `nil` and `failure`
 /// property is updated with the error.
 @property (nonatomic, readonly, strong, nonnull) NSArray<PowerAuthCoreHttpHeader*>* requestHeaders;

--- a/proj-xcode/PowerAuthCore/PowerAuthCoreRequest.mm
+++ b/proj-xcode/PowerAuthCore/PowerAuthCoreRequest.mm
@@ -30,7 +30,7 @@
     id _responseJson;
 }
 
-- (id) initWithRequest:(powerAuth::RequestPtr&)request
+- (id) initWithRequest:(const powerAuth::RequestPtr&)request
            withBuilder:(PowerAuthCoreResponseBuilder)builder
 {
     if (!request) {
@@ -38,13 +38,13 @@
     }
     self = [super init];
     if (self) {
-        _request = std::move(request);
+        _request = request;
         _responseBuilder = builder;
     }
     return self;
 }
 
-- (id) initWithRequest:(powerAuth::RequestPtr&)request
+- (id) initWithRequest:(const powerAuth::RequestPtr&)request
 {
     return [self initWithRequest:request withBuilder:nil];
 }
@@ -161,7 +161,9 @@
             _responseObject = _responseBuilder(_request->getResponseObject());
             _responseBuilder = nil;
         }
-        _responseJson = cc7::objc::JsonValueToObjC(_request->getResponseJson());
+        if (_request->isPublicResponseJson()) {
+            _responseJson = cc7::objc::JsonValueToObjC(_request->getResponseJson());
+        }
         return YES;
     } catch (...) {
         _failure = powerAuth::BuildNSErrorFromException();

--- a/src/Android.mk
+++ b/src/Android.mk
@@ -206,7 +206,13 @@ LOCAL_SRC_FILES := \
 	PowerAuthJni/NativeModuleJNI.cpp \
 	PowerAuthJni/NativeObjectJNI.cpp \
 	\
-	PowerAuthJni/SessionJNI.cpp \
+	PowerAuthJni/CoreConfigJNI.cpp \
+	PowerAuthJni/CoreSessionJNI.cpp \
+	PowerAuthJni/CoreRequestJNI.cpp \
+	PowerAuthJni/CoreTaskJNI.cpp \
+	PowerAuthJni/CoreCredentialsJNI.cpp \
+	PowerAuthJni/CoreEncryptorJNI.cpp \
+	PowerAuthJni/CoreEncryptorFactoryJNI.cpp \
 	PowerAuthJni/PasswordJNI.cpp \
 	PowerAuthJni/ActivationCodeUtilJNI.cpp \
 	PowerAuthJni/TokenCalculatorJNI.cpp \

--- a/src/PowerAuth/Request.cpp
+++ b/src/PowerAuth/Request.cpp
@@ -72,6 +72,11 @@ bool Request::isAuthenticated() const noexcept
     return _endpoint.isAuthenticated();
 }
 
+bool Request::isPublicResponseJson() const noexcept
+{
+    return _endpoint.isPublicResponseJson();
+}
+
 EncryptorScope Request::encryptorScope() const
 {
     return EncryptorSpec::specForId(_endpoint.encryptorId)->scope;

--- a/src/PowerAuth/Task.cpp
+++ b/src/PowerAuth/Task.cpp
@@ -207,7 +207,11 @@ void Task::setRequestCompleted(const Request &request) noexcept
             if (_state == State::PENDING) {
                 if (is_primary) {
                     _response_object = request.getResponseObject();
-                    _response_json = request.getResponseJson();
+                    if (request.isPublicResponseJson()) {
+                        _response_json = request.getResponseJson();
+                    } else {
+                        _response_json = cc7::json::JsonValue();
+                    }
                 }
                 onRequestSuccess(request);
             }

--- a/src/PowerAuth/request/EndpointSpec.cpp
+++ b/src/PowerAuth/request/EndpointSpec.cpp
@@ -21,7 +21,8 @@ namespace powerAuth {
 namespace v4 {
 
 const EndpointSpec Endpoint_SystemStatus {
-    Version_V4, "/pa/v4/status", "", EncryptorId::NONE, EndpointSpec::FL_ALLOWED_IN_UPGRADE
+    Version_V4, "/pa/v4/status", "", EncryptorId::NONE,
+    EndpointSpec::FL_ALLOWED_IN_UPGRADE | EndpointSpec::FL_PUBLIC_RESPONSE_JSON
 };
 
 const EndpointSpec Endpoint_TemporaryKey {
@@ -33,7 +34,7 @@ const EndpointSpec Endpoint_ActivationCreate {
 };
 
 const EndpointSpec Endpoint_ActivationConfirm {
-    Version_V4, "/pa/v4/activation/confirm", "/pa/activation/confirm", EncryptorId::NONE, EndpointSpec::Flags::FL_PENDING_REGISTRATION
+    Version_V4, "/pa/v4/activation/confirm", "/pa/activation/confirm", EncryptorId::NONE, EndpointSpec::FL_PENDING_REGISTRATION
 };
 
 const EndpointSpec Endpoint_ActivationRemove {
@@ -41,7 +42,9 @@ const EndpointSpec Endpoint_ActivationRemove {
 };
 
 const EndpointSpec Endpoint_ActivationStatus {
-    Version_V4, "/pa/v4/activation/status", "", EncryptorId::ACTIVATION_SCOPE_GENERIC, EndpointSpec::Flags::FL_PENDING_REGISTRATION // NOTE: V4 allows status during registration
+    Version_V4, "/pa/v4/activation/status", "", EncryptorId::ACTIVATION_SCOPE_GENERIC,
+    // NOTE: V4 allows status during registration
+    EndpointSpec::FL_PENDING_REGISTRATION | EndpointSpec::FL_PUBLIC_RESPONSE_JSON
 };
 
 const EndpointSpec Endpoint_PasswordChange {
@@ -61,7 +64,7 @@ const EndpointSpec Endpoint_VaultUnlock {
 };
 
 const EndpointSpec Endpoint_TokenCreate {
-    Version_V4, "/pa/v4/token/create", "/pa/token/create", EncryptorId::CREATE_TOKEN
+    Version_V4, "/pa/v4/token/create", "/pa/token/create", EncryptorId::CREATE_TOKEN, EndpointSpec::FL_PUBLIC_RESPONSE_JSON
 };
 
 const EndpointSpec Endpoint_TokenRemove {
@@ -84,7 +87,7 @@ const EndpointSpec Endpoint_ProtocolUpgradeConfirm {
 };
 
 const EndpointSpec Endpoint_UserInfo {
-    Version_V4, "/pa/v4/user/info", "", EncryptorId::ACTIVATION_SCOPE_GENERIC
+    Version_V4, "/pa/v4/user/info", "", EncryptorId::ACTIVATION_SCOPE_GENERIC, EndpointSpec::FL_PUBLIC_RESPONSE_JSON
 };
 
 } // namespace v4
@@ -92,7 +95,8 @@ const EndpointSpec Endpoint_UserInfo {
 namespace v3 {
 
 const EndpointSpec Endpoint_SystemStatus {
-    Version_V3, "/pa/v3/status", "", EncryptorId::NONE, EndpointSpec::FL_ALLOWED_IN_UPGRADE
+    Version_V3, "/pa/v3/status", "", EncryptorId::NONE,
+    EndpointSpec::FL_ALLOWED_IN_UPGRADE | EndpointSpec::FL_PUBLIC_RESPONSE_JSON
 };
 
 const EndpointSpec Endpoint_TemporaryKey {
@@ -104,7 +108,7 @@ const EndpointSpec Endpoint_ActivationCreate {
 };
 
 const EndpointSpec Endpoint_ActivationStatus {
-    Version_V3, "/pa/v3/activation/status", "", EncryptorId::NONE
+    Version_V3, "/pa/v3/activation/status", "", EncryptorId::NONE, EndpointSpec::FL_PUBLIC_RESPONSE_JSON
 };
 
 const EndpointSpec Endpoint_ActivationRemove {
@@ -120,7 +124,7 @@ const EndpointSpec Endpoint_VaultUnlock {
 };
 
 const EndpointSpec Endpoint_TokenCreate {
-    Version_V3, "/pa/v3/token/create", "/pa/token/create", EncryptorId::CREATE_TOKEN
+    Version_V3, "/pa/v3/token/create", "/pa/token/create", EncryptorId::CREATE_TOKEN, EndpointSpec::FL_PUBLIC_RESPONSE_JSON
 };
 
 const EndpointSpec Endpoint_TokenRemove {
@@ -128,7 +132,7 @@ const EndpointSpec Endpoint_TokenRemove {
 };
 
 const EndpointSpec Endpoint_UserInfo {
-    Version_V3, "/pa/v3/user/info", "", EncryptorId::ACTIVATION_SCOPE_GENERIC
+    Version_V3, "/pa/v3/user/info", "", EncryptorId::ACTIVATION_SCOPE_GENERIC, EndpointSpec::FL_PUBLIC_RESPONSE_JSON
 };
 
 } // namespace v3

--- a/src/PowerAuth/request/EndpointSpec.h
+++ b/src/PowerAuth/request/EndpointSpec.h
@@ -24,12 +24,20 @@ struct EndpointSpec
 {
     enum Flags
     {
+        /// If set, then the request must be processed in serialized queue.
         FL_SERIALIZED               = 1 << 0,
+        /// If set, then request is allowed while protocol upgrade is pending.
         FL_ALLOWED_IN_UPGRADE       = 1 << 1,
+        /// If set, then request require synchronized time.
         FL_SYNCHRONIZE_TIME         = 1 << 2,
+        /// If set, then the request and response objects are not wrapped in standard RESTFul API objects.
         FL_NOT_WRAPPED              = 1 << 3,
+        /// If set, then request is allowed while registration is pending.
         FL_PENDING_REGISTRATION     = 1 << 4,
-        FL_FORCE_ENCRYPTION_HEADER  = 1 << 5
+        /// If set, then encryption header is enforced in request.
+        FL_FORCE_ENCRYPTION_HEADER  = 1 << 5,
+        /// If set, then response JSON is marshaled to managed environments, such as Java or Objective-C.
+        FL_PUBLIC_RESPONSE_JSON     = 1 << 6
     };
     
     ProtocolVersion version;
@@ -62,6 +70,11 @@ struct EndpointSpec
     bool isAllowedInPendingRegistration() const noexcept
     {
         return (flags & FL_PENDING_REGISTRATION) == FL_PENDING_REGISTRATION;
+    }
+    
+    bool isPublicResponseJson() const noexcept
+    {
+        return (flags & FL_PUBLIC_RESPONSE_JSON) == FL_PUBLIC_RESPONSE_JSON;
     }
     
     bool requireSynchronizedTime() const noexcept

--- a/src/PowerAuthJni/ActivationCodeUtilJNI.cpp
+++ b/src/PowerAuthJni/ActivationCodeUtilJNI.cpp
@@ -48,7 +48,7 @@ CC7_JNI_STATIC_METHOD_PARAMS(jobject, parseFromActivationCode, jstring activatio
             return nullptr;
         }
         const auto& spec = NH_SPECS().activationCode;
-        return jni.createObject(spec.methods.initStringString,
+        return jni.createObject(spec.methods.init,
                                 jni.toJava(components.activationCode),
                                 jni.toJavaNullable(components.activationSignature));
     }

--- a/src/PowerAuthJni/ClassSpecs.cpp
+++ b/src/PowerAuthJni/ClassSpecs.cpp
@@ -31,9 +31,19 @@ ClassSpecs ClassSpecs::buildSpecs(JNI &jni)
         spec.coreCredentials = jni.buildNativeHandleSpec("io/getlime/security/powerauth/core/CoreCredentials");
         spec.coreEncryptor = jni.buildNativeHandleSpec("io/getlime/security/powerauth/core/CoreEncryptor");
         spec.coreEncryptorFactory = jni.buildNativeHandleSpec("io/getlime/security/powerauth/core/CoreEncryptorFactory");
-        spec.coreRequest = jni.buildNativeHandleSpec("io/getlime/security/powerauth/core/CoreRequest");
-        spec.coreTask = jni.buildNativeHandleSpec("io/getlime/security/powerauth/core/CoreTask");
-
+        // CoreRequest
+        spec.coreRequest.native = jni.buildNativeHandleSpec("io/getlime/security/powerauth/core/CoreRequest");
+        auto request = jni.fromJava(spec.coreRequest.native.classRef);
+        spec.coreRequest.responseBuilderHandle = request.findField("responseBuilderHandle", "J");
+        spec.coreRequest.responseObject = request.findField("responseObject", "Ljava/lang/Object;");
+        spec.coreRequest.responseJson = request.findField("responseJson", "Ljava/lang/Object;");
+        // CoreTask
+        spec.coreTask.native = jni.buildNativeHandleSpec("io/getlime/security/powerauth/core/CoreTask");
+        auto task = jni.fromJava(spec.coreTask.native.classRef);
+        spec.coreTask.responseIsCaptured = task.findField("responseIsCaptured", "Z");
+        spec.coreRequest.responseBuilderHandle = request.findField("responseBuilderHandle", "J");
+        spec.coreTask.responseObject = task.findField("responseObject", "Ljava/lang/Object;");
+        spec.coreTask.responseJson = task.findField("responseJson", "Ljava/lang/Object;");
         // Custom objects
         spec.secureData = jni.buildClassSpec<SecureData>("io/getlime/security/powerauth/core/SecureData");
         spec.coreHttpHeader = jni.buildClassSpec<CoreHttpHeader>("io/getlime/security/powerauth/core/CoreHttpHeader");
@@ -112,8 +122,8 @@ ClassSpecs ClassSpecs::buildSpecs(JNI &jni)
         jni.releaseSpec(spec.coreCredentials);
         jni.releaseSpec(spec.coreEncryptor);
         jni.releaseSpec(spec.coreEncryptorFactory);
-        jni.releaseSpec(spec.coreRequest);
-        jni.releaseSpec(spec.coreTask);
+        jni.releaseSpec(spec.coreRequest.native);
+        jni.releaseSpec(spec.coreTask.native);
         // custom objects
         jni.releaseSpec(spec.coreHttpHeader);
         jni.releaseSpec(spec.coreDevicePublicKeyData);

--- a/src/PowerAuthJni/ClassSpecs.cpp
+++ b/src/PowerAuthJni/ClassSpecs.cpp
@@ -22,28 +22,63 @@ ClassSpecs ClassSpecs::buildSpecs(JNI &jni)
 {
     ClassSpecs spec {};
     try {
+        // Resolve all objects used in JNI wrapper
+
         // Handle based objects
         spec.password = jni.buildNativeHandleSpec("io/getlime/security/powerauth/core/Password");
-        spec.session = jni.buildNativeHandleSpec("io/getlime/security/powerauth/core/Session");
-        spec.ecPublicKey = jni.buildNativeHandleSpec("io/getlime/security/powerauth/core/EcPublicKey");
-        spec.ecPrivateKey = jni.buildNativeHandleSpec("io/getlime/security/powerauth/core/EcPrivateKey");
+        spec.coreConfig = jni.buildNativeHandleSpec("io/getlime/security/powerauth/core/CoreConfig");
+        spec.coreSession = jni.buildNativeHandleSpec("io/getlime/security/powerauth/core/CoreSession");
+        spec.coreCredentials = jni.buildNativeHandleSpec("io/getlime/security/powerauth/core/CoreCredentials");
+        spec.coreEncryptor = jni.buildNativeHandleSpec("io/getlime/security/powerauth/core/CoreEncryptor");
+        spec.coreEncryptorFactory = jni.buildNativeHandleSpec("io/getlime/security/powerauth/core/CoreEncryptorFactory");
+        spec.coreRequest = jni.buildNativeHandleSpec("io/getlime/security/powerauth/core/CoreRequest");
+        spec.coreTask = jni.buildNativeHandleSpec("io/getlime/security/powerauth/core/CoreTask");
+
         // Custom objects
-        spec.ecKeyPair = jni.buildClassSpec<EcKeyPair>("io/getlime/security/powerauth/core/EcKeyPair");
         spec.secureData = jni.buildClassSpec<SecureData>("io/getlime/security/powerauth/core/SecureData");
-        spec.activationCode = jni.buildClassSpec<ActivationCode>("io/getlime/security/powerauth/core/ActivationCode");
+        spec.coreHttpHeader = jni.buildClassSpec<CoreHttpHeader>("io/getlime/security/powerauth/core/CoreHttpHeader");
+        spec.coreDevicePublicKeyData = jni.buildClassSpec<CoreDevicePublicKeyData>("io/getlime/security/powerauth/core/CoreDevicePublicKeyData");
+
         // Enums
-        spec.powerAuthAlgorithm = jni.buildConstantRangeSpec("io/getlime/security/powerauth/core/Algorithm", {
-            "LEGACY_P256",
-            "EC_P384",
-            "EC_P384_ML_L3",
-            "EC_P384_ML_L5"
-        });
         spec.protocolVersion = jni.buildConstantSetSpec("io/getlime/security/powerauth/core/ProtocolVersion", {
             "NA",
             "V2",
             "V3",
             "V4"
         });
+        spec.coreAlgorithm = jni.buildConstantRangeSpec("io/getlime/security/powerauth/core/CoreAlgorithm", {
+            "LEGACY_P256",
+            "EC_P384",
+            "EC_P384_ML_L3",
+            "EC_P384_ML_L5"
+        });
+        spec.coreSignatureKeyId = jni.buildConstantSetSpec("io/getlime/security/powerauth/core/CoreSignatureKeyId", {
+            "MASTER",
+            "MASTER_EC",
+            "MASTER_ML_DSA",
+            "SERVER",
+            "SERVER_EC",
+            "SERVER_ML_DSA",
+            "DEVICE",
+            "DEVICE_EC",
+            "DEVICE_ML_DSA",
+            "MAC_PERSONALIZED"
+        });
+        spec.coreSignatureKeyType = jni.buildConstantRangeSpec("io/getlime/security/powerauth/core/CoreSignatureKeyType", {
+            "EC",
+            "ML_DSA"
+        });
+        spec.coreDevicePublicKeyFormat = jni.buildConstantRangeSpec("io/getlime/security/powerauth/core/CoreDevicePublicKeyFormat", {
+            "DER",
+            "RAW"
+        });
+        spec.coreEncryptorScope = jni.buildConstantRangeSpec("io/getlime/security/powerauth/core/CoreEncryptorScope", {
+            "NONE",
+            "APPLICATION",
+            "ACTIVATION"
+        });
+
+        // Exceptions
         spec.coreErrorCode = jni.buildConstantRangeSpec("io/getlime/security/powerauth/core/CoreErrorCode", {
             "MISSING_ACTIVATION",
             "WRONG_ACTIVATION_STATE",
@@ -60,20 +95,44 @@ ClassSpecs ClassSpecs::buildSpecs(JNI &jni)
             "PENDING_PROTOCOL_UPGRADE",
             "OTHER"
         });
-        // Exceptions
         spec.coreException = jni.buildClassSpec<CoreException>("io/getlime/security/powerauth/core/CoreException");
+
+        // Deprecated
+        spec.ecKeyPair = jni.buildClassSpec<EcKeyPair>("io/getlime/security/powerauth/core/EcKeyPair");
+        spec.ecPublicKey = jni.buildNativeHandleSpec("io/getlime/security/powerauth/core/EcPublicKey");
+        spec.ecPrivateKey = jni.buildNativeHandleSpec("io/getlime/security/powerauth/core/EcPrivateKey");
+        spec.activationCode = jni.buildClassSpec<ActivationCode>("io/getlime/security/powerauth/core/ActivationCode");
+
     } catch (...) {
         // Cleanup already resolved classes
+        // handle based
         jni.releaseSpec(spec.password);
-        jni.releaseSpec(spec.session);
-        jni.releaseSpec(spec.ecPublicKey);
-        jni.releaseSpec(spec.ecPrivateKey);
-        jni.releaseSpec(spec.ecKeyPair);
+        jni.releaseSpec(spec.coreConfig);
+        jni.releaseSpec(spec.coreSession);
+        jni.releaseSpec(spec.coreCredentials);
+        jni.releaseSpec(spec.coreEncryptor);
+        jni.releaseSpec(spec.coreEncryptorFactory);
+        jni.releaseSpec(spec.coreRequest);
+        jni.releaseSpec(spec.coreTask);
+        // custom objects
+        jni.releaseSpec(spec.coreHttpHeader);
+        jni.releaseSpec(spec.coreDevicePublicKeyData);
         jni.releaseSpec(spec.secureData);
-        jni.releaseSpec(spec.activationCode);
+        // enums
         jni.releaseSpec(spec.protocolVersion);
+        jni.releaseSpec(spec.coreAlgorithm);
+        jni.releaseSpec(spec.coreSignatureKeyId);
+        jni.releaseSpec(spec.coreSignatureKeyType);
+        jni.releaseSpec(spec.coreDevicePublicKeyFormat);
+        jni.releaseSpec(spec.coreEncryptorScope);
+        // exception
         jni.releaseSpec(spec.coreErrorCode);
         jni.releaseSpec(spec.coreException);
+        // deprecated
+        jni.releaseSpec(spec.ecKeyPair);
+        jni.releaseSpec(spec.ecPublicKey);
+        jni.releaseSpec(spec.ecPrivateKey);
+        jni.releaseSpec(spec.activationCode);
         // rethrow the exception
         std::rethrow_exception(std::current_exception());
     }

--- a/src/PowerAuthJni/ClassSpecs.h
+++ b/src/PowerAuthJni/ClassSpecs.h
@@ -31,18 +31,18 @@ struct ClassSpecs
     {
         struct Methods
         {
-            JniMethod initBytes;
+            JniInitMethod initBytes;
         };
-        static constexpr JniMethodSpec methodSpecs[1] = {
-                { "<init>", "([B)V", offsetof(Methods, initBytes) }
+        static constexpr JniMethodSpec methodSpecs[] = {
+                JniMethodSpec::constructor("([B)V", offsetof(Methods, initBytes))
         };
 
         struct Fields
         {
             jfieldID sensitiveData;
         };
-        static constexpr JniFieldSpec fieldSpecs[1] {
-                { "sensitiveData", "[B", offsetof(Fields, sensitiveData) }
+        static constexpr JniFieldSpec fieldSpecs[] {
+            JniFieldSpec::field("sensitiveData", "[B", offsetof(Fields, sensitiveData))
         };
 
         jclass classRef;
@@ -56,46 +56,38 @@ struct ClassSpecs
     {
         struct Methods
         {
-            cc7::jni::JniMethod init;
+            cc7::jni::JniInitMethod init;
         };
-        static constexpr JniMethodSpec methodSpecs[1] = {
-                { "<init>", "(Ljava/lang/String;Ljava/lang/String;)V", offsetof(Methods, init) }
+        static constexpr JniMethodSpec methodSpecs[] = {
+                JniMethodSpec::constructor("(Ljava/lang/String;Ljava/lang/String;)V", offsetof(Methods, init))
         };
-
-        struct Fields {};
-        static constexpr JniFieldSpec fieldSpecs[] {};
 
         jclass classRef;
         Methods methods;
-        Fields fields;
     };
 
     struct CoreDevicePublicKeyData
     {
         struct Methods
         {
-            cc7::jni::JniMethod init;
+            cc7::jni::JniInitMethod init;
         };
-        static constexpr JniMethodSpec methodSpecs[1] = {
-                { "<init>", "(ILjava/lang/String;[B)V", offsetof(Methods, init) }
+        static constexpr JniMethodSpec methodSpecs[] = {
+                JniMethodSpec::constructor("(ILjava/lang/String;[B)V", offsetof(Methods, init))
         };
-
-        struct Fields {};
-        static constexpr JniFieldSpec fieldSpecs[] {};
 
         jclass classRef;
         Methods methods;
-        Fields fields;
     };
 
     struct ActivationCode
     {
         struct Methods
         {
-            cc7::jni::JniMethod init;
+            cc7::jni::JniInitMethod init;
         };
-        static constexpr JniMethodSpec methodSpecs[1] = {
-                { "<init>", "(Ljava/lang/String;Ljava/lang/String;)V", offsetof(Methods, init) }
+        static constexpr JniMethodSpec methodSpecs[] = {
+                JniMethodSpec::constructor("(Ljava/lang/String;Ljava/lang/String;)V", offsetof(Methods, init))
         };
 
         struct Fields
@@ -103,9 +95,9 @@ struct ClassSpecs
             jfieldID activationCode;
             jfieldID activationSignature;
         };
-        static constexpr JniFieldSpec fieldSpecs[2] {
-                { "activationCode", "Ljava/lang/String;", offsetof(Fields, activationCode) },
-                { "activationSignature", "Ljava/lang/String;", offsetof(Fields, activationSignature) }
+        static constexpr JniFieldSpec fieldSpecs[] {
+            JniFieldSpec::field("activationCode", "Ljava/lang/String;", offsetof(Fields, activationCode)),
+            JniFieldSpec::field("activationSignature", "Ljava/lang/String;", offsetof(Fields, activationSignature))
         };
 
         jclass classRef;
@@ -120,19 +112,15 @@ struct ClassSpecs
     {
         struct Methods
         {
-            cc7::jni::JniMethod init;
+            cc7::jni::JniInitMethod init;
         };
         static constexpr JniMethodSpec methodSpecs[1] = {
                 // constructor: EcKeyPair(EcPrivateKey, EcPublicKey)
-                { "<init>", "(Lio/getlime/security/powerauth/core/EcPrivateKey;Lio/getlime/security/powerauth/core/EcPublicKey;)V", offsetof(Methods, init) }
+                JniMethodSpec::constructor("(Lio/getlime/security/powerauth/core/EcPrivateKey;Lio/getlime/security/powerauth/core/EcPublicKey;)V", offsetof(Methods, init))
         };
-
-        struct Fields {};
-        static constexpr JniFieldSpec fieldSpecs[] {};
 
         jclass classRef;
         Methods methods;
-        Fields fields;
     };
 
     // Exceptions
@@ -142,21 +130,35 @@ struct ClassSpecs
     {
         struct Methods
         {
-            cc7::jni::JniMethod initCodeMessageInfo;
+            cc7::jni::JniInitMethod initCodeMessageInfo;
         };
         static constexpr JniMethodSpec methodSpecs[1] = {
                 // constructor: CoreException(int, String, String[])
-                { "<init>", "(ILjava/lang/String;[Ljava/lang/String;)V", offsetof(Methods, initCodeMessageInfo) },
+                JniMethodSpec::constructor("(ILjava/lang/String;[Ljava/lang/String;)V", offsetof(Methods, initCodeMessageInfo))
         };
-
-        struct Fields {};
-        static constexpr JniFieldSpec fieldSpecs[] {};
 
         jclass classRef;
         Methods methods;
-        Fields fields;
     };
 
+    // io.getlime.security.powerauth.core.CoreRequest
+    struct CoreRequest
+    {
+        JniCommon::NativeHandleClass native;
+        jfieldID responseBuilderHandle;
+        jfieldID responseObject;
+        jfieldID responseJson;
+    };
+
+    // io.getlime.security.powerauth.core.CoreTask
+    struct CoreTask
+    {
+        JniCommon::NativeHandleClass native;
+        jfieldID responseIsCaptured;
+        jfieldID responseBuilderHandle;
+        jfieldID responseObject;
+        jfieldID responseJson;
+    };
 
     // Deprecated?
     EcKeyPair ecKeyPair;
@@ -184,8 +186,8 @@ struct ClassSpecs
     JniCommon::NativeHandleClass coreCredentials;
     JniCommon::NativeHandleClass coreEncryptor;
     JniCommon::NativeHandleClass coreEncryptorFactory;
-    JniCommon::NativeHandleClass coreRequest;
-    JniCommon::NativeHandleClass coreTask;
+    CoreRequest coreRequest;
+    CoreTask coreTask;
 
     // exception
     JniCommon::ConstantRangeSpec coreErrorCode;

--- a/src/PowerAuthJni/ClassSpecs.h
+++ b/src/PowerAuthJni/ClassSpecs.h
@@ -51,14 +51,51 @@ struct ClassSpecs
     };
 
     // Model
+
+    struct CoreHttpHeader
+    {
+        struct Methods
+        {
+            cc7::jni::JniMethod init;
+        };
+        static constexpr JniMethodSpec methodSpecs[1] = {
+                { "<init>", "(Ljava/lang/String;Ljava/lang/String;)V", offsetof(Methods, init) }
+        };
+
+        struct Fields {};
+        static constexpr JniFieldSpec fieldSpecs[] {};
+
+        jclass classRef;
+        Methods methods;
+        Fields fields;
+    };
+
+    struct CoreDevicePublicKeyData
+    {
+        struct Methods
+        {
+            cc7::jni::JniMethod init;
+        };
+        static constexpr JniMethodSpec methodSpecs[1] = {
+                { "<init>", "(ILjava/lang/String;[B)V", offsetof(Methods, init) }
+        };
+
+        struct Fields {};
+        static constexpr JniFieldSpec fieldSpecs[] {};
+
+        jclass classRef;
+        Methods methods;
+        Fields fields;
+    };
+
     struct ActivationCode
     {
         struct Methods
         {
-            cc7::jni::JniMethod initStringString;
+            cc7::jni::JniMethod init;
         };
         static constexpr JniMethodSpec methodSpecs[1] = {
-                { "<init>", "(Ljava/lang/String;Ljava/lang/String;)V", offsetof(Methods, initStringString) }
+                { "<init>", "(Ljava/lang/String;Ljava/lang/String;)V", offsetof(Methods, init) }
         };
 
         struct Fields
@@ -121,20 +158,38 @@ struct ClassSpecs
     };
 
 
+    // Deprecated?
     EcKeyPair ecKeyPair;
-    SecureData secureData;
-    ActivationCode activationCode;
-    CoreException coreException;
-
-    // enums
-    JniCommon::ConstantRangeSpec powerAuthAlgorithm;
-    JniCommon::ConstantRangeSpec coreErrorCode;
-    JniCommon::ConstantSetSpec protocolVersion;
-    // handle based objects
     JniCommon::NativeHandleClass ecPublicKey;
     JniCommon::NativeHandleClass ecPrivateKey;
+    ActivationCode activationCode;
+
+    // model
+    SecureData secureData;
+    CoreHttpHeader coreHttpHeader;
+    CoreDevicePublicKeyData coreDevicePublicKeyData;
+
+    // enums
+    JniCommon::ConstantRangeSpec coreAlgorithm;
+    JniCommon::ConstantSetSpec coreSignatureKeyId;
+    JniCommon::ConstantRangeSpec coreSignatureKeyType;
+    JniCommon::ConstantRangeSpec coreDevicePublicKeyFormat;
+    JniCommon::ConstantSetSpec protocolVersion;
+    JniCommon::ConstantRangeSpec coreEncryptorScope;
+
+    // handle based objects
     JniCommon::NativeHandleClass password;
-    JniCommon::NativeHandleClass session;
+    JniCommon::NativeHandleClass coreConfig;
+    JniCommon::NativeHandleClass coreSession;
+    JniCommon::NativeHandleClass coreCredentials;
+    JniCommon::NativeHandleClass coreEncryptor;
+    JniCommon::NativeHandleClass coreEncryptorFactory;
+    JniCommon::NativeHandleClass coreRequest;
+    JniCommon::NativeHandleClass coreTask;
+
+    // exception
+    JniCommon::ConstantRangeSpec coreErrorCode;
+    CoreException coreException;
 
     /// Build ClassSpecs structure at JNI initialization.
     static ClassSpecs buildSpecs(JNI& jni);

--- a/src/PowerAuthJni/CoreConfigJNI.cpp
+++ b/src/PowerAuthJni/CoreConfigJNI.cpp
@@ -61,7 +61,7 @@ CC7_JNI_METHOD(jstring, getInstanceId)
     {
         return jni.toJava(THIS_OBJ()->instanceId());
     }
-    NH_CATCH(nullptr)
+    NH_CATCH_RT_ONLY(nullptr)
 }
 
 CC7_JNI_METHOD(jbyteArray, getDeviceSpecificData)
@@ -70,7 +70,7 @@ CC7_JNI_METHOD(jbyteArray, getDeviceSpecificData)
     {
         return jni.toJava(THIS_OBJ()->deviceSpecificData());
     }
-    NH_CATCH(nullptr)
+    NH_CATCH_RT_ONLY(nullptr)
 }
 
 CC7_JNI_METHOD(jint, getAlgorithm)
@@ -81,7 +81,7 @@ CC7_JNI_METHOD(jint, getAlgorithm)
         auto config = jni.fromJava<Configuration>(spec.coreConfig, thiz);
         return jni.toJava(spec.coreAlgorithm, config->algorithm());
     }
-    NH_CATCH(0)
+    NH_CATCH_RT_ONLY(0)
 }
 
 CC7_JNI_MODULE_CLASS_END()

--- a/src/PowerAuthJni/CoreConfigJNI.cpp
+++ b/src/PowerAuthJni/CoreConfigJNI.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "NativeHelper.h"
+#include <PowerAuth/Configuration.h>
+
+// Package: io.getlime.security.powerauth.core
+#define CC7_JNI_CLASS_PATH          "io/getlime/security/powerauth/core"
+#define CC7_JNI_CLASS_PACKAGE       io_getlime_security_powerauth_core
+#define CC7_JNI_JAVA_CLASS          CoreConfig
+#define CC7_JNI_CPP_CLASS           Configuration
+#include <cc7/jni/JniModule.inl>
+
+using namespace powerAuth;
+
+CC7_JNI_MODULE_CLASS_BEGIN()
+
+#define THIS_OBJ()  jni.fromJava<CC7_JNI_CPP_CLASS>(NH_SPECS().coreConfig, thiz)
+
+CC7_JNI_STATIC_METHOD_PARAMS(jboolean, validateConfiguration, jstring configuration, jint algorithm)
+{
+    NH_TRY
+    {
+        return Configuration::validateSdkConfig(jni.fromJava(configuration),
+                                                jni.fromJava<PowerAuthSpec::Algorithm>(NH_SPECS().coreAlgorithm, algorithm));
+    }
+    NH_NO_THROW(false)
+}
+
+CC7_JNI_STATIC_METHOD_PARAMS(jobject, build, jstring configuration, jbyteArray deviceSpecificData, jstring instanceId, jint algorithm)
+{
+    NH_TRY
+    {
+        auto& spec = NH_SPECS();
+        auto cpp_alg = jni.fromJava<PowerAuthSpec::Algorithm>(spec.coreAlgorithm, algorithm);
+        auto cpp_config = Configuration::Builder(jni.fromJava(configuration), cpp_alg)
+                .withInstanceId(jni.fromJava(instanceId))
+                .withDeviceSpecificData(jni.fromJava(deviceSpecificData))
+                .build();
+        return jni.toJava(spec.coreConfig, cpp_config);
+    }
+    NH_CATCH(nullptr)
+}
+
+CC7_JNI_METHOD(jstring, getInstanceId)
+{
+    NH_TRY
+    {
+        return jni.toJava(THIS_OBJ()->instanceId());
+    }
+    NH_CATCH(nullptr)
+}
+
+CC7_JNI_METHOD(jbyteArray, getDeviceSpecificData)
+{
+    NH_TRY
+    {
+        return jni.toJava(THIS_OBJ()->deviceSpecificData());
+    }
+    NH_CATCH(nullptr)
+}
+
+CC7_JNI_METHOD(jint, getAlgorithm)
+{
+    NH_TRY
+    {
+        auto& spec = NH_SPECS();
+        auto config = jni.fromJava<Configuration>(spec.coreConfig, thiz);
+        return jni.toJava(spec.coreAlgorithm, config->algorithm());
+    }
+    NH_CATCH(0)
+}
+
+CC7_JNI_MODULE_CLASS_END()

--- a/src/PowerAuthJni/CoreCredentialsJNI.cpp
+++ b/src/PowerAuthJni/CoreCredentialsJNI.cpp
@@ -15,42 +15,49 @@
  */
 
 #include "NativeHelper.h"
+#include <PowerAuth/Credentials.h>
 
 // Package: io.getlime.security.powerauth.core
 #define CC7_JNI_CLASS_PATH          "io/getlime/security/powerauth/core"
 #define CC7_JNI_CLASS_PACKAGE       io_getlime_security_powerauth_core
-#define CC7_JNI_JAVA_CLASS          NativeObject
-#define CC7_JNI_CPP_CLASS           NA
+#define CC7_JNI_JAVA_CLASS          CoreCredentials
+#define CC7_JNI_CPP_CLASS           Credentials
 #include <cc7/jni/JniModule.inl>
 
 using namespace powerAuth;
-using namespace powerAuth::jni;
-using namespace cc7::jni;
 
 CC7_JNI_MODULE_CLASS_BEGIN()
 
-//
-// private native static void safeNativeDestroy(long handle);
-//
-CC7_JNI_STATIC_METHOD_PARAMS(void, safeNativeDestroy, jlong handle)
+#define THIS_OBJ()  jni.fromJava<CC7_JNI_CPP_CLASS>(NH_SPECS().coreConfig, thiz)
+
+CC7_JNI_STATIC_METHOD(jobject, possession)
 {
     NH_TRY
     {
-        jni.global().objectRegister().removeEntry(handle);
+        return jni.toJava(NH_SPECS().coreCredentials, Credentials::possession());
     }
-    NH_NO_THROW()
+    NH_CATCH_RT_ONLY(nullptr)
 }
 
-//
-// private native static boolean isNativeDestroyed(long handle);
-//
-CC7_JNI_STATIC_METHOD_PARAMS(jboolean, isNativeDestroyed, jlong handle)
+CC7_JNI_STATIC_METHOD_PARAMS(jobject, knowledge, jobject password)
 {
     NH_TRY
     {
-        return !jni.global().objectRegister().containsEntry(handle);
+        auto& spec = NH_SPECS();
+        auto cpp_password = jni.fromJava<Password>(spec.password, password);
+        return jni.toJava(spec.coreCredentials, Credentials::knowledge(cpp_password->passwordData()));
     }
-    NH_NO_THROW(true)
+    NH_CATCH_RT_ONLY(nullptr)
+}
+
+CC7_JNI_STATIC_METHOD_PARAMS(jobject, biometry, jobject secureData)
+{
+    NH_TRY
+    {
+        auto cpp_data = jni::CopyFromSecureData(jni, secureData);
+        return jni.toJava(NH_SPECS().coreCredentials, Credentials::knowledge(cpp_data));
+    }
+    NH_CATCH_RT_ONLY(nullptr)
 }
 
 CC7_JNI_MODULE_CLASS_END()

--- a/src/PowerAuthJni/CoreCredentialsJNI.cpp
+++ b/src/PowerAuthJni/CoreCredentialsJNI.cpp
@@ -28,7 +28,7 @@ using namespace powerAuth;
 
 CC7_JNI_MODULE_CLASS_BEGIN()
 
-#define THIS_OBJ()  jni.fromJava<CC7_JNI_CPP_CLASS>(NH_SPECS().coreConfig, thiz)
+#define THIS_OBJ()  jni.fromJava<CC7_JNI_CPP_CLASS>(NH_SPECS().coreCredentials, thiz)
 
 CC7_JNI_STATIC_METHOD(jobject, possession)
 {

--- a/src/PowerAuthJni/CoreEncryptorFactoryJNI.cpp
+++ b/src/PowerAuthJni/CoreEncryptorFactoryJNI.cpp
@@ -15,42 +15,19 @@
  */
 
 #include "NativeHelper.h"
+#include <PowerAuth/Encryptor.h>
 
 // Package: io.getlime.security.powerauth.core
 #define CC7_JNI_CLASS_PATH          "io/getlime/security/powerauth/core"
 #define CC7_JNI_CLASS_PACKAGE       io_getlime_security_powerauth_core
-#define CC7_JNI_JAVA_CLASS          NativeObject
-#define CC7_JNI_CPP_CLASS           NA
+#define CC7_JNI_JAVA_CLASS          CoreEncryptorFactory
+#define CC7_JNI_CPP_CLASS           IClientEncryptorFactory
 #include <cc7/jni/JniModule.inl>
 
 using namespace powerAuth;
-using namespace powerAuth::jni;
-using namespace cc7::jni;
 
 CC7_JNI_MODULE_CLASS_BEGIN()
 
-//
-// private native static void safeNativeDestroy(long handle);
-//
-CC7_JNI_STATIC_METHOD_PARAMS(void, safeNativeDestroy, jlong handle)
-{
-    NH_TRY
-    {
-        jni.global().objectRegister().removeEntry(handle);
-    }
-    NH_NO_THROW()
-}
-
-//
-// private native static boolean isNativeDestroyed(long handle);
-//
-CC7_JNI_STATIC_METHOD_PARAMS(jboolean, isNativeDestroyed, jlong handle)
-{
-    NH_TRY
-    {
-        return !jni.global().objectRegister().containsEntry(handle);
-    }
-    NH_NO_THROW(true)
-}
+#define THIS_OBJ()  jni.fromJava<CC7_JNI_CPP_CLASS>(NH_SPECS().coreEncryptor, thiz)
 
 CC7_JNI_MODULE_CLASS_END()

--- a/src/PowerAuthJni/CoreEncryptorFactoryJNI.cpp
+++ b/src/PowerAuthJni/CoreEncryptorFactoryJNI.cpp
@@ -28,6 +28,6 @@ using namespace powerAuth;
 
 CC7_JNI_MODULE_CLASS_BEGIN()
 
-#define THIS_OBJ()  jni.fromJava<CC7_JNI_CPP_CLASS>(NH_SPECS().coreEncryptor, thiz)
+#define THIS_OBJ()  jni.fromJava<CC7_JNI_CPP_CLASS>(NH_SPECS().coreEncryptorFactory, thiz)
 
 CC7_JNI_MODULE_CLASS_END()

--- a/src/PowerAuthJni/CoreEncryptorJNI.cpp
+++ b/src/PowerAuthJni/CoreEncryptorJNI.cpp
@@ -15,42 +15,19 @@
  */
 
 #include "NativeHelper.h"
+#include <PowerAuth/Encryptor.h>
 
 // Package: io.getlime.security.powerauth.core
 #define CC7_JNI_CLASS_PATH          "io/getlime/security/powerauth/core"
 #define CC7_JNI_CLASS_PACKAGE       io_getlime_security_powerauth_core
-#define CC7_JNI_JAVA_CLASS          NativeObject
-#define CC7_JNI_CPP_CLASS           NA
+#define CC7_JNI_JAVA_CLASS          CoreEncryptor
+#define CC7_JNI_CPP_CLASS           IClientEncryptor
 #include <cc7/jni/JniModule.inl>
 
 using namespace powerAuth;
-using namespace powerAuth::jni;
-using namespace cc7::jni;
 
 CC7_JNI_MODULE_CLASS_BEGIN()
 
-//
-// private native static void safeNativeDestroy(long handle);
-//
-CC7_JNI_STATIC_METHOD_PARAMS(void, safeNativeDestroy, jlong handle)
-{
-    NH_TRY
-    {
-        jni.global().objectRegister().removeEntry(handle);
-    }
-    NH_NO_THROW()
-}
-
-//
-// private native static boolean isNativeDestroyed(long handle);
-//
-CC7_JNI_STATIC_METHOD_PARAMS(jboolean, isNativeDestroyed, jlong handle)
-{
-    NH_TRY
-    {
-        return !jni.global().objectRegister().containsEntry(handle);
-    }
-    NH_NO_THROW(true)
-}
+#define THIS_OBJ()  jni.fromJava<CC7_JNI_CPP_CLASS>(NH_SPECS().coreEncryptor, thiz)
 
 CC7_JNI_MODULE_CLASS_END()

--- a/src/PowerAuthJni/CoreRequestJNI.cpp
+++ b/src/PowerAuthJni/CoreRequestJNI.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "NativeHelper.h"
-#include <PowerAuth/Request.h>
 
 // Package: io.getlime.security.powerauth.core
 #define CC7_JNI_CLASS_PATH          "io/getlime/security/powerauth/core"
@@ -26,8 +25,272 @@
 
 using namespace powerAuth;
 
+
+// MARK: - Helper functions
+
+namespace powerAuth::jni {
+
+/// Cleanup response builder registered in the global register.
+/// @param jni JNI reference.
+/// @param specs ClassSpecs reference.
+/// @param thiz Wrapped CoreRequest java object.
+/// @param builder_handle Optional response builder handle. If not provided, then handle is get from "thiz".
+static void ClearResponseBuilderClosure(cc7::jni::JNI &jni, const ClassSpecs& specs, JniObject& thiz, jlong builder_handle = cc7::jni::JniObjectRegister::NULL_ID)
+{
+    if (cc7::jni::JNI::isNullHandle(builder_handle)) {
+        builder_handle = thiz.getLong(specs.coreRequest.responseBuilderHandle);
+        if (cc7::jni::JNI::isNullHandle(builder_handle)) {
+            // Nothing to do
+            return;
+        }
+    }
+    jni.removeHandle(builder_handle);
+    thiz.setLong(specs.coreRequest.responseBuilderHandle, cc7::jni::JniObjectRegister::NULL_ID);
+}
+
+jobject BuildCoreRequest(cc7::jni::JNI &jni, const RequestPtr& request)
+{
+    return jni.toJava(NH_SPECS().coreRequest.native, request);
+}
+
+jobject BuildCoreRequest(cc7::jni::JNI &jni, const RequestPtr& request, const ResponseObjectBuilder & builder)
+{
+    auto& specs = NH_SPECS();
+    // Wrap build function into auxiliary structure and register it as handle
+    auto callback = std::shared_ptr<JavaResponseBuilder>(new JavaResponseBuilder { builder });
+    auto callback_handle = jni.toHandle(callback);
+
+    // Build Request java object
+    auto java_request = jni.toJava(specs.coreRequest.native, request);
+
+    // Keep build function's handle into instance of java_request.
+    jni.fromJava(java_request).setLong(specs.coreRequest.responseBuilderHandle, callback_handle);
+
+    return java_request;
+}
+
+} // namespace powerAuth::jni
+
+
 CC7_JNI_MODULE_CLASS_BEGIN()
 
-#define THIS_OBJ()  jni.fromJava<CC7_JNI_CPP_CLASS>(NH_SPECS().coreConfig, thiz)
+#define THIS_OBJ()  jni.fromJava<CC7_JNI_CPP_CLASS>(NH_SPECS().coreRequest.native, thiz)
+
+CC7_JNI_METHOD(jboolean, isRequireSynchronizedTime)
+{
+    NH_TRY
+    {
+        return THIS_OBJ()->requireSynchronizedTime();
+    }
+    NH_CATCH_RT_ONLY(false)
+}
+
+CC7_JNI_METHOD(jboolean, isRequireSerialQueue)
+{
+    NH_TRY
+    {
+        return THIS_OBJ()->requireSerialQueue();
+    }
+    NH_CATCH_RT_ONLY(false)
+}
+
+CC7_JNI_METHOD(jboolean, isAllowedInUpgrade)
+{
+    NH_TRY
+    {
+        return THIS_OBJ()->isAllowedInUpgrade();
+    }
+    NH_CATCH_RT_ONLY(false)
+}
+
+CC7_JNI_METHOD(jint, getEncryptorScope)
+{
+    NH_TRY
+    {
+        auto& specs = NH_SPECS();
+        auto this_obj = jni.fromJava<Request>(specs.coreRequest.native, thiz);
+        if (this_obj->isEncrypted()) {
+            return jni.toJava(specs.coreEncryptorScope, this_obj->encryptorScope());
+        }
+        return specs.coreEncryptorScope.bottomValue; // NONE
+    }
+    NH_CATCH_RT_ONLY(0)
+}
+
+CC7_JNI_METHOD(jboolean, isAuthenticated)
+{
+    NH_TRY
+    {
+        return THIS_OBJ()->isAuthenticated();
+    }
+    NH_CATCH_RT_ONLY(false)
+}
+
+CC7_JNI_METHOD(jstring, getRelativePath)
+{
+    NH_TRY
+    {
+        return jni.toJava(THIS_OBJ()->getRelativePath());
+    }
+    NH_CATCH_RT_ONLY(nullptr)
+}
+
+CC7_JNI_METHOD(jstring, getHttpMethod)
+{
+    NH_TRY
+    {
+        return jni.toJava(THIS_OBJ()->getHttpMethod());
+    }
+    NH_CATCH_RT_ONLY(nullptr)
+}
+
+CC7_JNI_METHOD(jbyteArray, getRequestBody)
+{
+    NH_TRY
+    {
+        return jni.toJava(THIS_OBJ()->getRequestBody());
+    }
+    NH_CATCH(nullptr)
+}
+
+CC7_JNI_METHOD(jobjectArray , getRequestHeaders)
+{
+    NH_TRY
+    {
+        auto& specs = NH_SPECS();
+        auto headers = jni.fromJava<Request>(specs.coreRequest.native, thiz)->getRequestHeaders();
+        auto result = jni.createObjectArray(specs.coreHttpHeader.classRef, headers.size());
+        for (auto index = 0; index < headers.size(); index++) {
+            auto java_header = jni.createObject(specs.coreHttpHeader.methods.init,
+                                                jni.toJava(headers[index].headerName),
+                                                jni.toJava(headers[index].headerValue));
+            result.setObject(index, java_header);
+        }
+        return result;
+    }
+    NH_CATCH(nullptr)
+}
+
+CC7_JNI_METHOD(jboolean, isDone)
+{
+    NH_TRY
+    {
+        return THIS_OBJ()->isDone();
+    }
+    NH_CATCH_RT_ONLY(false)
+}
+
+CC7_JNI_METHOD(jboolean, isCompleted)
+{
+    NH_TRY
+    {
+        return THIS_OBJ()->isCompleted();
+    }
+    NH_CATCH_RT_ONLY(false)
+}
+
+CC7_JNI_METHOD(jboolean, isCanceled)
+{
+    NH_TRY
+    {
+        return THIS_OBJ()->isCanceled();
+    }
+    NH_CATCH_RT_ONLY(false)
+}
+
+CC7_JNI_METHOD(jboolean, isFailed)
+{
+    NH_TRY
+    {
+        return THIS_OBJ()->isFailed();
+    }
+    NH_CATCH_RT_ONLY(false)
+}
+
+CC7_JNI_METHOD(void, cancel)
+{
+    NH_TRY
+    {
+        auto& specs = NH_SPECS();
+        auto this_wrapped = jni.fromJava(thiz, specs.coreRequest.native.classRef);
+        auto this_obj = jni.fromHandle<Request>(this_wrapped.getLong(specs.coreRequest.native.handle));
+        // cancel object
+        this_obj->cancel();
+        // cleanup builder
+        jni::ClearResponseBuilderClosure(jni, specs, this_wrapped);
+    }
+    NH_CATCH_RT_ONLY()
+}
+
+CC7_JNI_METHOD(void, setFailed)
+{
+    NH_TRY
+    {
+        auto& specs = NH_SPECS();
+        auto this_wrapped = jni.fromJava(thiz, specs.coreRequest.native.classRef);
+        auto this_obj = jni.fromHandle<Request>(this_wrapped.getLong(specs.coreRequest.native.handle));
+        // set failed
+        this_obj->setFailed(nullptr);
+        // cleanup builder
+        jni::ClearResponseBuilderClosure(jni, specs, this_wrapped);
+    }
+    NH_CATCH_RT_ONLY()
+}
+
+CC7_JNI_METHOD(void, prepareRequestImpl)
+{
+    NH_TRY
+    {
+        auto& specs = NH_SPECS();
+        auto this_wrapped = jni.fromJava(thiz, specs.coreRequest.native.classRef);
+        auto this_obj = jni.fromHandle<Request>(this_wrapped.getLong(specs.coreRequest.native.handle));
+        try {
+            this_obj->prepareRequest();
+        } catch (...) {
+            // Cleanup builder and re-throw
+            jni::ClearResponseBuilderClosure(jni, specs, this_wrapped);
+            std::rethrow_exception(std::current_exception());
+        }
+    }
+    NH_CATCH()
+}
+
+CC7_JNI_METHOD_PARAMS(void, processResponseImpl, jbyteArray response)
+{
+    NH_TRY
+    {
+        auto& specs = NH_SPECS();
+        auto this_wrapped = jni.fromJava(thiz, specs.coreRequest.native.classRef);
+        auto this_obj = jni.fromHandle<Request>(this_wrapped.getLong(specs.coreRequest.native.handle));
+        auto response_builder_handle = this_wrapped.getLong(specs.coreRequest.responseBuilderHandle);
+
+        try {
+            // Process response
+            this_obj->processResponse(jni.fromJava(response));
+
+            if (!cc7::jni::JNI::isNullHandle(response_builder_handle)) {
+                // Java response construction build is specified.
+                auto callback = jni.fromHandle<jni::JavaResponseBuilder>(response_builder_handle);
+                auto response_object = callback->build(jni, specs, this_obj->getResponseObject());
+                // Keep response object in Request instance
+                this_wrapped.setObject(specs.coreRequest.responseObject, response_object);
+                // Cleanup builder
+                jni::ClearResponseBuilderClosure(jni, specs, this_wrapped, response_builder_handle);
+            }
+            if (this_obj->isPublicResponseJson()) {
+                // Convert response JSON to generic object hierarchy
+                auto response_json = cc7::jni::JsonValueToJava(jni, this_obj->getResponseJson());
+                // Keep response JSON in Request instance
+                this_wrapped.setObject(specs.coreRequest.responseJson, response_json);
+            }
+        } catch (...) {
+            // Cleanup builder in case of failure
+            jni::ClearResponseBuilderClosure(jni, specs, this_wrapped, response_builder_handle);
+            // Rethrow exception
+            std::rethrow_exception(std::current_exception());
+        }
+    }
+    NH_CATCH()
+}
 
 CC7_JNI_MODULE_CLASS_END()

--- a/src/PowerAuthJni/CoreRequestJNI.cpp
+++ b/src/PowerAuthJni/CoreRequestJNI.cpp
@@ -15,42 +15,19 @@
  */
 
 #include "NativeHelper.h"
+#include <PowerAuth/Request.h>
 
 // Package: io.getlime.security.powerauth.core
 #define CC7_JNI_CLASS_PATH          "io/getlime/security/powerauth/core"
 #define CC7_JNI_CLASS_PACKAGE       io_getlime_security_powerauth_core
-#define CC7_JNI_JAVA_CLASS          NativeObject
-#define CC7_JNI_CPP_CLASS           NA
+#define CC7_JNI_JAVA_CLASS          CoreRequest
+#define CC7_JNI_CPP_CLASS           Request
 #include <cc7/jni/JniModule.inl>
 
 using namespace powerAuth;
-using namespace powerAuth::jni;
-using namespace cc7::jni;
 
 CC7_JNI_MODULE_CLASS_BEGIN()
 
-//
-// private native static void safeNativeDestroy(long handle);
-//
-CC7_JNI_STATIC_METHOD_PARAMS(void, safeNativeDestroy, jlong handle)
-{
-    NH_TRY
-    {
-        jni.global().objectRegister().removeEntry(handle);
-    }
-    NH_NO_THROW()
-}
-
-//
-// private native static boolean isNativeDestroyed(long handle);
-//
-CC7_JNI_STATIC_METHOD_PARAMS(jboolean, isNativeDestroyed, jlong handle)
-{
-    NH_TRY
-    {
-        return !jni.global().objectRegister().containsEntry(handle);
-    }
-    NH_NO_THROW(true)
-}
+#define THIS_OBJ()  jni.fromJava<CC7_JNI_CPP_CLASS>(NH_SPECS().coreConfig, thiz)
 
 CC7_JNI_MODULE_CLASS_END()

--- a/src/PowerAuthJni/CoreSessionJNI.cpp
+++ b/src/PowerAuthJni/CoreSessionJNI.cpp
@@ -28,6 +28,6 @@ using namespace powerAuth;
 
 CC7_JNI_MODULE_CLASS_BEGIN()
 
-#define THIS_OBJ()  jni.fromJava<CC7_JNI_CPP_CLASS>(NH_SPECS().coreConfig, thiz)
+#define THIS_OBJ()  jni.fromJava<CC7_JNI_CPP_CLASS>(NH_SPECS().coreSession, thiz)
 
 CC7_JNI_MODULE_CLASS_END()

--- a/src/PowerAuthJni/CoreSessionJNI.cpp
+++ b/src/PowerAuthJni/CoreSessionJNI.cpp
@@ -15,42 +15,19 @@
  */
 
 #include "NativeHelper.h"
+#include <PowerAuth/Session.h>
 
 // Package: io.getlime.security.powerauth.core
 #define CC7_JNI_CLASS_PATH          "io/getlime/security/powerauth/core"
 #define CC7_JNI_CLASS_PACKAGE       io_getlime_security_powerauth_core
-#define CC7_JNI_JAVA_CLASS          NativeObject
-#define CC7_JNI_CPP_CLASS           NA
+#define CC7_JNI_JAVA_CLASS          CoreSession
+#define CC7_JNI_CPP_CLASS           Session
 #include <cc7/jni/JniModule.inl>
 
 using namespace powerAuth;
-using namespace powerAuth::jni;
-using namespace cc7::jni;
 
 CC7_JNI_MODULE_CLASS_BEGIN()
 
-//
-// private native static void safeNativeDestroy(long handle);
-//
-CC7_JNI_STATIC_METHOD_PARAMS(void, safeNativeDestroy, jlong handle)
-{
-    NH_TRY
-    {
-        jni.global().objectRegister().removeEntry(handle);
-    }
-    NH_NO_THROW()
-}
-
-//
-// private native static boolean isNativeDestroyed(long handle);
-//
-CC7_JNI_STATIC_METHOD_PARAMS(jboolean, isNativeDestroyed, jlong handle)
-{
-    NH_TRY
-    {
-        return !jni.global().objectRegister().containsEntry(handle);
-    }
-    NH_NO_THROW(true)
-}
+#define THIS_OBJ()  jni.fromJava<CC7_JNI_CPP_CLASS>(NH_SPECS().coreConfig, thiz)
 
 CC7_JNI_MODULE_CLASS_END()

--- a/src/PowerAuthJni/CoreTaskJNI.cpp
+++ b/src/PowerAuthJni/CoreTaskJNI.cpp
@@ -15,42 +15,19 @@
  */
 
 #include "NativeHelper.h"
+#include <PowerAuth/Task.h>
 
 // Package: io.getlime.security.powerauth.core
 #define CC7_JNI_CLASS_PATH          "io/getlime/security/powerauth/core"
 #define CC7_JNI_CLASS_PACKAGE       io_getlime_security_powerauth_core
-#define CC7_JNI_JAVA_CLASS          NativeObject
-#define CC7_JNI_CPP_CLASS           NA
+#define CC7_JNI_JAVA_CLASS          CoreTask
+#define CC7_JNI_CPP_CLASS           Task
 #include <cc7/jni/JniModule.inl>
 
 using namespace powerAuth;
-using namespace powerAuth::jni;
-using namespace cc7::jni;
 
 CC7_JNI_MODULE_CLASS_BEGIN()
 
-//
-// private native static void safeNativeDestroy(long handle);
-//
-CC7_JNI_STATIC_METHOD_PARAMS(void, safeNativeDestroy, jlong handle)
-{
-    NH_TRY
-    {
-        jni.global().objectRegister().removeEntry(handle);
-    }
-    NH_NO_THROW()
-}
-
-//
-// private native static boolean isNativeDestroyed(long handle);
-//
-CC7_JNI_STATIC_METHOD_PARAMS(jboolean, isNativeDestroyed, jlong handle)
-{
-    NH_TRY
-    {
-        return !jni.global().objectRegister().containsEntry(handle);
-    }
-    NH_NO_THROW(true)
-}
+#define THIS_OBJ()  jni.fromJava<CC7_JNI_CPP_CLASS>(NH_SPECS().coreConfig, thiz)
 
 CC7_JNI_MODULE_CLASS_END()

--- a/src/PowerAuthJni/CoreTaskJNI.cpp
+++ b/src/PowerAuthJni/CoreTaskJNI.cpp
@@ -26,8 +26,174 @@
 
 using namespace powerAuth;
 
+// MARK: - Helper functions
+
+namespace powerAuth::jni {
+
+/// Cleanup response builder registered in the global register.
+/// @param jni JNI reference.
+/// @param specs ClassSpecs reference.
+/// @param thiz Wrapped CoreTask java object.
+/// @param builder_handle Optional response builder handle. If not provided, then handle is get from "thiz".
+static void ClearResponseBuilderClosure(cc7::jni::JNI &jni, const ClassSpecs& specs, JniObject& thiz, jlong builder_handle = cc7::jni::JniObjectRegister::NULL_ID)
+{
+    if (cc7::jni::JNI::isNullHandle(builder_handle)) {
+        builder_handle = thiz.getLong(specs.coreTask.responseBuilderHandle);
+        if (cc7::jni::JNI::isNullHandle(builder_handle)) {
+            // Nothing to do
+            return;
+        }
+    }
+    jni.removeHandle(builder_handle);
+    thiz.setLong(specs.coreTask.responseBuilderHandle, cc7::jni::JniObjectRegister::NULL_ID);
+}
+
+jobject BuildCoreTask(cc7::jni::JNI &jni, const TaskPtr& task)
+{
+    return jni.toJava(NH_SPECS().coreTask.native, task);
+}
+
+jobject BuildCoreTask(cc7::jni::JNI &jni, const TaskPtr& task, const ResponseObjectBuilder & builder)
+{
+    auto& specs = NH_SPECS();
+    // Wrap build function into auxiliary structure and register it as handle
+    auto callback = std::shared_ptr<JavaResponseBuilder>(new JavaResponseBuilder { builder });
+    auto callback_handle = jni.toHandle(callback);
+
+    // Build Request java object
+    auto java_request = jni.toJava(specs.coreTask.native, task);
+
+    // Keep build function's handle into instance of java_request.
+    jni.fromJava(java_request).setLong(specs.coreTask.responseBuilderHandle, callback_handle);
+
+    return java_request;
+}
+
+} // namespace powerAuth::jni
+
 CC7_JNI_MODULE_CLASS_BEGIN()
 
-#define THIS_OBJ()  jni.fromJava<CC7_JNI_CPP_CLASS>(NH_SPECS().coreConfig, thiz)
+#define THIS_OBJ()  jni.fromJava<CC7_JNI_CPP_CLASS>(NH_SPECS().coreTask.native, thiz)
+
+CC7_JNI_METHOD(jstring, getTaskName)
+{
+    NH_TRY
+    {
+        return jni.toJava(THIS_OBJ()->name());
+    }
+    NH_CATCH(nullptr)
+}
+
+CC7_JNI_METHOD(jboolean, isDone)
+{
+    NH_TRY
+    {
+        return THIS_OBJ()->isDone();
+    }
+    NH_CATCH(true)
+}
+
+CC7_JNI_METHOD(jboolean, isCanceled)
+{
+    NH_TRY
+    {
+        return THIS_OBJ()->isCanceled();
+    }
+    NH_CATCH(true)
+}
+
+CC7_JNI_METHOD(jboolean, isCompleted)
+{
+    NH_TRY
+    {
+        return THIS_OBJ()->isCompleted();
+    }
+    NH_CATCH(false)
+}
+
+CC7_JNI_METHOD(jboolean, isFailed)
+{
+    NH_TRY
+    {
+        return THIS_OBJ()->isFailed();
+    }
+    NH_CATCH(true)
+}
+
+CC7_JNI_METHOD(void, updateResponse)
+{
+    NH_TRY
+    {
+        auto& specs = NH_SPECS();
+        auto this_wrapped = jni.fromJava(thiz, specs.coreTask.native.classRef);
+        auto this_obj = jni.fromHandle<Task>(this_wrapped.getLong(specs.coreTask.native.handle));
+        // Retrieve response builder handle in advance. The value will be useful later
+        auto response_builder_handle = this_wrapped.getLong(specs.coreTask.responseBuilderHandle);
+        if (this_obj->isCompleted() && !this_wrapped.getBoolean(specs.coreTask.responseIsCaptured)) {
+            // Task is completed and response is not captured yet.
+            try {
+                // Set responseIsCapture to true
+                this_wrapped.setBoolean(specs.coreTask.responseIsCaptured, true);
+                // Convert response JSON
+                this_wrapped.setObject(specs.coreTask.responseJson, jni::JsonValueToJava(jni, this_obj->getResponseJson()));
+                // Convert response object
+                if (!cc7::jni::JNI::isNullHandle(response_builder_handle)) {
+                    // Response builder is set, create builder reference and build a response object
+                    auto builder = jni.fromHandle<jni::JavaResponseBuilder>(response_builder_handle);
+                    auto response_object = builder->build(jni, specs, this_obj->getResponseObject());
+                    this_wrapped.setObject(specs.coreTask.responseObject, response_object);
+                    // Unregister builder and cleanup handle
+                    jni::ClearResponseBuilderClosure(jni, specs, this_wrapped, response_builder_handle);
+                }
+            } catch (...) {
+                // Keep exception in the native object
+                this_obj->setFailed(std::current_exception());
+                // Cleanup builder and re-throw
+                jni::ClearResponseBuilderClosure(jni, specs, this_wrapped, response_builder_handle);
+                std::rethrow_exception(std::current_exception());
+            }
+        } else if (this_obj->isFailed() || this_obj->isCanceled()) {
+            // If failed or canceled, then just release response builder.
+            jni::ClearResponseBuilderClosure(jni, specs, this_wrapped, response_builder_handle);
+        }
+    }
+    NH_CATCH()
+}
+
+CC7_JNI_METHOD(void, cancel)
+{
+    NH_TRY
+    {
+        auto& specs = NH_SPECS();
+        auto this_wrapped = jni.fromJava(thiz, specs.coreTask.native.classRef);
+        auto this_obj = jni.fromHandle<Task>(this_wrapped.getLong(specs.coreTask.native.handle));
+        // Cancel task
+        this_obj->cancel();
+        // Cleanup builder
+        jni::ClearResponseBuilderClosure(jni, specs, this_wrapped);
+    }
+    NH_CATCH()
+}
+
+CC7_JNI_METHOD(jobject, getNextRequestImpl)
+{
+    NH_TRY
+    {
+        auto& specs = NH_SPECS();
+        auto this_wrapped = jni.fromJava(thiz, specs.coreTask.native.classRef);
+        auto this_obj = jni.fromHandle<Task>(this_wrapped.getLong(specs.coreTask.native.handle));
+        try {
+            auto next = this_obj->getNextRequest();
+            return next ? jni.toJava(specs.coreRequest.native, next) : nullptr;
+        } catch (...) {
+            // Keep exception in the native object
+            this_obj->setFailed(std::current_exception());
+            // Cleanup builder and re-throw
+            jni::ClearResponseBuilderClosure(jni, specs, this_wrapped);
+            std::rethrow_exception(std::current_exception());
+        }
+    }
+    NH_CATCH(nullptr)
+}
 
 CC7_JNI_MODULE_CLASS_END()

--- a/src/PowerAuthJni/NativeHelper.cpp
+++ b/src/PowerAuthJni/NativeHelper.cpp
@@ -112,4 +112,24 @@ void NativeHelper::handleException(cc7::jni::JNI &jni, std::exception_ptr except
                     java_info.array());
 }
 
+void NativeHelper::handleJniExceptionsOnly(cc7::jni::JNI& jni, std::exception_ptr exception)
+{
+    if (jni.processException(exception, false)) {
+        // Already handled
+        return;
+    }
+    // Unhandled exception, throw
+    std::string message;
+    try {
+        std::rethrow_exception(exception);
+    } catch (cc7::BaseException & e) {
+        message = e.message();
+    } catch (std::exception & e) {
+        message = e.what();
+    } catch (...) {
+        message = "Unknown C++ exception type";
+    }
+    jni.throwToJava(jni.commonSpecs().illegalStateException.classRef, "Unhandled C++ exception: " + message);
+}
+
 } // namespace powerAuth::jni

--- a/src/PowerAuthJni/NativeHelper.cpp
+++ b/src/PowerAuthJni/NativeHelper.cpp
@@ -20,7 +20,7 @@ namespace powerAuth::jni {
 
 static NativeHelper& GetInstance()
 {
-    static NativeHelper instance;
+    static NativeHelper instance {};
     return instance;
 }
 

--- a/src/PowerAuthJni/NativeHelper.h
+++ b/src/PowerAuthJni/NativeHelper.h
@@ -18,6 +18,7 @@
 
 #include "ClassSpecs.h"
 #include "SecureDataJNI.h"
+#include <PowerAuth/Task.h>
 
 namespace powerAuth::jni {
 
@@ -117,5 +118,46 @@ private:
 
 /// Get reference to common class specifications provided by JNI instance.
 #define NH_COMMON_SPECS() jni.commonSpecs()
+
+// Support functions
+
+/// Closure for constructing Java model objects from C++ response objects.
+typedef std::function<
+        jobject(cc7::jni::JNI& jni,
+                const ClassSpecs& specs,
+                const powerAuth::ResponseObjectPtr& response
+        )> ResponseObjectBuilder;
+
+/// Structure contains information required for response object build.
+struct JavaResponseBuilder
+{
+    ResponseObjectBuilder build;
+};
+
+/// Build CoreRequest Java object from given C++ Request instance.
+/// @param jni JNI reference.
+/// @param request Request object.
+/// @return CoreRequest Java instance.
+jobject BuildCoreRequest(cc7::jni::JNI &jni, const RequestPtr& request);
+
+/// Build CoreRequest Java object from given C++ Request instance and set closure that translates received response into Java response object.
+/// @param jni JNI reference.
+/// @param request Request object.
+/// @param builder Closure that translates received C++ response object into Java response object.
+/// @return CoreRequest Java instance with additional builder closure.
+jobject BuildCoreRequest(cc7::jni::JNI &jni, const RequestPtr& request, const ResponseObjectBuilder& builder);
+
+/// Build CoreTask Java object from given C++ Task instance.
+/// @param jni JNI reference.
+/// @param task Task object.
+/// @return CoreTask Java instance.
+jobject BuildCoreTask(cc7::jni::JNI& jni, const TaskPtr& task);
+
+/// Build CoreTask Java object from given C++ Task instance and set closure that translates received response into Java response object.
+/// @param jni JNI reference.
+/// @param task Task object.
+/// @param builder Closure that translates received C++ response object into Java response object.
+/// @return CoreTask Java instance with additional builder closure.
+jobject BuildCoreTask(cc7::jni::JNI &jni, const TaskPtr& task, const ResponseObjectBuilder& builder);
 
 } // namespace powerAuth::jni

--- a/src/PowerAuthJni/NativeHelper.h
+++ b/src/PowerAuthJni/NativeHelper.h
@@ -17,8 +17,7 @@
 #pragma once
 
 #include "ClassSpecs.h"
-#include <PowerAuth/Password.h>
-#include <PowerAuth/Exception.h>
+#include "SecureDataJNI.h"
 
 namespace powerAuth::jni {
 
@@ -52,6 +51,11 @@ public:
     /// ```
     static void handleException(cc7::jni::JNI& jni, std::exception_ptr exception = std::current_exception());
 
+    /// Handle exception thrown from C++ code. Unlike `handleException()` this method processes only exceptions from `cc7::jni`
+    /// namespace. All such exceptions are marshalled to RuntimeException types, so it's useful for functions that
+    /// doesn't throw `CoreException`.
+    static void handleJniExceptionsOnly(cc7::jni::JNI& jni, std::exception_ptr exception = std::current_exception());
+
 private:
 
     bool _init_registered = false;
@@ -80,19 +84,32 @@ private:
 /// Macro ends try - catch block started in `NH_TRY` and translates any known C++ exception into Java exception.
 /// @param return_value Defines a value returned in case the exception occurred. In case this is JNI function
 ///        returning `void`, then you use nothing form parameter.
-#define NH_CATCH(return_value)                               \
-    catch (...) {                                            \
-        powerAuth::jni::NativeHelper::handleException(jni);  \
-        return return_value;                                 \
+#define NH_CATCH(return_value)                                      \
+    catch (...) {                                                   \
+        powerAuth::jni::NativeHelper::handleException(jni);         \
+        return return_value;                                        \
+    }
+
+/// Macro ends try - catch block started in `NH_TRY` and translates `cc7::jni` C++ exceptions into Java RuntimeException
+/// types. If other than `cc7::jni` exception is raised, then `IllegalStateException` is reported back to java.
+///
+/// This is useful for methods that suppose not to throw `CoreException`.
+///
+/// @param return_value Defines a value returned in case the exception occurred. In case this is JNI function
+///        returning `void`, then you use nothing form parameter.
+#define NH_CATCH_RT_ONLY(return_value)                              \
+    catch (...) {                                                   \
+        powerAuth::jni::NativeHelper::handleJniExceptionsOnly(jni); \
+        return return_value;                                        \
     }
 
 /// Macro ends try - catch block started by `NH_TRY` and swallows all C++ exceptions.
 /// @param return_value Defines a value returned in case the exception occurred. In case this is JNI function
 ///        returning `void`, then you use nothing form parameter.
-#define NH_NO_THROW(return_value)                            \
-    catch (...) {                                            \
-        jni.noThrow();                                       \
-        return return_value;                                 \
+#define NH_NO_THROW(return_value)                                   \
+    catch (...) {                                                   \
+        jni.noThrow();                                              \
+        return return_value;                                        \
     }
 
 /// Get reference to class specifications provided by NativeHelper.

--- a/src/PowerAuthJni/PasswordJNI.cpp
+++ b/src/PowerAuthJni/PasswordJNI.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "NativeHelper.h"
-#include <algorithm>
+#include <PowerAuth/Password.h>
 
 // Package: io.getlime.security.powerauth.core
 #define CC7_JNI_CLASS_PATH          "io/getlime/security/powerauth/core"


### PR DESCRIPTION
Added following new "core" types:

- `CoreSession` - replaces `Session`, including dummy JNI wrapper.
- `CoreEncryptor` - replaces `EciesEncryptor`, including dummy JNI wrapper.
- `CoreEncryptorFactory` - new class, including dummy JNI wrapper.
- `CoreEncryptorScope` - replaces `EciesEncryptorScope`
- `CoreConfig` - replaces `SessionSetup`
- `CoreAlgorithm` - new enumeration
- `CoreDevicePublicKeyData` + `PowerAuthDevicePublicKeyData` - new model classes
- `CoreDevicePublicKeyFormat` + `PowerAuthDevicePublicKeyFormat` - new enumerations
- `CoreHttpHeader` + `PowerAuthHttpHeader` - new model classes, replaces `PowerAuthAuthorizationHttpHeader`
- `CoreRequest` - new class, including JNI wrapper
- `CoreTask` - new class, including JNI wrapper
- `CoreSignatureKeyId`  + `PowerAuthSignatureKeyId` - new enumerations
- `CoreSignatureKeyType` + `PowerAuthSignatureKeyType`  - new enumerations
- `CoreCredentials` - new class, replaces `SignatureUnlockKeys`

On top of that, this PR contains:
- Fixes leaking of sensitive Request data in `responseJson` properties. The JSON representation is now available to managed code only if it's allowed by endpoint specification.
- Added missing property to PowerAuthCoreConfig on iOS
- Added missing documentation to PowerAuhtCoreCredentials on iOS
- `@Deprecated` markers now references 2.0.0 instead of 1.10.0 version