### PR TITLE
Android: DSA and JWS signature calculation and verify

### DIFF
--- a/docs/Migration-from-1.9-to-2.0.md
+++ b/docs/Migration-from-1.9-to-2.0.md
@@ -38,6 +38,9 @@ Notable changes on Android:
     - `requestGetSignatureWithAuthentication()` - use `authenticationHeaderForRequestWithParams()` method instead which throws an exception in case of failure.
     - `requestSignatureWithAuthentication()` - use `authenticationHeaderForRequestWithBody()` method instead which throws an exception in case of failure.
     - `offlineSignatureWithAuthentication()` - use asynchronous `offlineAuthenticationCode()` method instead.
+    - `signDataWithDevicePrivateKey()` - use `calculateDigitalSignature()` method where you can specify the key used for signing.
+    - `signJwtWithDevicePrivateKey()` - use `calculateJwsSignature()` method where you can specify the key used for signing.
+    - `verifyServerSignedData()` - use `verifyDigitalSignature()` method where you can specify the key used for verification.
     - `saveSerializedState()` - method is now private
     - `restoreState()` - method is now private
     - `getSession()` - access to a low-level session object is no longer available. Let us know if you have a problem with this.
@@ -53,6 +56,10 @@ Notable changes on Android:
 
   - `IPersistActivationListener` callback interface:
     - `onPersistActivationFailed()` method now receives `Throwable` instead of `PowerAuthErrorException`. You can also expect `FailedApiException` and similar exceptions if communication with the server failed.
+  
+  - `IDataSignatureListener` callback interface is deprecated, use API method that takes `IDigitalSignatureListener` listener at input.
+
+  - `IJwtSignatureListener` callback interface is deprecated, use API method that takes `IJwsSignatureListener` listener at input.
 
   - `IGenerateTokenHeaderListener` callback interface:
     - `onGenerateTokenHeaderSucceeded()` method now receives `PowerAuthHttpHeader` object.

