### PR TITLE
Android: Fix #795 NPE in BiometricAuthentication when keys invalidated by biometric enrollment

### DIFF
--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorAes.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorAes.java
@@ -109,7 +109,7 @@ public class BiometricKeyEncryptorAes implements IBiometricKeyEncryptor {
                 // Keep encrypt mode flag to be validated later in encrypt / decrypt methods.
                 this.encryptMode = encryptMode;
             }
-        } catch (ProviderException | NoSuchAlgorithmException | NoSuchPaddingException | InvalidAlgorithmParameterException | InvalidKeyException e) {
+        } catch (Throwable e) {
             PowerAuthLog.e("BiometricKeyEncryptorAes.initializeCipher failed: " + e.getMessage());
             this.cipher = null;
         } finally {

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorRsa.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorRsa.java
@@ -142,7 +142,7 @@ public class BiometricKeyEncryptorRsa implements IBiometricKeyEncryptor {
                 }
                 this.encryptMode = encryptMode;
             }
-        } catch (ProviderException | NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeySpecException | InvalidAlgorithmParameterException | InvalidKeyException e) {
+        } catch (Throwable e) {
             PowerAuthLog.e("BiometricKeyEncryptorRsa.initializeCipher failed: " + e.getMessage());
             this.cipher = null;
         } finally {

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeystore.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeystore.java
@@ -72,7 +72,27 @@ public class BiometricKeystore implements IBiometricKeystore {
             return false;
         }
         try {
-            return mKeyStore.containsAlias(getKeystoreAlias(keyId));
+            final String alias = getKeystoreAlias(keyId);
+            if (!mKeyStore.containsAlias(alias)) {
+                return false;
+            }
+            // Validate the key by attempting to initialize a cipher in decryption mode
+            final IBiometricKeyEncryptor encryptor = getBiometricKeyEncryptor(keyId);
+            if (encryptor == null) {
+                // Failed to get encryptor, remove the key
+                PowerAuthLog.w("BiometricKeystore.containsBiometricKeyEncryptor: Failed to get encryptor for key, removing invalid key");
+                mKeyStore.deleteEntry(alias);
+                return false;
+            }
+            // Try to initialize cipher in decryption mode
+            if (encryptor.initializeCipher(false) == null) {
+                // Failed to initialize cipher, key is invalid - remove it
+                PowerAuthLog.w("BiometricKeystore.containsBiometricKeyEncryptor: Failed to initialize cipher, removing invalid key");
+                mKeyStore.deleteEntry(alias);
+                return false;
+            }
+            // Key is valid
+            return true;
         } catch (KeyStoreException e) {
             PowerAuthLog.e("BiometricKeystore.containsBiometricKeyEncryptor failed: " + e.getMessage());
             return false;
@@ -93,8 +113,9 @@ public class BiometricKeystore implements IBiometricKeystore {
     @Override
     public void removeBiometricKeyEncryptor(@NonNull String keyId) {
         try {
-            if (containsBiometricKeyEncryptor(keyId)) {
-                mKeyStore.deleteEntry(getKeystoreAlias(keyId));
+            final String alias = getKeystoreAlias(keyId);
+            if (mKeyStore.containsAlias(alias)) {
+                mKeyStore.deleteEntry(alias);
             }
         } catch (KeyStoreException e) {
             PowerAuthLog.e("BiometricKeystore.removeBiometricKeyEncryptor failed: " + e.getMessage());


### PR DESCRIPTION
This is fix for #795 for develop branch, cherrypicked from `release/1.9.x`