### PR TITLE
Android: Support for biometric KEK

### DIFF
--- a/include/PowerAuth/Session.h
+++ b/include/PowerAuth/Session.h
@@ -404,12 +404,34 @@ public:
                            const std::string& data_type,
                            SignatureKeyId key_to_use,
                            bool use_compact_form) const;
+
+public:
+    // --------------------------------------------------------------------------------------------
+    // Utilities
+    // --------------------------------------------------------------------------------------------
+
+    /// Generate new factor KEK. The size of KEK depends on the current protocol version.
+    /// - Returns: New factor KEK.
+    cc7::ByteArray generateFactorKek() const;
+    
+    /// Generates a factor KEK from the provided input data. This method is typically used to derive
+    /// a KEK for a biometric factor.
+    ///
+    /// If the activation is still using protocol V3, the method is compatible with the normalization
+    /// used in SDK 1.9.x and older (`Session.normalizeSignatureUnlockKeyFromData()`).
+    /// - Parameter data: Input data.
+    /// - Returns: KEK calculated from input data.
+    cc7::ByteArray generateFactorKekFromData(const cc7::ByteRange& data) const;
+    
+    /// Generate new factor KEK for selected protocol version.
+    /// - Parameter version: Protocol version.
+    /// - Returns: New factor KEK for the selected protocol version.
+    static cc7::ByteArray generateFactorKekForProtocol(ProtocolVersion version);
     
 public:
     // --------------------------------------------------------------------------------------------
     // Services
     // --------------------------------------------------------------------------------------------