--- a/docs/PowerAuth-SDK-for-Android.md
+++ b/docs/PowerAuth-SDK-for-Android.md
@@ -14,11 +14,15 @@
   - [Validating User Inputs](#validating-user-inputs)
 - [Requesting Device Activation Status](#requesting-activation-status)
 - [Data Signing](#data-signing)
+- [Authentication Codes](#authentication-codes)
   - [Symmetric Multi-Factor Authentication Code](#symmetric-multi-factor-authentication-code)
-  - [Asymmetric Private Key Signature](#asymmetric-private-key-signature)
   - [Symmetric Offline Multi-Factor Authentication Code](#symmetric-offline-multi-factor-authentication-code)
+- [Digital Signatures](#digital-signatures)
+  - [Asymmetric Private Key Signature](#asymmetric-private-key-signature)
   - [Producing Signed JWT with Provided Claims](#producing-signed-jwt-with-provided-claims)
   - [Verify Server-Signed Data](#verify-server-signed-data)
+  - [Verify JSON Web Signature](#verify-json-web-signature)
+  - [Getting Device Public Keys](#getting-device-public-keys)
 - [Password Change](#password-change)
 - [Working with passwords securely](#working-with-passwords-securely)
 - [Working with sensitive data](#working-with-sensitive-data)
@@ -123,6 +127,7 @@ PowerAuthAppLifecycleListener.getInstance().registerForActivityLifecycleCallback
 
 The `PowerAuthConfiguration.Builder` class provides the following additional methods that can alter the configuration:
 
+- `algorithm()` - Alters [algorithm](#algorithms-for-communication) used for the communication with the PowerAuth Server.
 - `offlineAuthenticationCodeComponentLength()` - Alters the default component length for the [offline authentication code](#symmetric-offline-multi-factor-authentication-code). The values between 4 and 8 are allowed. The default value is 8.
 - `externalEncryptionKey()` - See [External Encryption Key](#external-encryption-key) chapter for more details.
 - `disableAutomaticProtocolUpgrade()` - Disables the automatic protocol upgrade. This option should be used only for debugging purposes.
@@ -215,6 +220,57 @@ try {
     // Basically, you should not create any PowerAuthSDK instance before the change.
 }
 ```
+
+### Algorithms for Communication
+
+The PowerAuth Mobile SDK supports multiple algorithms for communication with the **PowerAuth Server**. Each algorithm has unique properties, allowing you to choose whether to prioritize security, performance, or a balance of both.
+
+The following algorithms are currently supported:
+
+- `EC_P384_ML_L3` — **default algorithm**  
+  - Provides the best balance between performance and security, including post-quantum resistance.  
+  - Uses a **hybrid** scheme combining P-384–based ECC with ML-KEM-768 and ML-DSA-65 algorithms.  
+  - Requires PowerAuth Server **2.0 or later**.
+
+- `EC_P384_ML_L5`
+  - Provides the highest level of security, including post-quantum resistance.  
+  - Uses a **hybrid** scheme combining P-384–based ECC with ML-KEM-1024 and ML-DSA-87 algorithms.  
+  - Requires PowerAuth Server **2.0 or later**.
+
+- `EC_P384`
+  - Offers excellent performance and stronger security than the legacy protocol V3.3, but is not quantum-resistant.  
+  - This algorithm is based on P-384 ECC and should be used only if your infrastructure cannot yet handle the higher load introduced by post-quantum algorithms.  
+  - Requires PowerAuth Server **2.0 or later**.
+
+- `LEGACY_P256`
+  - Based on P-256 ECC and fully compatible with PowerAuth protocol V3.3.  
+  - Intended to help you migrate your application code to the API changes introduced in PowerAuth Mobile SDK 2.0 while maintaining compatibility with your existing infrastructure. Once your PowerAuth Server is upgraded to version 2.0 or later, you should switch to at least `EC_P384`.  
+  - Requires PowerAuth Server **1.9 or later**.
+
+<!-- begin box info -->
+If you select `LEGACY_P256` algorithm, then SDK may behave slightly different in some rare cases. The rest of the documentation will use **"legacy mode"** or **"legacy activation"** terminology to highlight such situation.
+<!-- end -->
+
+The default algorithm can be overridden by specifying a different one in the SDK configuration:
+
+```kotlin
+try {
+    val configuration = PowerAuthConfiguration.Builder(
+        INSTANCE_ID,
+        API_SERVER,
+        MOBILE_SDK_CONFIG)
+        .algorithm(PowerAuthAlgorithm.EC_P384_ML_L5)
+        .build()
+    val powerAuthSDK = PowerAuthSDK.Builder(configuration)
+        .build(applicationContext)
+} catch (exception: PowerAuthErrorException) {
+    // Failed to construct `PowerAuthSDK` due to insufficient keychain protection.
+    // (See next chapter for details)
+}
+```
+
+The selected algorithm cannot be changed after a `PowerAuthSDK` instance is created, but it can be updated across the lifetime of your application. If the selected algorithm does not match the one used for the activation currently present on the device, the [authenticated protocol upgrade](#authenticated-protocol-upgrade) process must be performed to switch to the new algorithm.
+
 
 ## Activation
 
@@ -619,12 +675,14 @@ In rare situations, this may also happen in development or testing environments,
 
 ## Data Signing
 
-The main feature of the PowerAuth protocol is data signing. PowerAuth has various types of signatures:
+The main feature of the PowerAuth protocol is data signing. PowerAuth has the following types of signatures:
 
-- **Symmetric Multi-Factor Authentication Code**: Suitable for most operations, such as login, new payment, or confirming changes in settings.
-- **Asymmetric Private Key Signature**: Suitable for documents where a strong one-sided signature is desired.
-- **Symmetric Offline Multi-Factor Authentication Code**: Suitable for very secure operations, where the signature is validated over the out-of-band channel.
-- **Verify server signed data**: Suitable for receiving arbitrary data from the server.
+- [Symmetric Multi-Factor Authentication Code](#symmetric-multi-factor-authentication-code): Suitable for most operations, such as login, new payment, or confirming changes in settings.
+- [Symmetric Offline Multi-Factor authentication Code](#symmetric-offline-multi-factor-authentication-code): Suitable for very secure operations, where the authentication code is validated over the out-of-band channel.
+- [Asymmetric Private Key Signature](#sign-data-with-device-private-key): Suitable for documents where a strong one-sided signature is desired.
+- [Verify server signed data](#verify-server-signed-data): Suitable for receiving arbitrary data from the server.
+
+## Authentication Codes
 
 ### Symmetric Multi-Factor Authentication Code
 
@@ -707,57 +765,6 @@ powerAuthSDK.serialExecutor.execute {
 }
 ```
 
-### Asymmetric Private Key Signature
-
-Asymmetric Private Key Signature uses a private key stored in the PowerAuth secure vault. In order to unlock the secure vault and retrieve the private key, the user has to first authenticate using the symmetric multi-factor authentication code with at least two factors. This mechanism protects the private key on the device - the server plays a role of a "doorkeeper" and holds the vault unlock key.
-
-This process is completely transparent on the SDK level. To compute an asymmetric private key signature, request user credentials (password, PIN, biometric image) and use the following code:
-
-```kotlin
-// Prepare the authentication object
-val authentication = PowerAuthAuthentication.possessionWithPassword("1234")
-
-// Get the data to be signed
-val data: ByteArray = this.getMyData()
-
-powerAuthSDK.signDataWithDevicePrivateKey(context, authentication, data, object: IDataSignatureListener {
-    override fun onDataSignedSucceed(signature: ByteArray) {
-        // Use data signature...
-    }
-
-    override fun onDataSignedFailed(t: Throwable) {
-        // Report error
-    }
-})
-```
-
-### Producing Signed JWT with Provided Claims
-
-The asymmetric private key signatures described above can be used to sign claims provided by the developer and construct a signed JWT (signed using ES256 algorithm).
-
-```kotlin
-// Construct claims array
-val claims = mapOf(
-    "sub" to "user-id", 
-    "first_name" to "John",
-    "last_name" to "Appleseed"
-)
-
-// 2FA - uses device related key and user PIN code
-val authentication = PowerAuthAuthentication.possessionWithPassword("1234")
-
-// Unlock the secure vault, fetch the private key and perform data signing
-powerAuthSDK.signJwtWithDevicePrivateKey(context, authentication, claims, object : IJwtSignatureListener {
-    override fun onJwtSignatureSucceed(jwt: String) {
-        // Use JWT value
-    }
-
-    override fun onJwtSignatureFailed(t: Throwable) {
-        // Authentication or network error
-    }
-})
-```
-
 ### Symmetric Offline Multi-Factor Authentication Code
 
 This type of authentication is very similar to [Symmetric Multi-Factor Authentication Code](#symmetric-multi-factor-authentication-code) but the result is provided in the form of a simple, human-readable string (unlike the online version, where the result is an HTTP header). To calculate the code, you need a typical `PowerAuthAuthentication` object to define all required factors, nonce and data to sign. The `nonce` and `data` should also be transmitted to the application over the OOB channel (for example, by scanning a QR code). Then the authentication code calculation is straightforward:
@@ -783,20 +790,226 @@ The application has to show that calculated code to the user now, and the user h
 You can alter the length of the code components by using `offlineAuthenticationCodeComponentLength()` function of `PowerAuthConfiguration.Builder` class.
 <!-- end -->
 
-### Verify Server-Signed Data
+## Digital Signatures
 
-This task is useful whenever you need to receive arbitrary data from the server and you need to be able to verify that the server has issued the data. The PowerAuthSDK provides a high-level method for validating data and associated signature:  
+Digital signatures are another form of data authentication supported in the PowerAuth protocol. The PowerAuth Mobile SDK provides a unified interface for digital signatures, allowing you to compute or verify digital signatures or MAC tokens.
+
+### Signature Key Identifiers
+
+To compute or verify a signature, you must specify the key used for the operation. The following basic key categories are available:
+
+- **"master"** public keys are used to verify data signed by the server. These keys can be used with or without an activation present in the `PowerAuthSDK` instance.
+- **"server"** public keys are personalized keys uniquely associated with an activation. You can use these keys to verify data signed by the server.
+- **"device"** private and public keys are stored locally on the device and associated with an activation. You can use these keys to sign data and to verify previously signed data.
+- **"MAC"** keys are symmetric keys used to verify MACs calculated by the server.
+
+The table below lists all available key identifiers defined in the `PowerAuthSignatureKeyId` enumeration and operations supported with the identifier:
+
+| Key identifier     | Key Type  | Signature       | Activation  | Sign | Verify | Description |
+|--------------------|-----------|-----------------|-------------|------|--------|--------------|
+| `MASTER`           | Any       | Any or Hybrid   | No          | No   | Yes    | Use all available "master" public keys for signature verification. |
+| `MASTER_EC`        | EC        | ECDSA           | No          | No   | Yes    | Use only the EC-based "master" public key for ECDSA signature verification. |
+| `MASTER_ML_DSA`    | ML-DSA    | ML-DSA          | No          | No   | Yes    | Use only the ML-DSA-based "master" public key for ML-DSA signature verification. |
+| `SERVER`           | Any       | Any or Hybrid   | Yes         | No   | Yes    | Use all available "server" public keys for signature verification. |
+| `SERVER_EC`        | EC        | ECDSA           | Yes         | No   | Yes    | Use only the EC-based "server" public key for ECDSA signature verification. |
+| `SERVER_ML_DSA`    | ML-DSA    | ML-DSA          | Yes         | No   | Yes    | Use only the ML-DSA-based "server" public key for ML-DSA signature verification. |
+| `DEVICE`           | Any       | Any or Hybrid   | Yes         | Yes  | Yes    | Use all available "device" private and public keys for signature computation or verification. |
+| `DEVICE_EC`        | EC        | ECDSA           | Yes         | Yes  | Yes    | Use only the EC-based "device" private and public key for ECDSA signature computation or verification. |
+| `DEVICE_ML_DSA`    | ML-DSA    | ML-DSA          | Yes         | Yes  | Yes    | Use only the ML-DSA-based "device" private and public key for ML-DSA signature computation or verification. |
+| `MAC_PERSONALIZED` | MAC       | KMAC            | Yes         | No   | Yes    | Use the KMAC-based symmetric key for MAC verification. |
+
+<!-- begin box info -->
+If you're interested in more technical details, such as the exact algorithms used for digital signatures, see the [Digital-Signatures.md](Digital-Signatures.md) document.
+<!-- end -->
+
+#### Signature Key Availability
+
+The availability of key types depends on the selected [PowerAuth Algorithm](#algorithms-for-communication):
+
+- **"EC"** keys are always available.
+- **"ML_DSA"** keys are available only if the `EC_P384_ML_L3` or `EC_P384_ML_L5` algorithms are used.
+- **"MAC"** keys are available for all algorithms except `LEGACY_P256`.
+
+<!-- begin box warning -->
+If you select a key without specifying its exact type (for example, `.master`), it may lead to multiple key selections. For example, the `EC_P384_ML_L3` and `EC_P384_ML_L5` algorithms use two keys for each key category. The format of hybrid signatures is not yet standardized; therefore, the PowerAuth Mobile SDK supports such key identifiers only in JWS functions. JWS, by design, supports multiple keys in signatures.
+<!-- end -->
+
+### Sign Data With Device Private Key
+
+To compute a digital signature using an asymmetric device private key, request user credentials (such as password or PIN), specify the signing key (always use the "device" key), and use the following code:
 
 ```kotlin
-// Validate data signed with the master server key
-if (powerAuthSDK.verifyServerSignedData(data, signature, true)) {
-    // data is signed with server's private master key
-}
-// Validate data signed with the personalized server key
-if (powerAuthSDK.verifyServerSignedData(data, signature, false)) {
-    // data is signed with the server's private key
-}  
+// 2FA authentication — uses the device-related key and user PIN code
+val authentication = PowerAuthAuthentication.possessionWithPassword("1234")
+// Specify the key to sign with. In this case, DEVICE_ML_DSA is used,
+// and therefore an ML-DSA signature will be produced.
+val signingKey = PowerAuthSignatureKeyId.DEVICE_ML_DSA
+// Data to sign
+val data = "hello".getBytes()
+// Calculate signature
+powerAuthSDK.calculateDigitalSignature(authentication, data, signingKey, object: IDigitalSignatureListener {
+    override fun onDigitalSignatureSucceed(signature: ByteArray) {
+        // Use data signature...
+    }
+
+    override fun onDigitalSignatureFailed(throwable: Throwable) {
+        // Report error
+    }
+})
 ```
+
+<!-- begin box info -->
+If the `PowerAuthSDK` instance is not configured for the legacy mode (that is, the algorithm is not `LEGACY_P256`), you can also use biometric authentication to access the device private key.
+<!-- end -->
+
+### Create JSON Web Signature with Device Private Key 
+
+The asymmetric private key signatures described in the previous chapter can be used to create a [JSON Web Signature (JWS)](https://www.rfc-editor.org/rfc/rfc7515). The example below demonstrates how to construct a JWS from generic data:
+
+```kotlin
+// 2FA authentication — uses the device-related key and user PIN code
+val authentication = PowerAuthAuthentication.possessionWithPassword("1234")
+// Specify the key to sign with. In this case, DEVICE_ML_DSA is used,
+// and therefore an ML-DSA signature will be produced.
+val signingKey = PowerAuthSignatureKeyId.DEVICE_ML_DSA
+// Data to sign
+val data = "hello".getBytes()
+// Unlock the device private key after successful authentication and perform data signing.
+// - The dataType parameter is added to the JWS Protected Header under the "typ" key.
+//   A null parameter means that no "typ" value is included in the header.
+// - The compact parameter determines whether the output is a JWS (compact = false) or JWT (compact = true).
+powerAuthSDK.calculateJwsSignature(authentication, data, null, false, signingKey, object: IJwsSignatureListener {
+    override fun onJwsSignatureSucceed(signedData: String, compactForm: Boolean) {
+        // Use signed data
+    }
+
+    override fun onJwsSignatureFailed(throwable: Throwable) {
+        // Report error
+    }    
+})
+```
+
+The following example demonstrates how to construct a signed JWT:
+
+```kotlin
+// Construct claims array
+val claims = mapOf(
+    "sub" to "user-id", 
+    "first_name" to "John",
+    "last_name" to "Appleseed"
+)
+// Convert to JSON bytes
+val claimsData = Gson().toJson(claims).toByteArray()
+// 2FA authentication — uses the device-related key and user PIN code
+val authentication = PowerAuthAuthentication.possessionWithPassword("1234")
+// Specify the key to sign with. In this case, DEVICE_ML_DSA is used,
+// and therefore an ML-DSA signature will be produced.
+val signingKey = PowerAuthSignatureKeyId.DEVICE_ML_DSA
+// Unlock the secure vault, fetch the private key, and perform data signing
+powerAuthSDK.calculateJwsSignature(authentication, claimsData, "JWT", true, signingKey, object: IJwsSignatureListener {
+    override fun onJwsSignatureSucceed(signedData: String, compactForm: Boolean) {
+        // Use signed data
+    }
+
+    override fun onJwsSignatureFailed(throwable: Throwable) {
+        // Report error
+    }    
+})
+```
+
+### Verify Server-Signed Data
+
+This task is useful when you receive arbitrary data from the server and need to verify that it was indeed issued by the server. The `PowerAuthSDK` provides a high-level method for validating data and its associated signature:
+
+```kotlin
+try {
+    verifyDigitalSignature(signature, signedData, PowerAuthSignatureKeyId.SERVER_ML_DSA)
+    // success, signature is valid
+} catch (exception: PowerAuthErrorException) {
+    // failure
+    if (exception.powerAuthErrorCode == PowerAuthErrorCodes.WRONG_SIGNATURE) {
+        // Invalid signature
+    } else {
+        // Other failure, such as missing activation
+    }
+}
+```
+
+#### Verify Data Encoded in QR Code
+
+In cases where you need to verify the authenticity of a QR code created on the server and authenticated with a personalized MAC key (for example, when authenticity is bound to an activation), use the `MAC_PERSONALIZED` key identifier. For example:
+
+```kotlin
+try {
+    verifyDigitalSignature(signature, signedData, PowerAuthSignatureKeyId.MAC_PERSONALIZED)
+    // success, MAC is valid
+} catch (exception: PowerAuthErrorException) {
+    // failure
+    if (exception.powerAuthErrorCode == PowerAuthErrorCodes.WRONG_SIGNATURE) {
+        // Invalid MAC
+    } else {
+        // Other failure, such as missing activation
+    }
+}
+```
+
+### Verify JSON Web Signature
+
+To verify a JSON Web Signature (JWS) created on the server, use the following code:
+
+```kotlin
+try {
+    verifyJwsSignature(jws, false, true, PowerAuthSignatureKeyId.SERVER)
+    // success, JWS is valid
+} catch (exception: PowerAuthErrorException) {
+    // failure
+    if (exception.powerAuthErrorCode == PowerAuthErrorCodes.WRONG_SIGNATURE) {
+        // Invalid signature
+    } else {
+        // Other failure, such as missing activation
+    }
+}
+```
+
+Explanation of `verifyJwsSignature` function parameters:
+
+- `signature` - A string containing JWS or JWT signed data.
+- `compactForm` - If `true`, the input string is a compact JWT; otherwise, a full JWS object is expected.
+- `strictVerify` — If `true`, all selected keys must successfully verify their corresponding signatures. If `false`, verification succeeds when at least one provided key matches a valid signature; however, invalid or mismatched signatures still result in an error. It is generally recommended to use `true`, unless you have a specific reason to reduce the strict verification.
+- `keyIdentifier`- The identifier of the key used for verification. Be aware, that this API doesn't support `PowerAuthSignatureKeyId.MAC_PERSONALIZED` key.
+
+<!-- begin box warning -->
+The compact (JWT) format encodes only a single signature, so it is recommended to specify the exact key type (EC, ML-DSA, etc.) for verification. If a generic key identifier is provided (such as `PowerAuthSignatureKeyId.SERVER`), the function may fail when the current algorithm results in multiple key selections. You can relax this behavior by setting the `strict` parameter to `false`, but this is generally not recommended. In non-strict mode, an attacker could potentially remove or replace a stronger PQC signature with a weaker one without detection.
+<!-- end box -->
+
+### Getting Device Public Keys
+
+Use the following code to retrieve device public keys associated with the activation:
+
+```swift
+try {
+    val keys = exportDevicePublicKeys(PowerAuthDevicePublicKeyFormat.DER)
+    for (key in keys) {
+        if (key.keyType == PowerAuthSignatureKeyType.EC) {
+            println("EC key algorithm: ${key.keyAlgorithm}")
+            println("  X.509 key data: ${Base64.getEncoder().encodeToString(key.keyData)}")
+        } else {
+            println("ML-DSA key algorithm: ${key.keyAlgorithm}")
+            println("       X.509 key data: ${Base64.getEncoder().encodeToString(key.keyData)}")
+        }
+    }
+} catch (exception: PowerAuthErrorException) {
+    // Fail, such as missing activation
+}
+```
+
+Available format specifiers:
+
+- `PowerAuthDevicePublicKeyFormat.DER` - The public key is exported in binary X.509 (DER) format.
+- `PowerAuthDevicePublicKeyFormat.RAW` - The raw key format depends on the key type:
+  - **EC keys**: The output is ASN.1 encoded, as defined in **ANSI X9.63**.
+  - **ML-DSA keys**: The output contains the raw public key obtained via OpenSSL’s `EVP_PKEY_get_raw_public_key()`.
+
 
 ## Password Change
 

--- a/docs/PowerAuth-SDK-for-iOS.md
+++ b/docs/PowerAuth-SDK-for-iOS.md
@@ -533,10 +533,6 @@ if powerAuthSDK.hasValidActivation() {
 
 This chapter explains activation states in detail. To get more information about activation lifecycle, check the [Activation States](https://github.com/wultra/powerauth-crypto/blob/develop/docs/Activation.md#activation-states) chapter available in our [powerauth-crypto](https://github.com/wultra/powerauth-crypto) repository.
 
-#### `PowerAuthActivationState.created` 
-
-The activation record is created using an external channel, such as the Internet banking, but the key exchange between the client and server did not happen yet. This state is never reported to the mobile client.
-
 #### `PowerAuthActivationState.pendingCommit`
 
 The activation record is created, and the key exchange between the client and server has already taken place, but the activation record on the server requires additional approval before it can be used. This approval is typically performed through an internet banking platform by the client or handled by an authorized representative in a back office system.

--- a/docs/PowerAuth-SDK-for-iOS.md
+++ b/docs/PowerAuth-SDK-for-iOS.md
@@ -143,7 +143,7 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
 The `PowerAuthConfiguration` has the following additional properties:
 
 - `algorithm` - Alters [algorithm](#algorithms-for-communication) used for the communication with the PowerAuth Server.
-- `offlineaAthenticationCodeComponentLength` - Alters the default component length for the [offline authentication code](#symmetric-offline-multi-factor-authentication-code). The values between 4 and 8 are allowed. The default value is 8.
+- `offlineAuthenticationCodeComponentLength` - Alters the default component length for the [offline authentication code](#symmetric-offline-multi-factor-authentication-code). The values between 4 and 8 are allowed. The default value is 8.
 - `externalEncryptionKey` - See [External Encryption Key](#external-encryption-key) chapter for more details.
 - `keychainKey_Biometry` - Specifies the 'key' used to store the `PowerAuthSDK` instance’s biometry-related key in the biometry keychain. If not set, the `instanceId` is applied. Do not alter this configuration unless you have a valid reason to do so.
 

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/PowerAuthTestHelper.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/PowerAuthTestHelper.java
@@ -272,6 +272,9 @@ public class PowerAuthTestHelper {
                     Logger.e("Shared PowerAuthSDK doesn't have a valid activation at test initialization.");
                 }
             }
+            // Apply client API to server API
+            serverApi.setClientAlgorithm(sdk.getCurrentAlgorithm());
+            // Build helper
             return new PowerAuthTestHelper(
                     context,
                     testConfig,

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/client/HttpRestClient.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/client/HttpRestClient.java
@@ -117,9 +117,9 @@ public class HttpRestClient {
     private @NonNull ResponseData sendAndReceiveData(@NonNull RequestData requestData) throws Exception {
 
         if (isVerboseLog) {
-            Logger.d("Test HTTP Send " + requestData.method + " to: " + requestData.url + "\n- body: " + new String(requestData.body, StandardCharsets.UTF_8));
+            Logger.d("%s", "Test HTTP Send " + requestData.method + " to: " + requestData.url + "\n- body: " + new String(requestData.body, StandardCharsets.UTF_8));
         } else {
-            Logger.d("Test HTTP Send " + requestData.method + " to: " + requestData.url);
+            Logger.d("%s", "Test HTTP Send " + requestData.method + " to: " + requestData.url);
         }
 
         final URL url = new URL(requestData.url);
@@ -142,9 +142,9 @@ public class HttpRestClient {
         final byte[] responseData = loadBytesFromInputStream(inputStream);
 
         if (isVerboseLog) {
-            Logger.d("Test HTTP Recv " + responseCode + " from: " + requestData.url + "\n- body: " + new String(responseData, StandardCharsets.UTF_8));
+            Logger.d("%s", "Test HTTP Recv " + responseCode + " from: " + requestData.url + "\n- body: " + new String(responseData, StandardCharsets.UTF_8));
         } else {
-            Logger.d("Test HTTP Recv " + responseCode + " from: " + requestData.url);
+            Logger.d("%s", "Test HTTP Recv " + responseCode + " from: " + requestData.url);
         }
 
         return new ResponseData(responseCode, responseData);

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/model/OfflineSignaturePayload.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/model/OfflineSignaturePayload.java
@@ -16,13 +16,21 @@
 
 package io.getlime.security.powerauth.integration.support.model;
 
+import androidx.annotation.NonNull;
+
+import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+
+import java.util.Arrays;
 
 public class OfflineSignaturePayload {
 
     private String nonce;
     @SerializedName("offlineData")
     private String data;
+
+    @Expose(serialize = false)
+    private String[] dataComponents;
 
     public String getNonce() {
         return nonce;
@@ -38,5 +46,47 @@ public class OfflineSignaturePayload {
 
     public void setData(String data) {
         this.data = data;
+        this.dataComponents = null;
+    }
+
+    @NonNull
+    public String[] getParsedComponents() {
+        if (dataComponents == null) {
+            if (data == null) {
+                throw new IllegalStateException("No offline data received");
+            }
+            String[] components = data.split("\n");
+            int count = components.length;
+            if (components.length <= 2) {
+                throw new IllegalStateException("Wrong offline data received");
+            }
+            String nonce = components[count - 2];
+            String signS = components[count - 1];
+            String key = signS.substring(0, 1);
+            String sign = signS.substring(1);
+            String data = String.join("\n", Arrays.copyOfRange(components, 0, count - 2));
+            dataComponents = new String[] { data, nonce, key, sign };
+        }
+        return dataComponents;
+    }
+    public String getParsedData() {
+        return getParsedComponents()[0];
+    }
+
+    public String getParsedNonce() {
+        return getParsedComponents()[1];
+    }
+
+    public String getParsedSigningKey() {
+        return getParsedComponents()[2];
+    }
+
+    public String getParsedSignature() {
+        return getParsedComponents()[3];
+    }
+
+    public String getParsedSignedData() {
+        String[] components = getParsedComponents();
+        return String.join("\n", Arrays.copyOfRange(components, 0, components.length - 1));
     }
 }

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v20/endpoints/CreateNonPersonalizedOfflineSignaturePayloadEndpoint.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v20/endpoints/CreateNonPersonalizedOfflineSignaturePayloadEndpoint.java
@@ -29,7 +29,7 @@ public class CreateNonPersonalizedOfflineSignaturePayloadEndpoint implements ISe
     @NonNull
     @Override
     public String getRelativePath() {
-        return "/rest/v4/signature/offline/non-personalized/create";
+        return "/rest/v4/auth/offline/non-personalized/create";
     }
 
     @Nullable

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v20/endpoints/CreatePersonalizedOfflineSignaturePayloadEndpoint.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/v20/endpoints/CreatePersonalizedOfflineSignaturePayloadEndpoint.java
@@ -29,7 +29,7 @@ public class CreatePersonalizedOfflineSignaturePayloadEndpoint implements IServe
     @NonNull
     @Override
     public String getRelativePath() {
-        return "/rest/v4/signature/offline/personalized/create";
+        return "/rest/v4/auth/offline/personalized/create";
     }
 
     @Nullable

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BaseSdkTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BaseSdkTest.java
@@ -16,21 +16,13 @@
 
 package io.getlime.security.powerauth.integration.tests;
 
-import android.text.TextUtils;
-import android.util.Base64;
-
 import androidx.annotation.NonNull;
-
-import com.google.gson.reflect.TypeToken;
 
 import io.getlime.security.powerauth.core.CoreEncryptor;
 import io.getlime.security.powerauth.core.SecureData;
-import io.getlime.security.powerauth.integration.support.model.SignatureFormat;
-import io.getlime.security.powerauth.integration.support.model.SignatureType;
 import io.getlime.security.powerauth.sdk.PowerAuthActivationState;
 import io.getlime.security.powerauth.sdk.PowerAuthActivationStatus;
 import io.getlime.security.powerauth.sdk.PowerAuthAlgorithm;
-import io.getlime.security.powerauth.sdk.impl.JsonSerialization;
 import io.getlime.security.powerauth.networking.response.*;
 import org.junit.After;
 import org.junit.Before;
@@ -38,10 +30,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.getlime.security.powerauth.exception.PowerAuthErrorCodes;
@@ -534,63 +523,6 @@ public class BaseSdkTest {
         // Check the last fetched User Info was updated (i.e. JWT ID was changed).
         assertNotEquals(info.getAllClaims().get("jti"), infoFromActivation.getAllClaims().get("jti"));
         assertEquals(info.getAllClaims().get("jti"), powerAuthSDK.getLastFetchedUserInfo().getAllClaims().get("jti"));
-    }
-
-    // JWT
-
-    @Test
-    public void testJwtSignature() throws Exception {
-        activationHelper.createStandardActivation(true, null);
-
-        // Get JWT
-        final HashMap<String, Object> originalClaims = new HashMap<>();
-        originalClaims.put("sub", "1234567890");
-        originalClaims.put("name", "John Doe");
-        originalClaims.put("admin", true);
-        final String jwt = AsyncHelper.await(resultCatcher -> {
-            ICancelable task = powerAuthSDK.signJwtWithDevicePrivateKey(testHelper.getContext(), activationHelper.getValidAuthentication(), originalClaims, new IJwtSignatureListener() {
-                @Override
-                public void onJwtSignatureSucceed(@NonNull String jwt) {
-                    resultCatcher.completeWithResult(jwt);
-                }
-
-                @Override
-                public void onJwtSignatureFailed(@NonNull Throwable t) {
-                    resultCatcher.completeWithError(t);
-                }
-            });
-            assertNotNull(task);
-        });
-
-        // Parse JWT and validate result
-        final JsonSerialization jsonSerialization = new JsonSerialization();
-        final String[] jwtComponents = TextUtils.split(jwt, "\\.");
-        assertEquals(3, jwtComponents.length);
-        final String jwtHeader = jwtComponents[0];
-        final String jwtClaims = jwtComponents[1];
-        final String jwtSignature = jwtComponents[2];
-        // Validate header
-        Map<String, Object> headerObject = jsonSerialization.deserializeObject(Base64.decode(jwtHeader, Base64.NO_WRAP | Base64.URL_SAFE | Base64.NO_PADDING), new TypeToken<Map<String, Object>>() {});
-        assertEquals("JWT", headerObject.get("typ"));
-        assertEquals("ES256", headerObject.get("alg"));
-        // Validate claims
-        Map<String, Object> claimsObject = jsonSerialization.deserializeObject(Base64.decode(jwtClaims, Base64.NO_WRAP | Base64.URL_SAFE | Base64.NO_PADDING), new TypeToken<Map<String, Object>>() {});
-        assertEquals(originalClaims.size(), claimsObject.size());
-        claimsObject.forEach((key, value) -> {
-            assertEquals(originalClaims.get(key), value);
-        });
-        // Prepare signed data
-        final String jwtSignedDatasBase64 = Base64.encodeToString((jwtHeader + "." + jwtClaims).getBytes(StandardCharsets.US_ASCII), Base64.NO_WRAP);
-        // Decode signature and encode back to Base64
-        final String jwtSignatureBase64 = Base64.encodeToString(
-                Base64.decode(jwtSignature, Base64.NO_WRAP | Base64.URL_SAFE | Base64.NO_PADDING),
-                Base64.NO_WRAP
-        );
-
-        // Validate signature
-        // Note that signature format is supported from PAS 1.9+
-        boolean result = testHelper.getServerApi().verifyDsaSignature(activationHelper.getActivation().getActivationId(), jwtSignedDatasBase64, jwtSignatureBase64, SignatureFormat.JOSE, SignatureType.ECDSA);
-        assertTrue(result);
     }
 
     @Test

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/DsaSignatureTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/DsaSignatureTest.java
@@ -16,10 +16,17 @@
 
 package io.getlime.security.powerauth.integration.tests;
 
+import androidx.annotation.BoolRes;
 import androidx.annotation.NonNull;
 import android.text.TextUtils;
 import android.util.Base64;
 
+import io.getlime.security.powerauth.exception.PowerAuthErrorCodes;
+import io.getlime.security.powerauth.exception.PowerAuthErrorException;
+import io.getlime.security.powerauth.integration.support.model.Activation;
+import io.getlime.security.powerauth.integration.support.model.ActivationDetail;
+import io.getlime.security.powerauth.integration.support.model.AuthenticationCodeData;
+import io.getlime.security.powerauth.integration.support.model.AuthenticationResult;
 import io.getlime.security.powerauth.integration.support.model.SignatureFormat;
 import io.getlime.security.powerauth.integration.support.model.SignatureType;
 import io.getlime.security.powerauth.networking.interfaces.ICancelable;
@@ -30,17 +37,34 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 import io.getlime.security.powerauth.integration.support.AsyncHelper;
 import io.getlime.security.powerauth.integration.support.PowerAuthTestHelper;
 import io.getlime.security.powerauth.integration.support.model.OfflineSignaturePayload;
 import io.getlime.security.powerauth.networking.response.IDataSignatureListener;
+import io.getlime.security.powerauth.networking.response.IDigitalSignatureListener;
+import io.getlime.security.powerauth.networking.response.IJwsSignatureListener;
+import io.getlime.security.powerauth.networking.response.IJwtSignatureListener;
+import io.getlime.security.powerauth.networking.response.IOfflineAuthenticationCodeListener;
 import io.getlime.security.powerauth.sdk.PowerAuthAlgorithm;
+import io.getlime.security.powerauth.sdk.PowerAuthAuthentication;
+import io.getlime.security.powerauth.sdk.PowerAuthDevicePublicKeyData;
+import io.getlime.security.powerauth.sdk.PowerAuthDevicePublicKeyFormat;
 import io.getlime.security.powerauth.sdk.PowerAuthSDK;
+import io.getlime.security.powerauth.sdk.PowerAuthSignatureKeyId;
+import io.getlime.security.powerauth.sdk.PowerAuthSignatureKeyType;
+import io.getlime.security.powerauth.sdk.impl.JsonSerialization;
 
 import static org.junit.Assert.*;
+
+import com.google.gson.reflect.TypeToken;
 
 @RunWith(Parameterized.class)
 public class DsaSignatureTest {
@@ -59,6 +83,7 @@ public class DsaSignatureTest {
     private PowerAuthTestHelper testHelper;
     private PowerAuthSDK powerAuthSDK;
     private ActivationHelper activationHelper;
+    private AuthenticationHelper authenticationHelper;
 
     @Before
     public void setUp() throws Exception {
@@ -67,6 +92,7 @@ public class DsaSignatureTest {
                 .build();
         powerAuthSDK = testHelper.getSharedSdk();
         activationHelper = new ActivationHelper(testHelper);
+        authenticationHelper = new AuthenticationHelper();
     }
 
     @After
@@ -77,7 +103,518 @@ public class DsaSignatureTest {
     }
 
     @Test
-    public void testDeviceSignedData() throws Exception {
+    public void testExportDevicePublicKey() throws Exception {
+        // Without activation function should fail
+        try {
+            List<PowerAuthDevicePublicKeyData> keys = powerAuthSDK.exportDevicePublicKeys(PowerAuthDevicePublicKeyFormat.DER);
+            fail();
+        } catch (PowerAuthErrorException exception) {
+            assertEquals(PowerAuthErrorCodes.MISSING_ACTIVATION, exception.getPowerAuthErrorCode());
+        }
+
+        // Now create activation
+        activationHelper.createStandardActivation(false, null);
+
+        HashMap<Integer, String> keyMapping = new HashMap<>(2);
+        switch (getAlgorithmForTest()) {
+            case PowerAuthAlgorithm.LEGACY_P256:
+                keyMapping.put(PowerAuthSignatureKeyType.EC, "P-256");
+                break;
+            case PowerAuthAlgorithm.EC_P384:
+                keyMapping.put(PowerAuthSignatureKeyType.EC, "P-384");
+                break;
+            case PowerAuthAlgorithm.EC_P384_ML_L3:
+                keyMapping.put(PowerAuthSignatureKeyType.EC, "P-384");
+                keyMapping.put(PowerAuthSignatureKeyType.ML_DSA, "ML-DSA-65");
+                break;
+            case PowerAuthAlgorithm.EC_P384_ML_L5:
+                keyMapping.put(PowerAuthSignatureKeyType.EC, "P-384");
+                keyMapping.put(PowerAuthSignatureKeyType.ML_DSA, "ML-DSA-87");
+                break;
+            default:
+                fail("Unsupported algorithm");
+        }
+
+        List<PowerAuthDevicePublicKeyData> keys = powerAuthSDK.exportDevicePublicKeys(PowerAuthDevicePublicKeyFormat.DER);
+        int matched = 0;
+        for (PowerAuthDevicePublicKeyData keyData : keys) {
+            String expectedAlgorithm = keyMapping.get(keyData.getKeyType());
+            assertNotNull(expectedAlgorithm);
+            assertEquals(expectedAlgorithm, keyData.getKeyAlgorithm());
+            matched++;
+        }
+        assertEquals(keyMapping.size(), matched);
+
+        keys = powerAuthSDK.exportDevicePublicKeys(PowerAuthDevicePublicKeyFormat.RAW);
+        matched = 0;
+        for (PowerAuthDevicePublicKeyData keyData : keys) {
+            String expectedAlgorithm = keyMapping.get(keyData.getKeyType());
+            assertNotNull(expectedAlgorithm);
+            assertEquals(expectedAlgorithm, keyData.getKeyAlgorithm());
+            matched++;
+        }
+        assertEquals(keyMapping.size(), matched);
+    }
+
+    @Test
+    public void testActivationCodeSignature() throws Exception {
+        activationHelper.createStandardActivation(false, null);
+        Activation activation = activationHelper.getActivation();
+        final byte[] activationCodeData = activation.getActivationCode().getBytes(StandardCharsets.UTF_8);
+        switch (getAlgorithmForTest()) {
+            case PowerAuthAlgorithm.LEGACY_P256:
+                assertNotNull(activation.getActivationSignatureLegacy());
+                powerAuthSDK.verifyDigitalSignature(
+                        Base64.decode(activation.getActivationSignatureLegacy(), Base64.NO_WRAP),
+                        activationCodeData,
+                        PowerAuthSignatureKeyId.MASTER_EC
+                );
+                break;
+            case PowerAuthAlgorithm.EC_P384:
+                assertNotNull(activation.getActivationSignatureEcdsaP384());
+                powerAuthSDK.verifyDigitalSignature(
+                        Base64.decode(activation.getActivationSignatureEcdsaP384(), Base64.NO_WRAP),
+                        activationCodeData,
+                        PowerAuthSignatureKeyId.MASTER_EC
+                );
+                break;
+            case PowerAuthAlgorithm.EC_P384_ML_L3:
+                assertNotNull(activation.getActivationSignatureEcdsaP384());
+                assertNotNull(activation.getActivationSignatureMlDsa65());
+                powerAuthSDK.verifyDigitalSignature(
+                        Base64.decode(activation.getActivationSignatureEcdsaP384(), Base64.NO_WRAP),
+                        activationCodeData,
+                        PowerAuthSignatureKeyId.MASTER_EC
+                );
+                powerAuthSDK.verifyDigitalSignature(
+                        Base64.decode(activation.getActivationSignatureMlDsa65(), Base64.NO_WRAP),
+                        activationCodeData,
+                        PowerAuthSignatureKeyId.MASTER_ML_DSA
+                );
+                break;
+            case PowerAuthAlgorithm.EC_P384_ML_L5:
+                assertNotNull(activation.getActivationSignatureEcdsaP384());
+                assertNotNull(activation.getActivationSignatureMlDsa87());
+                powerAuthSDK.verifyDigitalSignature(
+                        Base64.decode(activation.getActivationSignatureEcdsaP384(), Base64.NO_WRAP),
+                        activationCodeData,
+                        PowerAuthSignatureKeyId.MASTER_EC
+                );
+                powerAuthSDK.verifyDigitalSignature(
+                        Base64.decode(activation.getActivationSignatureMlDsa87(), Base64.NO_WRAP),
+                        activationCodeData,
+                        PowerAuthSignatureKeyId.MASTER_ML_DSA
+                );
+                break;
+            default:
+                fail("Unsupported algorithm");
+                break;
+        }
+    }
+
+    @Test
+    public void testVerifyOfflineServerSignedData() throws Exception {
+        OfflineSignaturePayload payload;
+        {
+            // Verify data signed with master key (non-personalized)
+            String dataForSigning = Base64.encodeToString("All your money are belong to us!".getBytes(StandardCharsets.UTF_8), Base64.NO_WRAP);
+            // prepare signed data
+            payload = testHelper.getServerApi().createNonPersonalizedOfflineSignaturePayload(testHelper.getSharedApplication().getApplicationId(), dataForSigning);
+            assertEquals(payload.getParsedData(), dataForSigning);
+            assertEquals("0", payload.getParsedSigningKey());
+            // verify
+            byte[] signedDataBytes = payload.getParsedSignedData().getBytes(StandardCharsets.UTF_8);
+            powerAuthSDK.verifyDigitalSignature(
+                    Base64.decode(payload.getParsedSignature(), Base64.NO_WRAP),
+                    signedDataBytes,
+                    PowerAuthSignatureKeyId.MASTER_EC);
+            // Bad data
+            signedDataBytes[0] ^= 127;
+            try {
+                powerAuthSDK.verifyDigitalSignature(
+                        Base64.decode(payload.getParsedSignature(), Base64.NO_WRAP),
+                        signedDataBytes,
+                        PowerAuthSignatureKeyId.MASTER_EC
+                );
+                fail("Function above must fail");
+            } catch (PowerAuthErrorException exception) {
+                assertEquals(PowerAuthErrorCodes.WRONG_SIGNATURE, exception.getPowerAuthErrorCode());
+            }
+        }
+        // Create activation
+        activationHelper.createStandardActivation(false, null);
+        Activation activation = activationHelper.getActivation();
+        PowerAuthAuthentication authentication = activationHelper.getValidAuthentication();
+        {
+            // Retry after activation creation
+            // Verify data signed with master key (non-personalized)
+            String dataForSigning = Base64.encodeToString("All your money are belong to us!".getBytes(StandardCharsets.UTF_8), Base64.NO_WRAP);
+            // prepare signed data
+            payload = testHelper.getServerApi().createNonPersonalizedOfflineSignaturePayload(testHelper.getSharedApplication().getApplicationId(), dataForSigning);
+            assertEquals(payload.getParsedData(), dataForSigning);
+            assertEquals("0", payload.getParsedSigningKey());
+            // verify
+            byte[] signedDataBytes = payload.getParsedSignedData().getBytes(StandardCharsets.UTF_8);
+            powerAuthSDK.verifyDigitalSignature(
+                    Base64.decode(payload.getParsedSignature(), Base64.NO_WRAP),
+                    signedDataBytes,
+                    PowerAuthSignatureKeyId.MASTER_EC);
+            // Bad data
+            signedDataBytes[0] ^= 127;
+            try {
+                powerAuthSDK.verifyDigitalSignature(
+                        Base64.decode(payload.getParsedSignature(), Base64.NO_WRAP),
+                        signedDataBytes,
+                        PowerAuthSignatureKeyId.MASTER_EC
+                );
+                fail("Function above must fail");
+            } catch (PowerAuthErrorException exception) {
+                assertEquals(PowerAuthErrorCodes.WRONG_SIGNATURE, exception.getPowerAuthErrorCode());
+            }
+        }
+        {
+            // Verify data signed with server key (personalized)
+            final String expectedSigningKey;
+            final int signingKeyId;
+            if (getAlgorithmForTest() == PowerAuthAlgorithm.LEGACY_P256) {
+                // V3 uses SERVER_EC key for signature
+                expectedSigningKey = "1";
+                signingKeyId = PowerAuthSignatureKeyId.SERVER_EC;
+            } else {
+                // V4 uses MAC key
+                expectedSigningKey = "2";
+                signingKeyId = PowerAuthSignatureKeyId.MAC_PERSONALIZED;
+            }
+            String dataForSigning = Base64.encodeToString("All your money are belong to us!".getBytes(StandardCharsets.UTF_8), Base64.NO_WRAP);
+            // prepare signed data
+            payload = testHelper.getServerApi().createPersonalizedOfflineSignaturePayload(activation.getActivationId(), dataForSigning);
+            assertEquals(payload.getParsedData(), dataForSigning);
+            assertEquals(expectedSigningKey, payload.getParsedSigningKey());
+            // verify
+            byte[] signedDataBytes = payload.getParsedSignedData().getBytes(StandardCharsets.UTF_8);
+            powerAuthSDK.verifyDigitalSignature(
+                    Base64.decode(payload.getParsedSignature(), Base64.NO_WRAP),
+                    signedDataBytes,
+                    signingKeyId
+            );
+            // Bad data
+            signedDataBytes[0] ^= 127;
+            try {
+                powerAuthSDK.verifyDigitalSignature(
+                        Base64.decode(payload.getParsedSignature(), Base64.NO_WRAP),
+                        signedDataBytes,
+                        signingKeyId
+                );
+                fail("Function above must fail");
+            } catch (PowerAuthErrorException exception) {
+                assertEquals(PowerAuthErrorCodes.WRONG_SIGNATURE, exception.getPowerAuthErrorCode());
+            }
+        }
+        // Well, we have a data for offline signature, so let's try to verify it.
+        String uriId = "/operation/authorize/offline";
+        byte[] body = payload.getParsedData().getBytes(StandardCharsets.UTF_8);
+        String nonce = payload.getParsedNonce();
+        String offlineAuthCode = AsyncHelper.await(resultCatcher -> {
+            powerAuthSDK.offlineAuthenticationCode(testHelper.getContext(), authentication, uriId, body, nonce, new IOfflineAuthenticationCodeListener() {
+                @Override
+                public void onOfflineAuthenticationCodeSucceed(@NonNull String authenticationCode) {
+                    resultCatcher.completeWithResult(authenticationCode);
+                }
+
+                @Override
+                public void onOfflineAuthenticationCodeFailed(@NonNull PowerAuthErrorException error) {
+                    resultCatcher.completeWithError(error);
+                }
+            });
+        });
+        String normalizedData = authenticationHelper.normalizeOfflineData(payload.getParsedData(), uriId, nonce);
+        AuthenticationCodeData authenticationCodeData = new AuthenticationCodeData();
+        authenticationCodeData.setActivationId(powerAuthSDK.getActivationIdentifier());
+        authenticationCodeData.setData(normalizedData);
+        authenticationCodeData.setAuthenticationCode(offlineAuthCode);
+        authenticationCodeData.setAllowBiometry(false);
+        AuthenticationResult authenticationResult = testHelper.getServerApi().verifyOfflineAuthenticationCode(authenticationCodeData);
+        assertTrue(authenticationResult.isAuthenticationValid());
+    }
+
+    /**
+     * Function calculates signature with device private key and verifies such signature locally and on the server.
+     * @param signatureKeyId Signature key identifier to use.
+     * @param signatureType Signature type.
+     * @param authentication Authentication object.
+     * @param shouldPass If true, test should pass.
+     * @throws Exception In case of failure.
+     */
+    private void verifyDataSignedWithSignatureKeyId(@PowerAuthSignatureKeyId int signatureKeyId, SignatureType signatureType, PowerAuthAuthentication authentication, boolean shouldPass) throws Exception {
+        final byte[] dataForSigning = "This is a very sensitive information and must be signed.".getBytes(StandardCharsets.UTF_8);
+        byte[] resultSignature = AsyncHelper.await(resultCatcher -> {
+            ICancelable task = powerAuthSDK.calculateDigitalSignature(authentication, dataForSigning, signatureKeyId, new IDigitalSignatureListener() {
+                @Override
+                public void onDigitalSignatureSucceed(@NonNull byte[] signature) {
+                    resultCatcher.completeWithResult(signature);
+                }
+
+                @Override
+                public void onDigitalSignatureFailed(@NonNull Throwable throwable) {
+                    resultCatcher.completeWithResult(null);
+                }
+            });
+            if (shouldPass) {
+                assertNotNull(task);
+            }
+        });
+        if (shouldPass) {
+            assertNotNull(resultSignature);
+            // Verify on server
+            boolean result = testHelper.getServerApi().verifyDsaSignature(
+                    Objects.requireNonNull(powerAuthSDK.getActivationIdentifier()),
+                    Base64.encodeToString(dataForSigning, Base64.NO_WRAP),
+                    Base64.encodeToString(resultSignature, Base64.NO_WRAP),
+                    SignatureFormat.DER,
+                    signatureType);
+            assertTrue(result);
+            // Verify locally
+            powerAuthSDK.verifyDigitalSignature(resultSignature, dataForSigning, signatureKeyId);
+        } else {
+            assertNull(resultSignature);
+        }
+    }
+
+    @Test
+    public void testSignDataWithDevicePrivateKey() throws Exception {
+        activationHelper.createStandardActivation(false, null);
+        PowerAuthAuthentication authentication = activationHelper.getValidAuthentication();
+        switch (getAlgorithmForTest()) {
+            case PowerAuthAlgorithm.EC_P384_ML_L5:
+            case PowerAuthAlgorithm.EC_P384_ML_L3:
+                verifyDataSignedWithSignatureKeyId(PowerAuthSignatureKeyId.DEVICE, SignatureType.ECDSA, authentication, false);
+                verifyDataSignedWithSignatureKeyId(PowerAuthSignatureKeyId.DEVICE_EC, SignatureType.ECDSA, authentication, true);
+                verifyDataSignedWithSignatureKeyId(PowerAuthSignatureKeyId.DEVICE_ML_DSA, SignatureType.MLDSA, authentication, true);
+                break;
+            case PowerAuthAlgorithm.EC_P384:
+            case PowerAuthAlgorithm.LEGACY_P256:
+                verifyDataSignedWithSignatureKeyId(PowerAuthSignatureKeyId.DEVICE, SignatureType.ECDSA, authentication, true);
+                verifyDataSignedWithSignatureKeyId(PowerAuthSignatureKeyId.DEVICE_EC, SignatureType.ECDSA, authentication, true);
+                verifyDataSignedWithSignatureKeyId(PowerAuthSignatureKeyId.DEVICE_ML_DSA, SignatureType.MLDSA, authentication, false);
+                break;
+            default:
+                fail("Not supported algorithm");
+                break;
+        }
+    }
+
+    @Test
+    public void testVerifyServerSignedData() throws Exception {
+        activationHelper.createStandardActivation(false, null);
+
+        final byte[] dataForSigning = "This is a very sensitive information and must be signed.".getBytes(StandardCharsets.UTF_8);
+        final byte[] badSignedData  = "This is a very sens1tive information and must be signed.".getBytes(StandardCharsets.UTF_8);
+        Map<SignatureType, String> signatures = testHelper.getServerApi().createDsaSignature(
+                Objects.requireNonNull(powerAuthSDK.getActivationIdentifier()),
+                Base64.encodeToString(dataForSigning, Base64.NO_WRAP));
+        final byte[] mldsa = signatures.get(SignatureType.MLDSA) == null ? null : Base64.decode(signatures.get(SignatureType.MLDSA), Base64.NO_WRAP);
+        final byte[] ecdsa = signatures.get(SignatureType.ECDSA) == null ? null : Base64.decode(signatures.get(SignatureType.ECDSA), Base64.NO_WRAP);
+        switch (getAlgorithmForTest()) {
+            case PowerAuthAlgorithm.LEGACY_P256:
+            case PowerAuthAlgorithm.EC_P384:
+                assertNotNull(ecdsa);
+                assertNull(mldsa);
+                powerAuthSDK.verifyDigitalSignature(ecdsa, dataForSigning, PowerAuthSignatureKeyId.SERVER_EC);
+                // bad data
+                try {
+                    powerAuthSDK.verifyDigitalSignature(ecdsa, badSignedData, PowerAuthSignatureKeyId.SERVER_EC);
+                } catch (PowerAuthErrorException exception) {
+                    assertEquals(PowerAuthErrorCodes.WRONG_SIGNATURE, exception.getPowerAuthErrorCode());
+                }
+                break;
+            case PowerAuthAlgorithm.EC_P384_ML_L5:
+            case PowerAuthAlgorithm.EC_P384_ML_L3:
+                assertNotNull(ecdsa);
+                assertNotNull(mldsa);
+                powerAuthSDK.verifyDigitalSignature(ecdsa, dataForSigning, PowerAuthSignatureKeyId.SERVER_EC);
+                powerAuthSDK.verifyDigitalSignature(mldsa, dataForSigning, PowerAuthSignatureKeyId.SERVER_ML_DSA);
+                // bad data
+                try {
+                    powerAuthSDK.verifyDigitalSignature(ecdsa, badSignedData, PowerAuthSignatureKeyId.SERVER_EC);
+                } catch (PowerAuthErrorException exception) {
+                    assertEquals(PowerAuthErrorCodes.WRONG_SIGNATURE, exception.getPowerAuthErrorCode());
+                }
+                try {
+                    powerAuthSDK.verifyDigitalSignature(mldsa, badSignedData, PowerAuthSignatureKeyId.SERVER_ML_DSA);
+                } catch (PowerAuthErrorException exception) {
+                    assertEquals(PowerAuthErrorCodes.WRONG_SIGNATURE, exception.getPowerAuthErrorCode());
+                }
+                break;
+            default:
+                fail("Unsupported algorithm");
+                break;
+        }
+    }
+
+    /**
+     * Sign data with server private key and verify locally.
+     * @param signatureKeyId Key identifier to use for verify.
+     * @param signatureType Signature type.
+     * @param compactForm Use compact form.
+     * @param strict Use strict verify.
+     * @param shouldPass If true, test should pass.
+     * @throws Exception In case of failure.
+     */
+    private void verifyJwsServerSignedData(@PowerAuthSignatureKeyId int signatureKeyId, SignatureType signatureType, boolean compactForm, boolean strict, boolean shouldPass) throws Exception {
+        final byte[] dataForSigning = "This is a very sensitive information and must be signed.".getBytes(StandardCharsets.UTF_8);
+
+        String jws = testHelper.getServerApi().createJwtSignature(
+                Objects.requireNonNull(powerAuthSDK.getActivationIdentifier()),
+                Base64.encodeToString(dataForSigning, Base64.NO_WRAP),
+                compactForm,
+                signatureType);
+        try {
+            powerAuthSDK.verifyJwsSignature(jws, compactForm, strict, signatureKeyId);
+            assertTrue(shouldPass);
+        } catch (PowerAuthErrorException exception) {
+            assertFalse(shouldPass);
+        }
+    }
+
+    @Test
+    public void testVerifyJwsServerSignedData() throws Exception {
+        switch (getAlgorithmForTest()) {
+            case PowerAuthAlgorithm.LEGACY_P256:
+                // not available for legacy activations
+                break;
+            case PowerAuthAlgorithm.EC_P384:
+                activationHelper.createStandardActivation(false, null);
+                // JWT
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER,       SignatureType.ECDSA, true, true, true);
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER_EC,    SignatureType.ECDSA, true, true, true);
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER,       SignatureType.ECDSA, true, false, true);
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER_EC,    SignatureType.ECDSA, true, false, true);
+                // JWS
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER,       SignatureType.ECDSA, false, true, true);
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER_EC,    SignatureType.ECDSA, false, true, true);
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER,       SignatureType.ECDSA, false, false, true);
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER_EC,    SignatureType.ECDSA, false, false, true);
+                // JWT - hybrid (should work, there's only one key available)
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER,       null, true, true, true);
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER,       null, true, false, true);
+                // JWS - hybrid
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER,       null, false, true, true);
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER,       null, false, false, true);
+                break;
+            case PowerAuthAlgorithm.EC_P384_ML_L3:
+            case PowerAuthAlgorithm.EC_P384_ML_L5:
+                activationHelper.createStandardActivation(false, null);
+                // JWT - ecdsa
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER,       SignatureType.ECDSA, true, true, false); // strict mode require all keys to satisfy
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER_EC,    SignatureType.ECDSA, true, true, true);
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER,       SignatureType.ECDSA, true, false, true);
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER_EC,    SignatureType.ECDSA, true, false, true);
+                // JWT - mldsa
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER,       SignatureType.MLDSA, true, true, false); // strict mode require all keys to satisfy
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER_ML_DSA,SignatureType.MLDSA, true, true, true);
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER,       SignatureType.MLDSA, true, false, true);
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER_ML_DSA,SignatureType.MLDSA, true, false, true);
+                // JWS - ecdsa
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER,       SignatureType.ECDSA, false, true, false); // strict mode require all keys to satisfy
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER_EC,    SignatureType.ECDSA, false, true, true);
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER,       SignatureType.ECDSA, false, false, true);
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER_EC,    SignatureType.ECDSA, false, false, true);
+                // JWS - mldsa
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER,       SignatureType.MLDSA, false, true, false); // strict mode require all keys to satisfy
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER_ML_DSA,SignatureType.MLDSA, false, true, true);
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER,       SignatureType.MLDSA, false, false, true);
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER_ML_DSA,SignatureType.MLDSA, false, false, true);
+                // JWS - hybrid
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER,       null, false, true, true);
+                verifyJwsServerSignedData(PowerAuthSignatureKeyId.SERVER,       null, false, false, true);
+                break;
+
+            default:
+                fail("Unsupported algorithm");
+                break;
+        }
+    }
+
+    /**
+     * Calculate JWS signature and then verify signature on the server and locally.
+     * @param signatureKeyId Key identifier to use for calculation.
+     * @param compact Use compact form.
+     * @param strict Use strict local verification.
+     * @param authentication Authentication object.
+     * @param shouldPass If true, then test should pass.
+     * @throws Exception In case of failure.
+     */
+    private void verifyJwsSignedWithSignatureKeyId(@PowerAuthSignatureKeyId int signatureKeyId, boolean compact, boolean strict, PowerAuthAuthentication authentication, boolean shouldPass) throws Exception {
+        final byte[] dataForSigning = "This is a very sensitive information and must be signed.".getBytes(StandardCharsets.UTF_8);
+        String resultSignature = AsyncHelper.await(resultCatcher -> {
+            ICancelable task = powerAuthSDK.calculateJwsSignature(authentication, dataForSigning, null, compact, signatureKeyId, new IJwsSignatureListener() {
+                @Override
+                public void onJwsSignatureSucceed(@NonNull String signedData, boolean compactForm) {
+                    assertEquals(compact, compactForm);
+                    resultCatcher.completeWithResult(signedData);
+                }
+
+                @Override
+                public void onJwsSignatureFailed(@NonNull Throwable throwable) {
+                    resultCatcher.completeWithResult(null);
+                }
+            });
+            if (shouldPass) {
+                assertNotNull(task);
+            }
+        });
+        if (shouldPass) {
+            assertNotNull(resultSignature);
+            // verify signature on the server
+            boolean result = testHelper.getServerApi().verifyJwtSignature(Objects.requireNonNull(powerAuthSDK.getActivationIdentifier()), resultSignature, compact);
+            assertTrue(result);
+            // verify signature locally
+            try {
+                powerAuthSDK.verifyJwsSignature(resultSignature, compact, strict, signatureKeyId);
+            } catch (PowerAuthErrorException exception) {
+                assertFalse(shouldPass);
+            }
+        } else {
+            assertNull(resultSignature);
+        }
+    }
+
+    @Test
+    public void testJwsSignDataWithDevicePrivateKey() throws Exception {
+        PowerAuthAuthentication authentication;
+        switch (getAlgorithmForTest()) {
+            case PowerAuthAlgorithm.EC_P384_ML_L3:
+            case PowerAuthAlgorithm.EC_P384_ML_L5:
+                activationHelper.createStandardActivation(false, null);
+                authentication = activationHelper.getValidAuthentication();
+                verifyJwsSignedWithSignatureKeyId(PowerAuthSignatureKeyId.DEVICE_ML_DSA, false, true, authentication, true);
+                verifyJwsSignedWithSignatureKeyId(PowerAuthSignatureKeyId.DEVICE_ML_DSA, true, true, authentication, true);
+                verifyJwsSignedWithSignatureKeyId(PowerAuthSignatureKeyId.DEVICE, false, true, authentication, true);
+                verifyJwsSignedWithSignatureKeyId(PowerAuthSignatureKeyId.DEVICE_EC, false, true, authentication, true);
+                verifyJwsSignedWithSignatureKeyId(PowerAuthSignatureKeyId.DEVICE_EC, true, true, authentication, true);
+                break;
+            case PowerAuthAlgorithm.EC_P384:
+                activationHelper.createStandardActivation(false, null);
+                authentication = activationHelper.getValidAuthentication();
+                verifyJwsSignedWithSignatureKeyId(PowerAuthSignatureKeyId.DEVICE, true, true, authentication, true);
+                verifyJwsSignedWithSignatureKeyId(PowerAuthSignatureKeyId.DEVICE, false, true, authentication, true);
+                verifyJwsSignedWithSignatureKeyId(PowerAuthSignatureKeyId.DEVICE_EC, false, true, authentication, true);
+                verifyJwsSignedWithSignatureKeyId(PowerAuthSignatureKeyId.DEVICE_EC, true, true, authentication, true);
+                verifyJwsSignedWithSignatureKeyId(PowerAuthSignatureKeyId.DEVICE_ML_DSA, false, true, authentication, false);
+                break;
+            case PowerAuthAlgorithm.LEGACY_P256:
+                // API not supported on the server.
+                break;
+            default:
+                fail("Unsupported algorithm");
+                break;
+        }
+    }
+
+    // The next tests are using deprecated PowerAuthSDK methods. @Deprecated  // 2.0.0
+
+    @Test
+    public void testDeprecated_DeviceSignedData() throws Exception {
 
         final String testData = "Data signed with device private key: " + testHelper.getRandomGenerator().generateRandomString(10, 32);
 
@@ -112,9 +649,9 @@ public class DsaSignatureTest {
     }
 
     @Test
-    public void testNonPersonalizedServerSignedData() throws Exception {
+    public void testDeprecated_NonPersonalizedServerSignedData() throws Exception {
 
-        final String testData = "HELLO\nThis is a test for ECDSA signature signed with master server public key" + testHelper.getRandomGenerator().generateRandomString(10, 32);
+        final String testData = Base64.encodeToString("All your money are belong to us!".getBytes(StandardCharsets.UTF_8), Base64.NO_WRAP);
 
         final OfflineSignaturePayload payload = testHelper.getServerApi().createNonPersonalizedOfflineSignaturePayload(testHelper.getSharedApplication().getApplicationId(), testData);
         assertNotNull(payload);
@@ -143,7 +680,7 @@ public class DsaSignatureTest {
     }
 
     @Test
-    public void testPersonalizedServerSignedData() throws Exception {
+    public void testDeprecated_PersonalizedServerSignedData() throws Exception {
 
         activationHelper.createStandardActivation(true, null);
 
@@ -165,9 +702,11 @@ public class DsaSignatureTest {
         final byte[] signature = Base64.decode(signatureBase64, Base64.NO_WRAP);
         final byte[] signedBytes = dataForSigning.getBytes(Charset.defaultCharset());
 
+        // Only legacy mode should pass, because V4 uses MAC for verification.
+        boolean shouldPass = getAlgorithmForTest() == PowerAuthAlgorithm.LEGACY_P256;
 
         boolean signatureValid = powerAuthSDK.verifyServerSignedData(signedBytes, signature, false);
-        assertTrue(signatureValid);
+        assertEquals(shouldPass, signatureValid);
 
         // Modify signed bytes to invalidate signature
         signedBytes[33] += 1;
@@ -179,5 +718,61 @@ public class DsaSignatureTest {
         powerAuthSDK.removeActivationLocal(testHelper.getContext());
         signatureInvalid = powerAuthSDK.verifyServerSignedData(signedBytes, signature, false);
         assertFalse(signatureInvalid);
+    }
+
+    @Test
+    public void testDeprecated_JwtSignature() throws Exception {
+        activationHelper.createStandardActivation(true, null);
+
+        // Get JWT
+        final HashMap<String, Object> originalClaims = new HashMap<>();
+        originalClaims.put("sub", "1234567890");
+        originalClaims.put("name", "John Doe");
+        originalClaims.put("admin", true);
+        final String jwt = AsyncHelper.await(resultCatcher -> {
+            ICancelable task = powerAuthSDK.signJwtWithDevicePrivateKey(testHelper.getContext(), activationHelper.getValidAuthentication(), originalClaims, new IJwtSignatureListener() {
+                @Override
+                public void onJwtSignatureSucceed(@NonNull String jwt) {
+                    resultCatcher.completeWithResult(jwt);
+                }
+
+                @Override
+                public void onJwtSignatureFailed(@NonNull Throwable t) {
+                    resultCatcher.completeWithError(t);
+                }
+            });
+            assertNotNull(task);
+        });
+
+        // Parse JWT and validate result
+        final JsonSerialization jsonSerialization = new JsonSerialization();
+        final String[] jwtComponents = TextUtils.split(jwt, "\\.");
+        assertEquals(3, jwtComponents.length);
+        final String jwtHeader = jwtComponents[0];
+        final String jwtClaims = jwtComponents[1];
+        final String jwtSignature = jwtComponents[2];
+        // Validate header
+        String expectedAlgorithm = getAlgorithmForTest() == PowerAuthAlgorithm.LEGACY_P256 ? "ES256" : "ES384";
+        Map<String, Object> headerObject = jsonSerialization.deserializeObject(Base64.decode(jwtHeader, Base64.NO_WRAP | Base64.URL_SAFE | Base64.NO_PADDING), new TypeToken<Map<String, Object>>() {});
+        assertEquals("JWT", headerObject.get("typ"));
+        assertEquals(expectedAlgorithm, headerObject.get("alg"));
+        // Validate claims
+        Map<String, Object> claimsObject = jsonSerialization.deserializeObject(Base64.decode(jwtClaims, Base64.NO_WRAP | Base64.URL_SAFE | Base64.NO_PADDING), new TypeToken<Map<String, Object>>() {});
+        assertEquals(originalClaims.size(), claimsObject.size());
+        claimsObject.forEach((key, value) -> {
+            assertEquals(originalClaims.get(key), value);
+        });
+        // Prepare signed data
+        final String jwtSignedDatasBase64 = Base64.encodeToString((jwtHeader + "." + jwtClaims).getBytes(StandardCharsets.US_ASCII), Base64.NO_WRAP);
+        // Decode signature and encode back to Base64
+        final String jwtSignatureBase64 = Base64.encodeToString(
+                Base64.decode(jwtSignature, Base64.NO_WRAP | Base64.URL_SAFE | Base64.NO_PADDING),
+                Base64.NO_WRAP
+        );
+
+        // Validate signature
+        // Note that signature format is supported from PAS 1.9+
+        boolean result = testHelper.getServerApi().verifyDsaSignature(activationHelper.getActivation().getActivationId(), jwtSignedDatasBase64, jwtSignatureBase64, SignatureFormat.JOSE, SignatureType.ECDSA);
+        assertTrue(result);
     }
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreDevicePublicKeyFormat.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreDevicePublicKeyFormat.java
@@ -28,12 +28,12 @@ import java.lang.annotation.Retention;
  * the device public key.
  */
 @Retention(SOURCE)
-@IntDef({DER, RAW})
+@IntDef({SPKI, RAW})
 public @interface CoreDevicePublicKeyFormat {
     /**
      * DER key format, which corresponds to the SPKI or X.509 structure.
      */
-    int DER = 0;
+    int SPKI = 0;
     /**
      * RAW key format. The actual output depends on the key type:
      * <ul>

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreSession.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreSession.java
@@ -332,7 +332,87 @@ public class CoreSession extends NativeObject {
      * @return {@link CoreRequest} object containing all required information for token removal.
      * @throws CoreException In case of failure.
      */
+    @NonNull
     public native CoreRequest<Object> removeAccessToken(@NonNull String tokenIdentifier) throws CoreException;
+
+    // Digital signatures
+
+    /**
+     * Export device public keys into the specified format.
+     * @param format Required format of the output public key data.
+     * @return Array of {@link CoreDevicePublicKeyData} objects.
+     * @throws CoreException In case of failure.
+     */
+    @NonNull
+    public native CoreDevicePublicKeyData[] exportDevicePublicKeys(@CoreDevicePublicKeyFormat int format) throws CoreException;
+
+    /**
+     * Verify a digital signature over the given data.
+     * @param signature Signature calculated from signed data.
+     * @param data Signed data.
+     * @param keyId Key used for signature verification. The key must support signature verification.
+     * @throws CoreException In case of failure. If the signature is not valid, then exception with
+     *                       {@link CoreErrorCode#WRONG_SIGNATURE} code is raised.
+     */
+    public native void verifySignature(@NonNull byte[] signature,
+                                       @Nullable byte[] data,
+                                       @CoreSignatureKeyId int keyId) throws CoreException;
+
+
+    /**
+     * Create a digital signature over the given data. If the request succeeds, the response
+     * contains an array of bytes with the calculated signature.
+     * @param data Data to sign.
+     * @param credentials Credentials used for unlocking the device private key.
+     * @param keyId Key used for signature calculation. The key must support such operation.
+     * @return {@link CoreRequest} object containing all required information for unlocking device private key.
+     * @throws CoreException In case of failure.
+     */
+    @NonNull
+    public native CoreRequest<byte[]> signData(@Nullable byte[] data,
+                                               @NonNull CoreCredentials credentials,
+                                               @CoreSignatureKeyId int keyId) throws CoreException;
+
+    // JWS
+
+    /**
+     * Verify server-signed data in JWS or JWT form.
+     * @param signedData JWS or JWT signed data.
+     * @param compactForm If {@code true}, the provided string is a JWT instead of a full JWS object.
+     * @param strict If {@code true}, all provided keys must be used to successfully verify
+     *               their corresponding signatures. If {@code false}, verification succeeds when at
+     *               least one provided key matches a valid signature; however, invalid or
+     *               mismatched signatures still result in an error.
+     * @param keyId Key used for signature verification. The key must support such operation.
+     * @throws CoreException In case of failure. If the signature is not valid, then exception with
+     *                       {@link CoreErrorCode#WRONG_SIGNATURE} code is raised.
+     */
+    public native void jwsVerifySignature(@NonNull String signedData,
+                                          boolean compactForm,
+                                          boolean strict,
+                                          @CoreSignatureKeyId int keyId) throws CoreException;
+
+    /**
+     * Create a JWS (or compact JWT) over the given data. If the request succeeds, the response
+     * contains a {@code String} with the calculated JWS or JWT.
+     *
+     * @param data Data to sign and embed into JWS.
+     * @param dataType Data type set to JOSE header. Use {@code "JWT"} or {@code null} if no type
+     *                 is set.
+     * @param compactForm If {@code true}, the result contains a compact JWT string instead of a JWS.
+     *                    If used with hybrid keys, an error is reported.
+     * @param credentials Credentials used for unlocking the device private key.
+     * @param keyId Key used for signature calculation. The key must support such operation.
+     * @return {@link CoreRequest} object containing all required information for unlocking device
+     *         private key.
+     * @throws CoreException In case of failure.
+     */
+    @NonNull
+    public native CoreRequest<String> jwsSignData(@Nullable byte[] data,
+                                                  @Nullable String dataType,
+                                                  boolean compactForm,
+                                                  @NonNull CoreCredentials credentials,
+                                                  @CoreSignatureKeyId int keyId) throws CoreException;
 
     // Services
 

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/response/IDigitalSignatureListener.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/response/IDigitalSignatureListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Wultra s.r.o.
+ * Copyright 2026 Wultra s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,27 +20,22 @@ import androidx.annotation.MainThread;
 import androidx.annotation.NonNull;
 
 /**
- * Listener for data signature.
- *
- * @author Petr Dvorak, petr@wultra.com
- * @deprecated Use methods using new {@link IDigitalSignatureListener} callback.
+ * Listener for calculating digital signatures.
  */
-@Deprecated // 2.0.0
-public interface IDataSignatureListener {
-
+public interface IDigitalSignatureListener {
     /**
-     * Called when data signature succeeds.
+     * Called when digital signature calculation succeeds.
      *
-     * @param signature the data signature.
+     * @param signature the calculated signature.
      */
     @MainThread
-    void onDataSignedSucceed(@NonNull byte[] signature);
+    void onDigitalSignatureSucceed(@NonNull byte[] signature);
 
     /**
-     * Called when data signature fails.
+     * Called when digital signature calculation fails.
      *
-     * @param t error that occurred during the data signature.
+     * @param throwable error that occurred during the data signature.
      */
     @MainThread
-    void onDataSignedFailed(@NonNull Throwable t);
+    void onDigitalSignatureFailed(@NonNull Throwable throwable);
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/response/IJwsSignatureListener.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/response/IJwsSignatureListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Wultra s.r.o.
+ * Copyright 2026 Wultra s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,27 +20,24 @@ import androidx.annotation.MainThread;
 import androidx.annotation.NonNull;
 
 /**
- * Listener for data signature.
- *
- * @author Petr Dvorak, petr@wultra.com
- * @deprecated Use methods using new {@link IDigitalSignatureListener} callback.
+ * Listener for calculating JWS or JWT signatures.
  */
-@Deprecated // 2.0.0
-public interface IDataSignatureListener {
-
+public interface IJwsSignatureListener {
     /**
-     * Called when data signature succeeds.
+     * Called when JWS or JWT signature calculation succeeds.
      *
-     * @param signature the data signature.
+     * @param signedData the signature calculated from claims.
+     * @param compactForm If {@code true}, the signed data is a compact JWT; otherwise, a full JWS
+     *                    object is provided.
      */
     @MainThread
-    void onDataSignedSucceed(@NonNull byte[] signature);
+    void onJwsSignatureSucceed(@NonNull String signedData, boolean compactForm);
 
     /**
      * Called when data signature fails.
      *
-     * @param t error that occurred during the data signature.
+     * @param throwable error that occurred during the data signature.
      */
     @MainThread
-    void onDataSignedFailed(@NonNull Throwable t);
+    void onJwsSignatureFailed(@NonNull Throwable throwable);
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/response/IJwtSignatureListener.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/response/IJwtSignatureListener.java
@@ -21,7 +21,11 @@ import androidx.annotation.NonNull;
 
 /**
  * Listener for JWT signature.
+ *
+ * @deprecated Interface is deprecated, please use API that receive {@link IJwsSignatureListener}
+ * as callback.
  */
+@Deprecated // 2.0.0
 public interface IJwtSignatureListener {
     /**
      * Called when data signature succeeds.

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthDevicePublicKeyFormat.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthDevicePublicKeyFormat.java
@@ -35,7 +35,7 @@ public @interface PowerAuthDevicePublicKeyFormat {
     /**
      * DER key format, which corresponds to the SPKI or X.509 structure.
      */
-    int DER = CoreDevicePublicKeyFormat.DER;
+    int DER = CoreDevicePublicKeyFormat.SPKI;
     /**
      * RAW key format. The actual output depends on the key type:
      * <ul>

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -23,11 +23,16 @@ import androidx.annotation.*;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 
+import java.io.Console;
+import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.logging.Logger;
 
 import io.getlime.security.powerauth.BuildConfig;
 import io.getlime.security.powerauth.biometry.*;
@@ -1599,21 +1604,128 @@ public class PowerAuthSDK {
         }
     }
 
-    /***
+    // Digital signatures
+
+    /**
+     * Export device public key(s) into the specified format.
+     * @param format Required format of the output public key data.
+     * @return List with {@link PowerAuthDevicePublicKeyData} containing public key data.
+     * @throws PowerAuthErrorException In case of failure.
+     */
+    @NonNull
+    public List<PowerAuthDevicePublicKeyData> exportDevicePublicKeys(@PowerAuthDevicePublicKeyFormat int format) throws PowerAuthErrorException {
+        try {
+            final int coreFormat = format == PowerAuthDevicePublicKeyFormat.DER ? CoreDevicePublicKeyFormat.SPKI : CoreDevicePublicKeyFormat.RAW;
+            CoreDevicePublicKeyData[] coreKeys = mSession.exportDevicePublicKeys(coreFormat);
+            return PowerAuthDevicePublicKeyData.fromCoreObject(coreKeys);
+        } catch (CoreException exception) {
+            throw PowerAuthErrorException.wrapException(exception);
+        }
+    }
+
+    /**
+     * Convert {@link PowerAuthSignatureKeyId} into {@link CoreSignatureKeyId}.
+     * @param keyId Key identifier to convert.
+     * @return Converted key identifier.
+     */
+    @SuppressLint("WrongConstant")
+    @CoreSignatureKeyId
+    private static int convertPowerAuthSignatureKeyId(@PowerAuthSignatureKeyId int keyId) {
+        // @PowerAuthSignatureKeyId is defined from @CoreSignatureKeyId constants, so direct return
+        // with suppressed warning is OK.
+        return keyId;
+    }
+
+    /**
+     * Verifies a digital signature for the given data using the key specified by its identifier.
+     * <p>
+     * If the selected key identifier represents multiple key types, an error is reported.
+     * Hybrid signatures are not supported in this version of the library.
+     *
+     * @param signature The digital signature calculated for the data.
+     * @param signedData The data that was signed.
+     * @param keyIdentifier The identifier of the key used for verification.
+     * @throws PowerAuthErrorException In case of failure. If the signature is not valid, then
+     *      exception with {@link PowerAuthErrorCodes#WRONG_SIGNATURE} code is raised.
+     */
+    public void verifyDigitalSignature(@NonNull byte[] signature,
+                                       @Nullable byte[] signedData,
+                                       @PowerAuthSignatureKeyId int keyIdentifier) throws PowerAuthErrorException {
+        try {
+            mSession.verifySignature(signature, signedData, convertPowerAuthSignatureKeyId(keyIdentifier));
+        } catch (CoreException exception) {
+            throw PowerAuthErrorException.wrapException(exception);
+        }
+    }
+
+    /**
+     * Calculates a digital signature for the given data using the key specified by its identifier.
+     * <p>
+     * The selected key must support signature calculation; otherwise, an error is reported.
+     * If the key identifier represents multiple key types, an error is also reported.
+     * Hybrid signatures are not supported in this version of the library.
+     *
+     * @param authentication The authentication object used for vault unlocking.
+     * @param dataToSign The data to sign.
+     * @param keyIdentifier The identifier of the key used for signature calculation.
+     * @param listener The callback interface invoked with the resulting signature or an error.
+     * @return Cancelable object associated with the asynchronous operation, or {@code null} if
+     *         the error is detected immediately.
+     */
+    @Nullable
+    public ICancelable calculateDigitalSignature(@NonNull PowerAuthAuthentication authentication,
+                                                 @Nullable byte[] dataToSign,
+                                                 @PowerAuthSignatureKeyId int keyIdentifier,
+                                                 @NonNull IDigitalSignatureListener listener) {
+        try {
+            final int coreKeyId = convertPowerAuthSignatureKeyId(keyIdentifier);
+            final CoreCredentials credentials = resolveCredentialsWithAuthentication(authentication);
+            final CoreRequest<byte[]> request = mSession.signData(dataToSign, credentials, coreKeyId);
+            return mClient.post(request, new INetworkResponseListener<>() {
+                @Override
+                public void onNetworkResponse(@Nullable byte[] bytes) {
+                    byte[] response = Objects.requireNonNull(bytes);
+                    listener.onDigitalSignatureSucceed(response);
+                }
+
+                @Override
+                public void onNetworkError(@NonNull Throwable throwable) {
+                    listener.onDigitalSignatureFailed(throwable);
+                }
+
+                @Override
+                public void onCancel() {
+                }
+            });
+        } catch (CoreException exception) {
+            dispatchCallback(() -> listener.onDigitalSignatureFailed(PowerAuthErrorException.wrapException(exception)));
+        } catch (PowerAuthErrorException exception) {
+            dispatchCallback(() -> listener.onDigitalSignatureFailed(exception));
+        }
+        return null;
+    }
+
+    /**
      * Validates whether the data has been signed with master server private key, or personalized server's private key.
      *
      * @param data An arbitrary data
      * @param signature A signature calculated for data
      * @param useMasterKey If true, then master server's public key is used for validation, otherwise personalized server's key.
      * @return true if signature is valid
+     * @deprecated Method is deprecated, please use {@link #verifyDigitalSignature(byte[], byte[], int)} instead.
      */
+    @Deprecated // 2.0.0
     public boolean verifyServerSignedData(byte[] data, byte[] signature, boolean useMasterKey) {
-
-//        // Verify signature
-//        final int signingKey = useMasterKey ? SigningDataKey.ECDSA_MASTER_SERVER_KEY : SigningDataKey.ECDSA_PERSONALIZED_KEY;
-//        final SignedData signedData = new SignedData(data, signature, signingKey, SignatureFormat.ECDSA_DER);
-//        return mSession.verifyServerSignedData(signedData) == ErrorCode.OK;
-        return false;
+        if (signature == null) {
+            return false;
+        }
+        try {
+            int keyId = useMasterKey ? PowerAuthSignatureKeyId.MASTER_EC : PowerAuthSignatureKeyId.SERVER_EC;
+            verifyDigitalSignature(signature, data, keyId);
+            return true;
+        } catch (PowerAuthErrorException exception) {
+            return false;
+        }
     }
 
     /**
@@ -1623,51 +1735,132 @@ public class PowerAuthSDK {
      * @param data Data to be signed.
      * @param listener Listener with callbacks to signature status.
      * @return Async task associated with vault unlock request.
+     * @deprecated Method is deprecated, please use {@link #calculateDigitalSignature(PowerAuthAuthentication, byte[], int, IDigitalSignatureListener)} instead.
      */
-    public @Nullable
-    ICancelable signDataWithDevicePrivateKey(@NonNull final Context context, @NonNull PowerAuthAuthentication authentication, @NonNull final byte[] data, @NonNull final IDataSignatureListener listener) {
-        mCallbackDispatcher.dispatchCallback(() -> listener.onDataSignedFailed(new PowerAuthErrorException(PowerAuthErrorCodes.OTHER, "Not implemented")));
-        return null;
-        //return signDataWithDevicePrivateKeyImpl(context, authentication, data, SignatureFormat.ECDSA_DER, listener);
+    @Deprecated // 2.0.0
+    @Nullable
+    public ICancelable signDataWithDevicePrivateKey(@NonNull final Context context, @NonNull PowerAuthAuthentication authentication, @NonNull final byte[] data, @NonNull final IDataSignatureListener listener) {
+        return calculateDigitalSignature(authentication, data, PowerAuthSignatureKeyId.DEVICE_EC, new IDigitalSignatureListener() {
+            @Override
+            public void onDigitalSignatureSucceed(@NonNull byte[] signature) {
+                listener.onDataSignedSucceed(signature);
+            }
+
+            @Override
+            public void onDigitalSignatureFailed(@NonNull Throwable throwable) {
+                listener.onDataSignedFailed(throwable);
+            }
+        });
+    }
+
+    // JWS
+
+    /**
+     * Verifies JWS or JWT signed data using the key specified by its identifier.
+     * <p>
+     * If the selected key identifier represents multiple key types, compact format cannot be used.
+     *
+     * @param signature A string containing JWS or JWT signed data.
+     * @param compactForm If {@code true}, the input string is a compact JWT; otherwise, a full JWS object is expected.
+     * @param strictVerify If {@code true}, all provided keys must be used to successfully verify their corresponding signatures.
+     *                     If {@code false}, verification succeeds when at least one provided key matches a valid signature; however,
+     *                     invalid or mismatched signatures still result in an error.
+     * @param keyIdentifier The identifier of the key used for verification.
+     * @throws PowerAuthErrorException In case of failure. If the signature is not valid, then
+     *          exception with {@link PowerAuthErrorCodes#WRONG_SIGNATURE} code is raised.
+     */
+    public void verifyJwsSignature(@NonNull String signature,
+                                   boolean compactForm,
+                                   boolean strictVerify,
+                                   @PowerAuthSignatureKeyId int keyIdentifier) throws PowerAuthErrorException {
+        try {
+            final int keyId = convertPowerAuthSignatureKeyId(keyIdentifier);
+            mSession.jwsVerifySignature(signature, compactForm, strictVerify, keyId);
+        } catch (CoreException exception) {
+            throw PowerAuthErrorException.wrapException(exception);
+        }
     }
 
     /**
-     * Sign provided data with a private key that is stored in secure vault.
-     * @param context Context.
-     * @param authentication Authentication object for vault unlock request.
-     * @param data Data to be signed.
-     * @param signatureFormat Format of output signature.
-     * @param listener Listener with callbacks to signature status.
-     * @return Async task associated with vault unlock request.
+     * Calculates a JWS signature for the given data using the key specified by its identifier.
+     * <p>
+     * The selected key must support signature calculation; otherwise, an error is reported.
+     * If the key identifier represents multiple key types, compact format cannot be used for output.
+     *
+     * @param authentication The authentication object used for vault unlocking.
+     * @param dataToSign The data to sign.
+     * @param dataType Data type set to JOSE header. Use {@code "JWT"} or {@code null} if no type is set.
+     * @param compactForm If {@code true}, the output string is a compact JWT; otherwise, a full JWS object is returned.
+     * @param keyIdentifier The identifier of the key used for signature calculation.
+     * @param listener The callback interface invoked with the resulting signature or an error.
+     * @return Cancelable object associated with the asynchronous operation, or {@code null} if
+     *         the error is detected immediately.
      */
-    private @Nullable
-    ICancelable signDataWithDevicePrivateKeyImpl(@NonNull final Context context, @NonNull PowerAuthAuthentication authentication, @NonNull final byte[] data, @SignatureFormat int signatureFormat, @NonNull final IDataSignatureListener listener) {
-        mCallbackDispatcher.dispatchCallback(() -> listener.onDataSignedFailed(new PowerAuthErrorException(PowerAuthErrorCodes.OTHER, "Not implemented")));
+    @Nullable
+    public ICancelable calculateJwsSignature(@NonNull PowerAuthAuthentication authentication,
+                                             @Nullable byte[] dataToSign,
+                                             @Nullable String dataType,
+                                             boolean compactForm,
+                                             @PowerAuthSignatureKeyId int keyIdentifier,
+                                             @NonNull IJwsSignatureListener listener) {
+        try {
+            final CoreCredentials credentials = resolveCredentialsWithAuthentication(authentication);
+            final int keyId = convertPowerAuthSignatureKeyId(keyIdentifier);
+            final CoreRequest<String> request = mSession.jwsSignData(dataToSign, dataType, compactForm, credentials, keyId);
+            return mClient.post(request, new INetworkResponseListener<>() {
+                @Override
+                public void onNetworkResponse(@Nullable String s) {
+                    String response = Objects.requireNonNull(s);
+                    listener.onJwsSignatureSucceed(response, compactForm);
+                }
+
+                @Override
+                public void onNetworkError(@NonNull Throwable throwable) {
+                    listener.onJwsSignatureFailed(throwable);
+                }
+
+                @Override
+                public void onCancel() {
+                }
+            });
+        } catch (CoreException exception) {
+            dispatchCallback(() -> listener.onJwsSignatureFailed(PowerAuthErrorException.wrapException(exception)));
+        } catch (PowerAuthErrorException exception) {
+            dispatchCallback(() -> listener.onJwsSignatureFailed(exception));
+        }
         return null;
-//        // Fetch vault encryption key using vault unlock request.
-//        return this.fetchEncryptedVaultUnlockKey(context, authentication, VaultUnlockReason.SIGN_WITH_DEVICE_PRIVATE_KEY, new IFetchEncryptedVaultUnlockKeyListener() {
-//            @Override
-//            public void onFetchEncryptedVaultUnlockKeySucceed(String encryptedEncryptionKey) {
-//                if (encryptedEncryptionKey != null) {
-//                    // Let's sign the data
-//                    SignatureUnlockKeys keys = new SignatureUnlockKeys(deviceRelatedKey(context), null, null);
-//                    byte[] signature = mSession.signDataWithDevicePrivateKey(encryptedEncryptionKey, keys, data, signatureFormat);
-//                    // Propagate error
-//                    if (signature != null) {
-//                        listener.onDataSignedSucceed(signature);
-//                    } else {
-//                        listener.onDataSignedFailed(new PowerAuthErrorException(PowerAuthErrorCodes.INVALID_ACTIVATION_DATA));
-//                    }
-//                } else {
-//                    listener.onDataSignedFailed(new PowerAuthErrorException(PowerAuthErrorCodes.INVALID_ACTIVATION_STATE));
-//                }
-//            }
-//
-//            @Override
-//            public void onFetchEncryptedVaultUnlockKeyFailed(Throwable t) {
-//                listener.onDataSignedFailed(t);
-//            }
-//        });
+    }
+
+    /**
+     * Sign provided claims with the original device private key (asymmetric signature).
+     * <p>
+     * This method calls PowerAuth Standard RESTful API endpoint '/pa/vault/unlock' to obtain the vault encryption key
+     * used for private key decryption. Claims provided as a dictionary is then converted to Base64 encoded format and
+     * signed using ECDSA algorithm (ES256 or ES384) with the private key and converted to JWT representation that can be
+     * validated on the server side.
+     *
+     * @param context Android context.
+     * @param authentication Authentication object that must contain the possession factor.
+     * @param claims Claims to be signed with the private key.
+     * @param listener Listener with the callback methods
+     * @return {@link ICancelable} object associated with the underlying HTTP request.
+     * @deprecated Method is deprecated, please use {@link #calculateJwsSignature(PowerAuthAuthentication, byte[], String, boolean, int, IJwsSignatureListener)} instead.
+     */
+    @Deprecated // 2.0.0
+    @Nullable
+    public ICancelable signJwtWithDevicePrivateKey(@NonNull Context context, @NonNull PowerAuthAuthentication authentication, @NonNull Map<String, Object> claims, @NonNull IJwtSignatureListener listener) {
+        byte[] dataForSign = new JsonSerialization().serializeObject(claims);
+        return calculateJwsSignature(authentication, dataForSign, "JWT", true, PowerAuthSignatureKeyId.DEVICE_EC, new IJwsSignatureListener() {
+            @Override
+            public void onJwsSignatureSucceed(@NonNull String signedData, boolean compactForm) {
+                listener.onJwtSignatureSucceed(signedData);
+            }
+
+            @Override
+            public void onJwsSignatureFailed(@NonNull Throwable throwable) {
+                listener.onJwtSignatureFailed(throwable);
+            }
+        });
     }
 
 
@@ -2464,47 +2657,6 @@ public class PowerAuthSDK {
                 }
             }
         });
-    }
-
-    // JWT
-
-    /**
-     * Sign provided claims with the original device private key (asymmetric signature).
-     * <p>
-     * This method calls PowerAuth Standard RESTful API endpoint '/pa/vault/unlock' to obtain the vault encryption key
-     * used for private key decryption. Claims provided as a dictionary is then converted to Base64 encoded format and
-     * signed using ECDSA algorithm (ES256) with the private key and converted to JWT representation that can be
-     * validated on the server side.
-     *
-     * @param context Android context.
-     * @param authentication Authentication object that must contain the possession factor.
-     * @param claims Claims to be signed with the private key.
-     * @param listener Listener with the callback methods
-     * @return {@link ICancelable} object associated with the underlying HTTP request.
-     */
-    @Nullable
-    public ICancelable signJwtWithDevicePrivateKey(@NonNull Context context, @NonNull PowerAuthAuthentication authentication, @NonNull Map<String, Object> claims, @NonNull IJwtSignatureListener listener) {
-        mCallbackDispatcher.dispatchCallback(() -> listener.onJwtSignatureFailed(new PowerAuthErrorException(PowerAuthErrorCodes.OTHER, "Not implemented")));
-        return null;
-//        final JsonSerialization serialization = new JsonSerialization();
-//        final String jwtHeader = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9"; // {"alg":"ES256","typ":"JWT"}
-//        final String jwtClaims = serialization.serializeJwtObject(claims);
-//        final String jwtHeaderAndClaims = jwtHeader + "." + jwtClaims;
-//        return signDataWithDevicePrivateKeyImpl(context, authentication, jwtHeaderAndClaims.getBytes(StandardCharsets.US_ASCII), SignatureFormat.ECDSA_JOSE, new IDataSignatureListener() {
-//            @Override
-//            public void onDataSignedSucceed(@NonNull byte[] signature) {
-//                // Encoded signature
-//                final String jwtSignature = Base64.encodeToString(signature, Base64.NO_WRAP | Base64.URL_SAFE | Base64.NO_PADDING);
-//                // Construct final JWT
-//                final String jwt = jwtHeaderAndClaims + "." + jwtSignature;
-//                listener.onJwtSignatureSucceed(jwt);
-//            }
-//
-//            @Override
-//            public void onDataSignedFailed(@NonNull Throwable t) {
-//                listener.onJwtSignatureFailed(t);
-//            }
-//        });
     }
 
     // E2EE

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKBaseTests.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKBaseTests.m
@@ -1430,18 +1430,34 @@
     // This test checks whether SDK can verify data signed by server's master key
     //
     BOOL result;
-    PowerAuthSdkActivation * activation = [_helper createActivation:YES];
-    if (!activation) {
-        return;
-    }
-    PowerAuthAuthentication * auth = activation.credentials;
-    
     NSError *error = nil;
     PATSOfflineSignaturePayload *payload;
     {
         // Verify data signed with master key (non-personalized)
         NSString * dataForSigning = @"All your money are belong to us!";
-        payload = [_helper.testServerApi createNonPersonalizedOfflineSignaturePayload:activation.activationData.applicationId data:dataForSigning];
+        payload = [_helper.testServerApi createNonPersonalizedOfflineSignaturePayload:_helper.testServerApi.appDetail.applicationId data:dataForSigning];
+        XCTAssertNotNil(payload);
+        XCTAssertTrue([payload.parsedData isEqualToString:dataForSigning]);
+        XCTAssertTrue([payload.parsedSigningKey isEqualToString:@"0"]);
+        
+        NSData * signedData = [payload.parsedSignedData dataUsingEncoding:NSUTF8StringEncoding];
+        result = [_sdk verifyDigitalSignature:[[NSData alloc] initWithBase64EncodedString:payload.parsedSignature options:0]
+                                   signedData:signedData
+                                keyIdentifier:PowerAuthSignatureKeyId_Master_EC
+                                        error:&error];
+        XCTAssertTrue(result);
+        XCTAssertNil(error);
+    }
+    PowerAuthSdkActivation * activation = [_helper createActivation:YES];
+    if (!activation) {
+        return;
+    }
+    PowerAuthAuthentication * auth = activation.credentials;
+    {
+        // Retry after activation creation
+        // Verify data signed with master key (non-personalized)
+        NSString * dataForSigning = @"All your money are belong to us!";
+        payload = [_helper.testServerApi createNonPersonalizedOfflineSignaturePayload:_helper.testServerApi.appDetail.applicationId data:dataForSigning];
         XCTAssertNotNil(payload);
         XCTAssertTrue([payload.parsedData isEqualToString:dataForSigning]);
         XCTAssertTrue([payload.parsedSigningKey isEqualToString:@"0"]);

--- a/proj-xcode/PowerAuthCore/PowerAuthCoreSession.h
+++ b/proj-xcode/PowerAuthCore/PowerAuthCoreSession.h
@@ -467,7 +467,7 @@
 /// - Returns: `true` if signature is valid, otherwise `false`. If failure is caused by invalid signature,
 ///            then error with `PowerAuthCoreError_WrongSignature` is returned.
 - (BOOL) verifySignature:(nonnull NSData*)signature
-                    data:(nonnull NSData*)data
+                    data:(nullable NSData*)data
                    keyId:(PowerAuthCoreSignatureKeyId)keyId
                    error:(NSError *_Nullable*_Nullable)error;
 

--- a/proj-xcode/PowerAuthCore/PowerAuthCoreSession.mm
+++ b/proj-xcode/PowerAuthCore/PowerAuthCoreSession.mm
@@ -699,7 +699,7 @@ static void _ReportError(PowerAuthCoreError code, NSString * message, NSError **
 }
 
 - (BOOL) verifySignature:(nonnull NSData*)signature
-                    data:(nonnull NSData*)data
+                    data:(nullable NSData*)data
                    keyId:(PowerAuthCoreSignatureKeyId)keyId
                    error:(NSError *_Nullable*_Nullable)error
 {
@@ -707,9 +707,9 @@ static void _ReportError(PowerAuthCoreError code, NSString * message, NSError **
         return NO;
     }
     try {
-        _session->verifySignature(cc7::objc::CopyFromNSData(data),
-                                  cc7::objc::CopyFromNSData(signature),
-                                  static_cast<SignatureKeyId>(keyId));
+    _session->verifySignature(cc7::objc::CopyFromNSData(data),
+                              cc7::objc::CopyFromNSData(signature),
+                              static_cast<SignatureKeyId>(keyId));
         return YES;
     } catch (...) {
         if (error) {
@@ -788,7 +788,7 @@ static void _ReportError(PowerAuthCoreError code, NSString * message, NSError **
         return [[PowerAuthCoreRequest alloc] initWithRequest:request withBuilder:^id(const powerAuth::ResponseObjectPtr &response) {
             auto stringResponse = std::dynamic_pointer_cast<powerAuth::StringResponse>(response);
             if (!stringResponse) {
-                throw Exception(EC_InternalError, "No DataResponse object created");
+                throw Exception(EC_InternalError, "No StringResponse object created");
             }
             return cc7::objc::CopyToNSString(stringResponse->string());
         }];

--- a/src/PowerAuthJni/ClassSpecs.cpp
+++ b/src/PowerAuthJni/ClassSpecs.cpp
@@ -96,7 +96,7 @@ ClassSpecs ClassSpecs::buildSpecs(JNI &jni)
             "ML_DSA"
         });
         spec.coreDevicePublicKeyFormat = jni.buildConstantRangeSpec("io/getlime/security/powerauth/core/CoreDevicePublicKeyFormat", {
-            "DER",
+            "SPKI",
             "RAW"
         });
         spec.coreEncryptorScope = jni.buildConstantRangeSpec("io/getlime/security/powerauth/core/CoreEncryptorScope", {

--- a/src/PowerAuthJni/CoreSessionJNI.cpp
+++ b/src/PowerAuthJni/CoreSessionJNI.cpp
@@ -429,6 +429,107 @@ CC7_JNI_METHOD_PARAMS(jobject, removeAccessToken, jstring tokenIdentifier)
     NH_CATCH(nullptr)
 }
 
+// Digital signatures
+
+/// Enumeration identical to `io.getlime.security.powerauth.core.CoreDevicePublicKeyFormat`.
+/// We don't need to expose it as a public interface.
+enum class CoreDevicePublicKeyFormat
+{
+    SPKI = 0,
+    RAW = 1
+};
+
+CC7_JNI_METHOD_PARAMS(jobjectArray, exportDevicePublicKeys, jint format)
+{
+    NH_TRY
+    {
+        auto& specs = NH_SPECS();
+        auto key_format = jni.fromJava<CoreDevicePublicKeyFormat>(specs.coreDevicePublicKeyFormat, format);
+        auto keys = THIS_OBJ()->exportDevicePublicKeys(key_format == CoreDevicePublicKeyFormat::SPKI ? cc7::crypto::KEY_FORMAT_SPKI : cc7::crypto::KEY_FORMAT_RAW);
+        auto result = jni.createObjectArray(specs.coreDevicePublicKeyData.classRef, keys.size());
+        for (jsize index = 0; index < keys.size(); ++index) {
+            const auto& key = keys[index];
+            auto key_data = jni.createObject(specs.coreDevicePublicKeyData.methods.init,
+                                             jni.toJava(specs.coreSignatureKeyType, key.keyType),
+                                             jni.toJava(key.keyAlgorithm),
+                                             jni.toJava(key.keyData));
+            result.setObject(index, key_data);
+            key_data.releaseLocal();
+        }
+        return result;
+    }
+    NH_CATCH(nullptr)
+}
+
+CC7_JNI_METHOD_PARAMS(void, verifySignature, jbyteArray signature, jbyteArray data, jint keyId)
+{
+    NH_TRY
+    {
+        jni.requireParameter(signature, "signature");
+        THIS_OBJ()->verifySignature(jni.fromJava(data),
+                                    jni.fromJava(signature),
+                                    jni.fromJava<SignatureKeyId>(NH_SPECS().coreSignatureKeyId, keyId));
+    }
+    NH_CATCH()
+}
+
+CC7_JNI_METHOD_PARAMS(jobject, signData, jbyteArray data, jobject credentials, jint keyId)
+{
+    NH_TRY
+    {
+        jni.requireParameter(credentials, "credentials");
+        auto& specs = NH_SPECS();
+        auto request = THIS_OBJ()->signData(jni.fromJava<Credentials>(specs.coreCredentials, credentials),
+                                            jni.fromJava(data),
+                                            jni.fromJava<SignatureKeyId>(specs.coreSignatureKeyId, keyId));
+        return BuildCoreRequest(jni, request, [](JNI& jni, const ClassSpecs& specs, const ResponseObjectPtr& response, const JsonValue& response_json) -> jobject {
+            auto result = std::dynamic_pointer_cast<DataResponse>(response);
+            if (!result) {
+                throw Exception(EC_InternalError, "No DataResponse object created");
+            }
+            return jni.toJava(result->data());
+        });
+    }
+    NH_CATCH(nullptr)
+}
+
+// JWS
+
+CC7_JNI_METHOD_PARAMS(void, jwsVerifySignature, jstring signature, jboolean compactForm, jboolean strict, jint keyId)
+{
+    NH_TRY
+    {
+        jni.requireParameter(signature, "signature");
+        THIS_OBJ()->jwsVerifySignature(jni.fromJava(signature),
+                                       jni.fromJava<SignatureKeyId>(NH_SPECS().coreSignatureKeyId, keyId),
+                                       compactForm,
+                                       strict);
+    }
+    NH_CATCH()
+}
+
+CC7_JNI_METHOD_PARAMS(jobject, jwsSignData, jbyteArray data, jstring dataType, jboolean compactForm, jobject credentials, jint keyId)
+{
+    NH_TRY
+    {
+        jni.requireParameter(credentials, "credentials");
+        auto& specs = NH_SPECS();
+        auto request = THIS_OBJ()->jwsSignData(jni.fromJava<Credentials>(specs.coreCredentials, credentials),
+                                               jni.fromJava(data),
+                                               jni.fromJava(dataType),
+                                               jni.fromJava<SignatureKeyId>(specs.coreSignatureKeyId, keyId),
+                                               compactForm);
+        return BuildCoreRequest(jni, request, [](JNI& jni, const ClassSpecs& specs, const ResponseObjectPtr& response, const JsonValue& response_json) -> jobject {
+            auto result = std::dynamic_pointer_cast<StringResponse>(response);
+            if (!result) {
+                throw Exception(EC_InternalError, "No StringResponse object created");
+            }
+            return jni.toJava(result->string());
+        });
+    }
+    NH_CATCH(nullptr)
+}
+
 // Services
 
 CC7_JNI_METHOD(jobject, getEncryptorFactory)


### PR DESCRIPTION
This PR adds new API for DSA and JWS/JWT signature calculation and verification. 

The following important changes are also in this PR:

- Fixed bugs in integration tests support on Android:
  - Fixed URLs in endpoints related to offline payload creation
  - Fixed crash in `HttpRestClient` logging (used only for tests)
  - Apply client's protocol version in `PowerAuthTestHelper` before activation is created
- iOS changes
  - Allow to verify DSA signature over empty data
  - Small improvements in iOS tests
  - Fixed bugs in iOS documentation