-    
     
     /// Get smart pointer with the `TimeService` object, providing time synchronization tasks.
     const TimeServicePtr& getTimeService() const noexcept;

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreSession.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreSession.java
@@ -366,6 +366,20 @@ public class CoreSession extends NativeObject {
     public native SecureData generateFactorKek() throws CoreException;
 
     /**
+     * Generates a factor KEK from the provided input data. This method is typically used to derive
+     * a KEK for a biometric factor.
+     * <p>
+     * If the activation is still using protocol V3, the method is compatible with the normalization
+     * used in SDK 1.9.x and older ({@code Session.normalizeSignatureUnlockKeyFromData()}).
+     *
+     * @param data Input data.
+     * @return KEK calculated from input data.
+     * @throws CoreException In case of failure.
+     */
+    @NonNull
+    public native SecureData generateFactorKekFromData(@NonNull SecureData data) throws CoreException;
+
+    /**
      * Generate new factor KEK for selected protocol version.
      *
      * @param protocolVersion Protocol version.

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -2385,7 +2385,15 @@ public class PowerAuthSDK {
         if (forceGenerateNewKey) {
             // new key has to be generated
             try {
-                rawKeyData = mSession.generateFactorKek();
+                // Always generate a 256-bit key, even for the V3 protocol. This prepares the
+                // biometry data for a future activation upgrade to V4, where 256-bit keys are the
+                // default.
+                //
+                // If the activation is still using V3, the generated 256-bit key is later
+                // reduced to the actual KEK size during the normalization step (SHA-256,
+                // then truncated to 16 bytes). This ensures compatibility with both 128-bit
+                // and 256-bit key sizes.
+                rawKeyData = CoreSession.generateFactorKekForProtocolVersion(CoreProtocolVersion.V4);
             } catch (CoreException e) {
                 // This should never happen.
                 throw new IllegalStateException("Failed to generate random KEK", e);
@@ -2432,13 +2440,16 @@ public class PowerAuthSDK {
 
             @Override
             public void onBiometricDialogSuccess(@NonNull BiometricKeyData biometricKeyData) {
-                callback.onBiometricDialogFailed(new PowerAuthErrorException(PowerAuthErrorCodes.OTHER, "Not implemented"));
-//                // Store the new key, if a new key was generated
-//                if (biometricKeyData.isNewKey()) {
-//                    mBiometryKeychain.putSecureData(biometricKeyData.getDataToSave(), biometricDataMapping.keychainKey);
-//                }
-//                SecureData normalizedEncryptionKey = mSession.normalizeSignatureUnlockKeyFromData(biometricKeyData.getDerivedData().getSensitiveData());
-//                callback.onBiometricDialogSuccess(new BiometricKeyData(biometricKeyData.getDataToSave(), normalizedEncryptionKey, biometricKeyData.isNewKey()));
+                // Store the new key, if a new key was generated
+                if (biometricKeyData.isNewKey()) {
+                    mBiometryKeychain.putSecureData(biometricKeyData.getDataToSave(), biometricDataMapping.keychainKey);
+                }
+                try {
+                    SecureData normalizedEncryptionKey = mSession.generateFactorKekFromData(biometricKeyData.getDerivedData());
+                    callback.onBiometricDialogSuccess(new BiometricKeyData(biometricKeyData.getDataToSave(), normalizedEncryptionKey, biometricKeyData.isNewKey()));
+                } catch (CoreException exception) {
+                    callback.onBiometricDialogFailed(PowerAuthErrorException.wrapException(exception));
+                }
             }
 
             @Override

--- a/proj-xcode/PowerAuthCore/PowerAuthCoreSession.mm
+++ b/proj-xcode/PowerAuthCore/PowerAuthCoreSession.mm
@@ -822,15 +822,22 @@ static void _ReportError(PowerAuthCoreError code, NSString * message, NSError **
     if (![self requireReadAccess:error]) {
         return nil;
     }
-    return [[self class] generateFactorKekForProtocolVersion:(PowerAuthCoreProtocolVersion) _session->getProtocolVersion()
-                                                       error:error];
+    try {
+        auto kek = _session->generateFactorKek();
+        return [[PowerAuthCoreData alloc] initWithByteRange:kek];
+    } catch (...) {
+        if (error) {
+            *error = BuildNSErrorFromException();
+        }
+        return nil;
+    }
 }
 
 + (nullable PowerAuthCoreData*) generateFactorKekForProtocolVersion:(PowerAuthCoreProtocolVersion)protocolVersion
                                                               error:(NSError**)error
 {
     try {
-        auto kek = cc7::crypto::GetRandomData(protocolVersion == PowerAuthCoreProtocolVersion_V4 ? 32 : 16);
+        auto kek = Session::generateFactorKekForProtocol((ProtocolVersion)protocolVersion);
         return [[PowerAuthCoreData alloc] initWithByteRange:kek];
     } catch (...) {
         if (error) {

--- a/src/PowerAuth/Session.cpp
+++ b/src/PowerAuth/Session.cpp
@@ -414,6 +414,44 @@ RequestPtr Session::jwsSignData(const CredentialsPtr& credentials,
     return _context->signatureService().jwsSignData(credentials, data_to_sign, data_type, key_to_use, use_compact_form);
 }
 
+// MARK: - Utilities
+
+cc7::ByteArray Session::generateFactorKek() const
+{
+    LOCK_GUARD();
+    return generateFactorKekForProtocol(_context->protocolVersion());
+}
+
+cc7::ByteArray Session::generateFactorKekFromData(const cc7::ByteRange& data) const
+{
+    LOCK_GUARD();
+    switch (_context->protocolVersion()) {
+        case Version_V4: {
+            return algorithms().v4.sha3_256().digest(data);
+        }
+        case Version_V3: {
+            // Compatible with 1.9.x, Session::normalizeSignatureUnlockKeyFromData()
+            auto kek = algorithms().v3.sha256().digest(data);
+            kek.resize(v3::FACTOR_KEY_SIZE);
+            return kek;
+        }
+        default:
+            throw Exception(EC_WrongParameter, "Unsupported protocol version");
+    }
+}
+
+cc7::ByteArray Session::generateFactorKekForProtocol(ProtocolVersion version)
+{
+    size_t kek_size;
+    switch (version) {
+        case Version_V4: kek_size = v4::FACTOR_KEY_SIZE; break;
+        case Version_V3: kek_size = v3::FACTOR_KEY_SIZE; break;
+        default:
+            throw Exception(EC_WrongParameter, "Unsupported protocol version");
+    }
+    return cc7::crypto::GetRandomData(kek_size);
+}
+
 // MARK: - Services
 
 const TimeServicePtr& Session::getTimeService() const noexcept

--- a/src/PowerAuthJni/CoreSessionJNI.cpp
+++ b/src/PowerAuthJni/CoreSessionJNI.cpp
@@ -442,17 +442,23 @@ CC7_JNI_METHOD(jobject, getEncryptorFactory)
 
 // Utilities
 
-static jobject GenerateFactorKek(JNI& jni, ProtocolVersion protocol_version)
-{
-    auto kek = cc7::crypto::GetRandomData(protocol_version == Version_V4 ? 32 : 16);
-    return jni::CopyToSecureData(jni, kek);
-}
-
 CC7_JNI_METHOD(jobject, generateFactorKek)
 {
     NH_TRY
     {
-        return GenerateFactorKek(jni, THIS_OBJ()->getProtocolVersion());
+        return CopyToSecureData(jni, THIS_OBJ()->generateFactorKek());
+    }
+    NH_CATCH(nullptr)
+}
+
+CC7_JNI_METHOD_PARAMS(jobject, generateFactorKekFromData, jobject data)
+{
+    NH_TRY
+    {
+        jni.requireParameter(data, "data");
+        auto input_data = CopyFromSecureData(jni, data);
+        auto kek = THIS_OBJ()->generateFactorKekFromData(input_data);
+        return CopyToSecureData(jni, kek);
     }
     NH_CATCH(nullptr)
 }
@@ -462,7 +468,7 @@ CC7_JNI_STATIC_METHOD_PARAMS(jobject, generateFactorKekForProtocolVersion, jint 
     NH_TRY
     {
         auto version = jni.fromJava<ProtocolVersion>(NH_SPECS().coreProtocolVersion, protocolVersion);
-        return GenerateFactorKek(jni, version);
+        return CopyToSecureData(jni, Session::generateFactorKekForProtocol(version));
     }
     NH_CATCH(nullptr)
 }


### PR DESCRIPTION
This PR adds functionality that guarantees biometrics to work after upgrade from protocol V3 to V4:

- C++ Session now contains functions for generate KEK. If session is still at protocol V3, then the normalization calculation is compatible with older SDKs (e.g. SHA-256(data), resize to 16B)
- All new biometry related keys are now 256-bits.
- Objective-C wrapper now use KEK functions from C++ session

Fix #758 
