### PR TITLE
Add support for tests with fake biometric key

### DIFF
--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/PowerAuthTestHelper.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/PowerAuthTestHelper.java
@@ -570,6 +570,7 @@ public class PowerAuthTestHelper {
     /**
      * Re-create a new instance of shared {@link PowerAuthSDK} with provided configurations.
      * @param configuration If null, then shared configuration will be used.
+     * @param biometricConfiguration  If null, then shared biometric configuration will be used.
      * @param clientConfiguration If null, then shared client configuration will be used.
      * @param keychainConfiguration If null, then shared keychain configuration will be used.
      * @return New instance of {@link PowerAuthSDK} that will be also used as new shared instance.
@@ -577,13 +578,16 @@ public class PowerAuthTestHelper {
      */
     public @NonNull PowerAuthSDK reCreateSdk(
             @Nullable PowerAuthConfiguration configuration,
+            @Nullable PowerAuthBiometricConfiguration biometricConfiguration,
             @Nullable PowerAuthClientConfiguration clientConfiguration,
             @Nullable PowerAuthKeychainConfiguration keychainConfiguration) throws Exception {
         final PowerAuthConfiguration newConfiguration = configuration != null ? configuration : getSharedPowerAuthConfiguration();
+        final PowerAuthBiometricConfiguration newBiometricConfiguration = biometricConfiguration != null ? biometricConfiguration : getSharedBiometricConfiguration();
         final PowerAuthClientConfiguration newClientConfiguration = clientConfiguration != null ? clientConfiguration : getSharedPowerAuthClientConfiguration();
         final PowerAuthKeychainConfiguration newKeychainConfiguration = keychainConfiguration != null ? keychainConfiguration : getSharedPowerAuthKeychainConfiguration();
         final PowerAuthSDK sdk = new PowerAuthSDK.Builder(newConfiguration)
                 .clientConfiguration(newClientConfiguration)
+                .biometricConfiguration(newBiometricConfiguration)
                 .keychainConfiguration(newKeychainConfiguration)
                 .build(getContext());
         sharedSdk = sdk;

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/ActivationHelper.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/ActivationHelper.java
@@ -22,7 +22,10 @@ import androidx.annotation.Nullable;
 import java.util.List;
 
 import io.getlime.security.powerauth.biometry.IPersistActivationWithBiometricsListener;
+import io.getlime.security.powerauth.core.CoreProtocolVersion;
+import io.getlime.security.powerauth.core.CoreSession;
 import io.getlime.security.powerauth.core.Password;
+import io.getlime.security.powerauth.core.SecureData;
 import io.getlime.security.powerauth.exception.PowerAuthErrorCodes;
 import io.getlime.security.powerauth.exception.PowerAuthErrorException;
 import io.getlime.security.powerauth.integration.support.AsyncHelper;
@@ -47,10 +50,11 @@ public class ActivationHelper {
     private final @NonNull PowerAuthTestHelper testHelper;
     private final @NonNull Application application;
     private final @NonNull String userId;
-    private final @NonNull PowerAuthSDK powerAuthSDK;
+    private @NonNull PowerAuthSDK powerAuthSDK;
     private Activation activation;
     private PowerAuthAuthentication validAuthentication;
     private PowerAuthAuthentication invalidAuthentication;
+    private SecureData fakeBiometricKek;
     private CreateActivationResult createActivationResult;
 
     /**
@@ -77,6 +81,11 @@ public class ActivationHelper {
      */
     public static final int TF_PERSIST_WITH_BIOMETRY_ACTIVITY   = 0x0010;
     /**
+     * Persist method with additional biometry factor represented by a generated biometry related key.
+     * No actual biometric authentication is needed. Combine with other flags.
+     */
+    public static final int TF_PERSIST_WITH_FAKE_BIOMETRY = 0x0020;
+    /**
      * Alternate method that persist activation with deprecated functions.
      */
     // @Deprecated // 2.0.0
@@ -90,10 +99,16 @@ public class ActivationHelper {
         PowerAuthAuthentication validAuthentication;
         PowerAuthAuthentication invalidAuthentication;
         CreateActivationResult createActivationResult;
-        HelperState(Activation activation, PowerAuthAuthentication validAuthentication, PowerAuthAuthentication invalidAuthentication, CreateActivationResult createActivationResult) {
+        SecureData fakeBiometricKek;
+        HelperState(Activation activation,
+                    PowerAuthAuthentication validAuthentication,
+                    PowerAuthAuthentication invalidAuthentication,
+                    SecureData fakeBiometricKek,
+                    CreateActivationResult createActivationResult) {
             this.activation = activation;
             this.validAuthentication = validAuthentication;
             this.invalidAuthentication = invalidAuthentication;
+            this.fakeBiometricKek = fakeBiometricKek.copy();
             this.createActivationResult = createActivationResult;
         }
     }
@@ -103,7 +118,7 @@ public class ActivationHelper {
      * @return Helper's state.
      */
     public @NonNull HelperState getHelperState() {
-        return new HelperState(activation, validAuthentication, invalidAuthentication, createActivationResult);
+        return new HelperState(activation, validAuthentication, invalidAuthentication, fakeBiometricKek, createActivationResult);
     }
 
     /**
@@ -120,6 +135,7 @@ public class ActivationHelper {
         this.activation = state.activation;
         this.validAuthentication = state.validAuthentication;
         this.invalidAuthentication = state.invalidAuthentication;
+        this.fakeBiometricKek = state.fakeBiometricKek;
         this.createActivationResult = state.createActivationResult;
     }
 
@@ -244,6 +260,7 @@ public class ActivationHelper {
         List<String> passwords = testHelper.getRandomGenerator().generateRandomStrings(2, 4, 16);
         validAuthentication = PowerAuthAuthentication.possessionWithPassword(passwords.get(0));
         invalidAuthentication = PowerAuthAuthentication.possessionWithPassword(passwords.get(1));
+        fakeBiometricKek = null;
         return passwords;
     }
 
@@ -277,6 +294,7 @@ public class ActivationHelper {
         final boolean persistWithDeprecated = (flags & TF_PERSIST_WITH_DEPRECATED) != 0;
         final boolean persistWithBiometryFrag = (flags & TF_PERSIST_WITH_BIOMETRY_FRAGMENT) != 0;
         final boolean persistWithBiometryAct = (flags & TF_PERSIST_WITH_BIOMETRY_ACTIVITY) != 0;
+        final boolean persistWithFakeBiometry = (flags & TF_PERSIST_WITH_FAKE_BIOMETRY) != 0;
 
         // Initial expectations
         assertFalse(powerAuthSDK.hasValidActivation());
@@ -351,7 +369,7 @@ public class ActivationHelper {
             if (!persistWithDeprecated) {
                 // New asynchronous persist (2.0.0)
                 // If biometry (in any form) is required, then we have to use auth object.
-                boolean useAuthObject = persistWithBiometryAct || persistWithBiometryFrag;
+                boolean useAuthObject = persistWithBiometryAct || persistWithBiometryFrag || persistWithFakeBiometry;
                 if (!useAuthObject) {
                     if (persistWithPassword) {
                         powerAuthSDK.persistActivationWithPassword(testHelper.getContext(), password, persistActivationListener);
@@ -364,23 +382,23 @@ public class ActivationHelper {
                 }
                 if (useAuthObject) {
                     final PowerAuthBiometricPrompt biometricPrompt;
-                    if (persistWithBiometryFrag) {
-                        biometricPrompt = PowerAuthBiometricPrompt.noPromptForBiometricKeySetup(testHelper.getFragment());
-                    } else if (persistWithBiometryAct) {
-                        biometricPrompt = PowerAuthBiometricPrompt.noPromptForBiometricKeySetup(testHelper.getFragmentActivity());
-                    } else {
+                    final SecureData biometricKey;
+                    if (persistWithFakeBiometry) {
+                        int protocolVersion = powerAuthSDK.getCurrentAlgorithm() == PowerAuthAlgorithm.LEGACY_P256 ? CoreProtocolVersion.V3 : CoreProtocolVersion.V4;
                         biometricPrompt = null;
-                    }
-                    final PowerAuthAuthentication authentication;
-                    if (persistWithCorePassword) {
-                        authentication = biometricPrompt != null
-                            ? PowerAuthAuthentication.persistWithPasswordAndBiometry(corePassword, biometricPrompt)
-                            : PowerAuthAuthentication.persistWithPassword(corePassword);
+                        biometricKey = CoreSession.generateFactorKekForProtocolVersion(protocolVersion);
+                        this.fakeBiometricKek = biometricKey.copy();
                     } else {
-                        authentication = biometricPrompt != null
-                                ? PowerAuthAuthentication.persistWithPasswordAndBiometry(password, biometricPrompt)
-                                : PowerAuthAuthentication.persistWithPassword(password);
+                        if (persistWithBiometryFrag) {
+                            biometricPrompt = PowerAuthBiometricPrompt.noPromptForBiometricKeySetup(testHelper.getFragment());
+                        } else if (persistWithBiometryAct) {
+                            biometricPrompt = PowerAuthBiometricPrompt.noPromptForBiometricKeySetup(testHelper.getFragmentActivity());
+                        } else {
+                            biometricPrompt = null;
+                        }
+                        biometricKey = null;
                     }
+                    final PowerAuthAuthentication authentication = buildPersistAuthObject(password, persistWithCorePassword, biometricPrompt, biometricKey);
                     powerAuthSDK.persistActivationWithAuthentication(testHelper.getContext(), authentication, persistActivationListener);
                 }
             } else {
@@ -471,6 +489,27 @@ public class ActivationHelper {
         return activationDetail;
     }
 
+    private static PowerAuthAuthentication buildPersistAuthObject(String password, boolean useCorePassword, PowerAuthBiometricPrompt prompt, SecureData biometricKey) {
+        if (useCorePassword) {
+            Password corePassword = new Password(password);
+            if (prompt != null) {
+                return PowerAuthAuthentication.persistWithPasswordAndBiometry(corePassword, prompt);
+            }
+            if (biometricKey != null) {
+                return PowerAuthAuthentication.persistWithPasswordAndBiometry(corePassword, biometricKey);
+            }
+            return PowerAuthAuthentication.persistWithPassword(corePassword);
+        } else {
+            if (prompt != null) {
+                return PowerAuthAuthentication.persistWithPasswordAndBiometry(password, prompt);
+            }
+            if (biometricKey != null) {
+                return PowerAuthAuthentication.persistWithPasswordAndBiometry(password, biometricKey);
+            }
+            return PowerAuthAuthentication.persistWithPassword(password);
+        }
+    }
+
     /**
      * Assign a custom created activation and its activation result to this helper object. This method
      * is useful in case that you need to test custom or recovery activations and wants to continue
@@ -513,6 +552,17 @@ public class ActivationHelper {
         ActivationDetail activationDetail = testHelper.getServerApi().getActivationDetail(activationId, null);
         activation = activationDetail.copyToActivation();
         return activationDetail;
+    }
+
+    /**
+     * Re-create instance of {@link PowerAuthSDK} with the same configuration to simulate application's restart.
+     * @return New instance of {@link PowerAuthSDK}.
+     * @throws Exception In case of failure.
+     */
+    @NonNull
+    PowerAuthSDK reCreateSdk() throws Exception {
+        powerAuthSDK = testHelper.reCreateSdk(null, null, null, null);
+        return powerAuthSDK;
     }
 
     /**
@@ -656,6 +706,26 @@ public class ActivationHelper {
             throw new Exception("ActivationHelper has no activation yet.");
         }
         return invalidAuthentication;
+    }
+
+    /**
+     * Get authentication object with biometric factor.
+     * @param prompt If provided, then returned object uses prompt for authentication. If null, then
+     *               activation has to be persisted with a fake biometric key.
+     * @return Authentication object configured for authentication with biometric factor.
+     * @throws Exception When called in wrong state or if prompt is required and is missing.
+     */
+    public @NonNull PowerAuthAuthentication getBiometricAuthentication(@Nullable PowerAuthBiometricPrompt prompt) throws Exception {
+        if (validAuthentication == null) {
+            throw new Exception("ActivationHelper has no activation yet.");
+        }
+        if (prompt != null) {
+            return PowerAuthAuthentication.possessionWithBiometry(prompt);
+        }
+        if (fakeBiometricKek == null) {
+            throw new Exception("Biometric prompt must be provided, because no fake biometry key is set");
+        }
+        return PowerAuthAuthentication.possessionWithBiometry(fakeBiometricKek.copy());
     }
 
     /**

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/AuthenticationCodeTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/AuthenticationCodeTest.java
@@ -24,13 +24,10 @@ import io.getlime.security.powerauth.exception.PowerAuthErrorException;
 import io.getlime.security.powerauth.integration.support.AsyncHelper;
 import io.getlime.security.powerauth.networking.response.IOfflineAuthenticationCodeListener;
 import io.getlime.security.powerauth.sdk.*;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Objects;
 
@@ -41,42 +38,7 @@ import io.getlime.security.powerauth.integration.support.model.AuthCodeType;
 
 import static org.junit.Assert.*;
 
-@RunWith(Parameterized.class)
-public class AuthenticationCodeTest {
-
-    @Parameterized.Parameter(0) public String alg;
-    @Parameterized.Parameters(name = " {0} ")
-    public static Iterable<Object[]> testParameters() {
-        return TestParameters.getParameters();
-    }
-
-    @PowerAuthAlgorithm
-    public int getAlgorithmForTest() {
-        return PowerAuthTestHelper.getAlgorithmForName(alg);
-    }
-
-    private PowerAuthTestHelper testHelper;
-    private PowerAuthSDK powerAuthSDK;
-    private ActivationHelper activationHelper;
-    private AuthenticationHelper authenticationHelper;
-
-    @Before
-    public void setUp() throws Exception {
-        testHelper = new PowerAuthTestHelper.Builder()
-                .powerAuthAlgorithm(getAlgorithmForTest())
-                .build();
-        powerAuthSDK = testHelper.getSharedSdk();
-        activationHelper = new ActivationHelper(testHelper);
-        authenticationHelper = new AuthenticationHelper();
-    }
-
-    @After
-    public void tearDown() {
-        if (activationHelper != null) {
-            activationHelper.cleanupAfterTest();
-        }
-    }
-
+public class AuthenticationCodeTest extends BaseTest {
 
     @Test
     public void testOfflineSignatureCalculation() throws Exception {
@@ -107,7 +69,7 @@ public class AuthenticationCodeTest {
             assertNotNull(offlineAuthCode);
 
             // Now verify signature on the server
-            final String dataToVerifySignature = authenticationHelper.normalizeOfflineData(testString, "/offline/test", nonce);
+            final String dataToVerifySignature = authenticationHelper.normalizeOfflineData(dataToSign, "/offline/test", nonce);
             AuthenticationCodeData authenticationCodeData = new AuthenticationCodeData();
             authenticationCodeData.setActivationId(powerAuthSDK.getActivationIdentifier());
             authenticationCodeData.setData(dataToVerifySignature);
@@ -174,30 +136,37 @@ public class AuthenticationCodeTest {
 
     @Test
     public void testOnlineSignatureCalculation() throws Exception {
-        final Context context = testHelper.getContext();
+        activationHelper.createStandardActivation(ActivationHelper.TF_PERSIST_WITH_FAKE_BIOMETRY, null);
 
-        activationHelper.createStandardActivation(true, null);
-
-        for (int iteration = 0; iteration < 33; iteration++) {
-
+        // Count is important, due to fact that we have 8-bit local counter since V3.1
+        for (int iteration = 0; iteration < 264; iteration++) {
             final String testString = "ONLINE signature test\n" + testHelper.getRandomGenerator().generateRandomString(10, 32);
 
             // Auth & expected result
             final PowerAuthAuthentication authentication;
             final AuthCodeType expectedSignatureType;
             final boolean expectedValidationResult;
-            if ((iteration % 3) == 0) {
-                authentication = activationHelper.getValidAuthentication();
-                expectedSignatureType = AuthCodeType.POSSESSION_KNOWLEDGE;
-                expectedValidationResult = true;
-            } else if ((iteration % 3) == 1){
-                authentication = activationHelper.getPossessionAuthentication();
-                expectedSignatureType = AuthCodeType.POSSESSION;
-                expectedValidationResult = true;
-            } else {
-                authentication = activationHelper.getInvalidAuthentication();
-                expectedSignatureType = AuthCodeType.POSSESSION_KNOWLEDGE;
-                expectedValidationResult = false;
+            switch (iteration % 4) {
+                case 0:
+                    authentication = activationHelper.getValidAuthentication();
+                    expectedSignatureType = AuthCodeType.POSSESSION_KNOWLEDGE;
+                    expectedValidationResult = true;
+                    break;
+                case 1:
+                    authentication = activationHelper.getPossessionAuthentication();
+                    expectedSignatureType = AuthCodeType.POSSESSION;
+                    expectedValidationResult = true;
+                    break;
+                case 2:
+                    authentication = activationHelper.getBiometricAuthentication(null);
+                    expectedSignatureType = AuthCodeType.POSSESSION_BIOMETRY;
+                    expectedValidationResult = true;
+                    break;
+                default:
+                    authentication = activationHelper.getInvalidAuthentication();
+                    expectedSignatureType = AuthCodeType.POSSESSION_KNOWLEDGE;
+                    expectedValidationResult = false;
+                    break;
             }
 
             // URI identifier
@@ -212,6 +181,8 @@ public class AuthenticationCodeTest {
 
             // Method
             final String method = (iteration & 1) == 0 ? "POST" : "GET";
+
+            System.out.println("Iteration " + iteration + ": " + expectedSignatureType + ", " + method);
 
             final byte[] dataToSign = testString.getBytes(Charset.defaultCharset());
             final PowerAuthHttpHeader onlineSignature = powerAuthSDK.authenticationHeaderForRequestWithBody(authentication, method, uriId, dataToSign);
@@ -256,6 +227,136 @@ public class AuthenticationCodeTest {
             assertNotNull(verifyResult);
             assertEquals(expectedValidationResult, verifyResult.isAuthenticationValid());
             assertEquals(expectedSignatureType, verifyResult.getAuthenticationCodeType());
+
+            if ((iteration & 0x3f) == 1) {
+                PowerAuthActivationStatus status = activationHelper.fetchActivationStatus();
+                assertEquals(PowerAuthActivationState.ACTIVE, status.getState());
+            }
+
+            if (iteration == 58 || iteration == 129 || iteration == 251) {
+                // simulate app restart at some points
+                powerAuthSDK = activationHelper.reCreateSdk();
+            }
         }
+    }
+
+
+    /**
+     * Counter look ahead set by default on server.
+     */
+    static final int CTR_LOOKAHEAD = 20;
+
+    @Test
+    public void testClientCounterIsAhead() throws Exception {
+        activationHelper.createStandardActivation(false, null);
+
+        PowerAuthAuthentication auth = activationHelper.getValidAuthentication();
+        PowerAuthActivationStatus status;
+        // Positive scenario, we should recover from it
+        for (int i = 0; i < CTR_LOOKAHEAD + 2; ++i) {
+            // calculate header and do not use it
+            powerAuthSDK.authenticationHeaderForRequestWithBody(auth, "POST", "/some/identifier", null);
+            if ((i % 4) == 0) {
+                // Every 4th auth code calculation try to get the status
+                status = activationHelper.fetchActivationStatus();
+                assertEquals(PowerAuthActivationState.ACTIVE, status.getState());
+            }
+
+        }
+        // fetch status at the end
+        status = activationHelper.fetchActivationStatus();
+        assertEquals(PowerAuthActivationState.ACTIVE, status.getState());
+
+        // Negative scenario, try to calculate too many signatures that server will never catch.
+        for (int i = 0; i < CTR_LOOKAHEAD + 2; ++i) {
+            // calculate header and do not use it
+            powerAuthSDK.authenticationHeaderForRequestWithBody(auth, "POST", "/some/identifier", null);
+        }
+        // fetch status at the end
+        status = activationHelper.fetchActivationStatus();
+        assertEquals(PowerAuthActivationState.DEADLOCK, status.getState());
+    }
+
+    @Test
+    public void testServerCounterIsAhead() throws Exception {
+        activationHelper.createStandardActivation(false, null);
+
+        byte[] dataToAuth = "Hello world!".getBytes(StandardCharsets.UTF_8);
+
+        PowerAuthAuthentication auth = activationHelper.getValidAuthentication();
+        PowerAuthActivationStatus status;
+        final Context context = testHelper.getContext();
+        final String uriId = "/test/id";
+        final String offlineNonce = "QVZlcnlDbGV2ZXJOb25jZQ==";
+
+        // Just calculate signature on the server.
+        // This is a little bit tricky, because we need to calculate a valid signature, to move server's counter forward. To do that,
+        // we have to calculate also a local signature, but that moves also local counter forward.
+        // To trick the system, we need to keep old persistent data and restore it later.
+        byte[] previousState = powerAuthSDK.getCoreSession().getSerializedState();
+        for (int i = 0; i < CTR_LOOKAHEAD/2; ++i) {
+            String localAuthCode = AsyncHelper.await(resultCatcher -> {
+                powerAuthSDK.offlineAuthenticationCode(context, auth, uriId, dataToAuth, offlineNonce, new IOfflineAuthenticationCodeListener() {
+                    @Override
+                    public void onOfflineAuthenticationCodeSucceed(@NonNull String authenticationCode) {
+                        resultCatcher.completeWithResult(authenticationCode);
+                    }
+
+                    @Override
+                    public void onOfflineAuthenticationCodeFailed(@NonNull PowerAuthErrorException error) {
+                        resultCatcher.completeWithError(error);
+                    }
+                });
+            });
+            String normalizedData = authenticationHelper.normalizeOfflineData(dataToAuth, uriId, offlineNonce);
+            // Now verify signature on the server
+            AuthenticationCodeData authenticationCodeData = new AuthenticationCodeData();
+            authenticationCodeData.setActivationId(powerAuthSDK.getActivationIdentifier());
+            authenticationCodeData.setData(normalizedData);
+            authenticationCodeData.setAuthenticationCode(localAuthCode);
+            authenticationCodeData.setAllowBiometry(false);
+
+            // Verify on server
+            final AuthenticationResult verifyResult = testHelper.getServerApi().verifyOfflineAuthenticationCode(authenticationCodeData);
+            assertNotNull(verifyResult);
+        }
+        // Rollback counter to some previous state, to simulate state when the server's counter is ahead
+        powerAuthSDK.getCoreSession().deserializeState(previousState);
+        status = activationHelper.fetchActivationStatus();
+        assertEquals(PowerAuthActivationState.ACTIVE, status.getState());
+
+        // negative scenario
+
+        previousState = powerAuthSDK.getCoreSession().getSerializedState();
+        for (int i = 0; i < CTR_LOOKAHEAD + 2; ++i) {
+            String localAuthCode = AsyncHelper.await(resultCatcher -> {
+                powerAuthSDK.offlineAuthenticationCode(context, auth, uriId, dataToAuth, offlineNonce, new IOfflineAuthenticationCodeListener() {
+                    @Override
+                    public void onOfflineAuthenticationCodeSucceed(@NonNull String authenticationCode) {
+                        resultCatcher.completeWithResult(authenticationCode);
+                    }
+
+                    @Override
+                    public void onOfflineAuthenticationCodeFailed(@NonNull PowerAuthErrorException error) {
+                        resultCatcher.completeWithError(error);
+                    }
+                });
+            });
+            String normalizedData = authenticationHelper.normalizeOfflineData(dataToAuth, uriId, offlineNonce);
+            // Now verify signature on the server
+            AuthenticationCodeData authenticationCodeData = new AuthenticationCodeData();
+            authenticationCodeData.setActivationId(powerAuthSDK.getActivationIdentifier());
+            authenticationCodeData.setData(normalizedData);
+            authenticationCodeData.setAuthenticationCode(localAuthCode);
+            authenticationCodeData.setAllowBiometry(false);
+
+            // Verify on server
+            final AuthenticationResult verifyResult = testHelper.getServerApi().verifyOfflineAuthenticationCode(authenticationCodeData);
+            assertNotNull(verifyResult);
+        }
+        // Rollback counter to some previous state, to simulate state when the server's counter is ahead
+        powerAuthSDK.getCoreSession().deserializeState(previousState);
+        status = activationHelper.fetchActivationStatus();
+        assertEquals(PowerAuthActivationState.DEADLOCK, status.getState());
     }
 }

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/AuthenticationHelper.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/AuthenticationHelper.java
@@ -44,26 +44,26 @@ public class AuthenticationHelper {
     }
 
     /**
-     * Normalize data for online signature verification.
-     * @param body Request body bytes.
-     * @param method Request method.
-     * @param uriId URI identifier.
-     * @param nonce Random nonce.
-     * @return Normalized string.
-     */
-    public @NonNull String normalizeOnlineData(@NonNull String body, @NonNull String method, @NonNull String uriId, @NonNull String nonce) {
-        return normalizeImpl(body.getBytes(Charset.defaultCharset()), method, uriId, nonce);
-    }
-
-    /**
      * Normalize data for offline signature verification.
      * @param body Request body bytes.
      * @param uriId URI identifier.
      * @param nonce Random nonce.
      * @return Normalized string.
      */
-    public @NonNull String normalizeOfflineData(@NonNull String body, @NonNull String uriId, @NonNull String nonce) {
-        return normalizeImpl(body.getBytes(Charset.defaultCharset()), "POST", uriId, nonce);
+    public @NonNull String normalizeOfflineData(@NonNull byte[] body, @NonNull String uriId, @NonNull String nonce) {
+        return normalizeImpl(body, "POST", uriId, nonce);
+    }
+
+    /**
+     * Normalize data for offline signature verification.
+     * @param bodyBase64 Request body in Base64 format
+     * @param uriId URI identifier.
+     * @param nonce Random nonce.
+     * @return Normalized string.
+     */
+    public @NonNull String normalizeOfflineData(@NonNull String bodyBase64, @NonNull String uriId, @NonNull String nonce) {
+        byte[] body = Base64.decode(bodyBase64, Base64.NO_WRAP);
+        return normalizeImpl(body, "POST", uriId, nonce);
     }
 
     /**

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BaseSdkTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BaseSdkTest.java
@@ -99,8 +99,12 @@ public class BaseSdkTest {
     public void testRestoreSdkState() throws Exception {
         activationHelper.createStandardActivation(false, null);
         assertTrue(powerAuthSDK.hasValidActivation());
-        powerAuthSDK = testHelper.reCreateSdk(null, null, null);
+        activationHelper.validateUserPassword(activationHelper.getValidPassword());
+        byte[] stateBefore = powerAuthSDK.getCoreSession().getSerializedState();
+        powerAuthSDK = activationHelper.reCreateSdk();
         assertTrue(powerAuthSDK.hasValidActivation());
+        byte[] stateAfter = powerAuthSDK.getCoreSession().getSerializedState();
+        assertArrayEquals(stateBefore, stateAfter);
     }
 
     @Test
@@ -340,6 +344,25 @@ public class BaseSdkTest {
         assertFalse(powerAuthSDK.hasValidActivation());
         assertFalse(powerAuthSDK.hasPendingActivation());
         assertTrue(powerAuthSDK.canStartActivation());
+    }
+
+    @Test
+    public void testRemoveActivationWithBiometry() throws Exception {
+        activationHelper.createStandardActivation(ActivationHelper.TF_PERSIST_WITH_FAKE_BIOMETRY, null);
+        boolean result = AsyncHelper.await(resultCatcher -> {
+            powerAuthSDK.removeActivationWithAuthentication(testHelper.getContext(), activationHelper.getBiometricAuthentication(null), new IActivationRemoveListener() {
+                @Override
+                public void onActivationRemoveSucceed() {
+                    resultCatcher.completeWithResult(true);
+                }
+
+                @Override
+                public void onActivationRemoveFailed(@NonNull Throwable t) {
+                    resultCatcher.completeWithResult(false);
+                }
+            });
+        });
+        assertTrue(result);
     }
 
     // Activation status

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BaseTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BaseTest.java
@@ -50,6 +50,7 @@ class BaseTest {
     PowerAuthTestHelper testHelper;
     PowerAuthSDK powerAuthSDK;
     ActivationHelper activationHelper;
+    AuthenticationHelper authenticationHelper;
 
     @Before
     public void setUp() throws Exception {
@@ -60,6 +61,7 @@ class BaseTest {
                 .build();
         powerAuthSDK = testHelper.getSharedSdk();
         activationHelper = new ActivationHelper(testHelper);
+        authenticationHelper = new AuthenticationHelper();
         assertEquals(getAlgorithmForTest(), getCurrentAlgorithm());
         if (isRequestFailureSimulatorAvailable()) {
             clearAllSimulateFailures();

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/TokenStoreTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/TokenStoreTest.java
@@ -21,11 +21,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import io.getlime.security.powerauth.networking.response.IGenerateTokenHeaderListener;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.Map;
 import java.util.Objects;
@@ -33,62 +29,31 @@ import java.util.Objects;
 import io.getlime.security.powerauth.exception.PowerAuthErrorCodes;
 import io.getlime.security.powerauth.exception.PowerAuthErrorException;
 import io.getlime.security.powerauth.integration.support.AsyncHelper;
-import io.getlime.security.powerauth.integration.support.PowerAuthTestHelper;
 import io.getlime.security.powerauth.integration.support.model.AuthCodeType;
 import io.getlime.security.powerauth.integration.support.model.TokenInfo;
 import io.getlime.security.powerauth.networking.exceptions.ErrorResponseApiException;
 import io.getlime.security.powerauth.networking.interfaces.ICancelable;
 import io.getlime.security.powerauth.networking.response.IGetTokenListener;
 import io.getlime.security.powerauth.networking.response.IRemoveTokenListener;
-import io.getlime.security.powerauth.sdk.PowerAuthAlgorithm;
 import io.getlime.security.powerauth.sdk.PowerAuthAuthentication;
 import io.getlime.security.powerauth.sdk.PowerAuthHttpHeader;
-import io.getlime.security.powerauth.sdk.PowerAuthSDK;
 import io.getlime.security.powerauth.sdk.PowerAuthToken;
 import io.getlime.security.powerauth.sdk.PowerAuthTokenStore;
 
 import static org.junit.Assert.*;
 
-@RunWith(Parameterized.class)
-public class TokenStoreTest {
+public class TokenStoreTest extends BaseTest {
 
-    @Parameterized.Parameter(0) public String alg;
-    @Parameterized.Parameters(name = " {0} ")
-    public static Iterable<Object[]> testParameters() {
-        return TestParameters.getParameters();
-    }
-
-    @PowerAuthAlgorithm
-    public int getAlgorithmForTest() {
-        return PowerAuthTestHelper.getAlgorithmForName(alg);
-    }
-
-    private PowerAuthTestHelper testHelper;
-    private PowerAuthSDK powerAuthSDK;
     private PowerAuthTokenStore tokenStore;
-    private ActivationHelper activationHelper;
-    private AuthenticationHelper authenticationHelper;
 
     private static final String TOKEN_NAME_POSSESSION = "TestToken_POSSESSION";
     private static final String TOKEN_NAME_POSSESSION_KNOWLEDGE = "TestToken_POSSESSION_KNOWLEDGE";
     private static final String TOKEN_NAME_OTHER = "TestToken_OTHER";
 
-    @Before
+    @Override
     public void setUp() throws Exception {
-        testHelper = new PowerAuthTestHelper.Builder()
-                .powerAuthAlgorithm(getAlgorithmForTest())
-                .build();
-        powerAuthSDK = testHelper.getSharedSdk();
+        super.setUp();
         tokenStore = powerAuthSDK.getTokenStore();
-        activationHelper = new ActivationHelper(testHelper);
-        authenticationHelper = new AuthenticationHelper();
-    }
-
-    @After
-    public void tearDown() {
-        if (activationHelper != null) {
-            activationHelper.cleanupAfterTest();
-        }
     }
 
     @Test(expected = PowerAuthErrorException.class)
@@ -138,7 +103,7 @@ public class TokenStoreTest {
         assertTrue(calculateAndValidateTokenDigest(token2, AuthCodeType.POSSESSION_KNOWLEDGE));
 
         // Try to re-create SDK. This simulates application restart.
-        powerAuthSDK = testHelper.reCreateSdk(null, null, null);
+        powerAuthSDK = activationHelper.reCreateSdk();
         tokenStore = powerAuthSDK.getTokenStore();
 
         // Now ask for the same tokens

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -23,16 +23,12 @@ import androidx.annotation.*;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 
-import java.io.Console;
-import java.util.ArrayList;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.logging.Logger;
 
 import io.getlime.security.powerauth.BuildConfig;
 import io.getlime.security.powerauth.biometry.*;
@@ -481,6 +477,22 @@ public class PowerAuthSDK {
      */
     public @NonNull PowerAuthKeychainConfiguration getKeychainConfiguration() {
         return mKeychainConfiguration;
+    }
+
+    /**
+     * Get low-level {@link CoreSession} object.
+     * <p>
+     * Be aware that this method should be used only for the testing or debugging purposes. If you
+     * call this method in RELEASE build, then {@link IllegalStateException} is raised.
+     *
+     * @return Instance of {@link CoreSession}.
+     */
+    @NonNull
+    public CoreSession getCoreSession() {
+        if (!BuildConfig.DEBUG) {
+            throw new IllegalStateException("Getting CoreSession is not allowed");
+        }
+        return mSession;
     }
 
     /**

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -1237,7 +1237,7 @@ public class PowerAuthSDK {
                 task = mGetActivationStatusTask.createChildTask(completion);
             }
             if (task == null) {
-                mGetActivationStatusTask = new GetActivationStatusTask(mClient, mSession, mLock, mCallbackDispatcher, new GetActivationStatusTask.ICompletionListener() {
+                mGetActivationStatusTask = new GetActivationStatusTask(mClient, mSession, mLock, mCallbackDispatcher, this::saveSerializedState, new GetActivationStatusTask.ICompletionListener() {
                     @Override
                     public void onSessionStateChange() {
                         saveSerializedState();
@@ -1387,6 +1387,7 @@ public class PowerAuthSDK {
         try {
             final CoreCredentials credentials = resolveCredentialsWithAuthentication(authentication);
             final CoreHttpHeader header = mSession.calculateOnlineAuthenticationHeader(credentials, uriId, method, body);
+            saveSerializedState();
             return PowerAuthHttpHeader.fromCoreObject(header);
         } catch (CoreException exception) {
             throw PowerAuthErrorException.wrapException(exception);
@@ -1417,6 +1418,7 @@ public class PowerAuthSDK {
             final byte[] normalizedParams = mSession.normalizeGetRequestParameters(params);
             final CoreCredentials credentials = resolveCredentialsWithAuthentication(authentication);
             final CoreHttpHeader header = mSession.calculateOnlineAuthenticationHeader(credentials, uriId, method, normalizedParams);
+            saveSerializedState();
             return PowerAuthHttpHeader.fromCoreObject(header);
         } catch (CoreException exception) {
             throw PowerAuthErrorException.wrapException(exception);
@@ -1528,7 +1530,9 @@ public class PowerAuthSDK {
         try {
             final CoreCredentials credentials = resolveCredentialsWithAuthentication(authentication);
             final int codeLength = mConfiguration.getOfflineAuthenticationCodeComponentLength();
-            return mSession.calculateOfflineAuthenticationCode(credentials, uriId, nonce, codeLength, body);
+            String code = mSession.calculateOfflineAuthenticationCode(credentials, uriId, nonce, codeLength, body);
+            saveSerializedState();
+            return code;
         } catch (CoreException e) {
             throw PowerAuthErrorException.wrapException(e);
         }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/GetActivationStatusTask.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/GetActivationStatusTask.java
@@ -50,6 +50,8 @@ public class GetActivationStatusTask extends GroupedTask<PowerAuthActivationStat
     @NonNull
     private final CoreSession session;
     @NonNull
+    private final Runnable saveStateCallback;
+    @NonNull
     private final ICompletionListener completionListener;
 
     /**
@@ -58,6 +60,7 @@ public class GetActivationStatusTask extends GroupedTask<PowerAuthActivationStat
      * @param httpClient HTTP client
      * @param session Core Session object.
      * @param sharedLock Shared lock.
+     * @param saveStateCallback Callback called when save of session state is required.
      * @param callbackDispatcher callback dispatcher from parent SDK object
      * @param completionListener final completion listener.
      */
@@ -66,10 +69,12 @@ public class GetActivationStatusTask extends GroupedTask<PowerAuthActivationStat
             @NonNull CoreSession session,
             @NonNull ReentrantLock sharedLock,
             @NonNull ICallbackDispatcher callbackDispatcher,
+            @NonNull Runnable saveStateCallback,
             @NonNull ICompletionListener completionListener) {
         super("GetActivationStatus", sharedLock, callbackDispatcher);
         this.httpClient = httpClient;
         this.session = session;
+        this.saveStateCallback = saveStateCallback;
         this.completionListener = completionListener;
     }
 
@@ -86,6 +91,9 @@ public class GetActivationStatusTask extends GroupedTask<PowerAuthActivationStat
                 @Override
                 public void onNetworkResponse(@Nullable CoreActivationStatus status) {
                     final CoreActivationStatus coreStatus = Objects.requireNonNull(status);
+                    if (coreStatus.isSessionSerializationNeeded()) {
+                        saveStateCallback.run();
+                    }
                     complete(new PowerAuthActivationStatus(coreStatus));
                 }
 

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKBaseTests.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKBaseTests.m
@@ -295,9 +295,13 @@
     //
     // Online & offline signatures (calculated as http auth header)
     //
-    for (int i = 1; i <= 2; i++)
+    for (int i = 1; i <= 4; i++)
     {
-        BOOL online_mode = i == 1;
+        if (i == 3) {
+            // re-create SDK to simulate app restart
+            _sdk = [_helper reCreateSdkInstanceWithConfiguration:nil biometricConfiguration:nil keychainConfiguration:nil clientConfiguration:nil];
+        }
+        BOOL online_mode = (i & 1) == 1;
         // Offline signature contains a
         NSData * data = online_mode
                             ? [@"hello online world" dataUsingEncoding:NSUTF8StringEncoding]
@@ -616,7 +620,7 @@
         PowerAuthHttpHeader * header = [_sdk authenticationHeaderForRequestWithBodyWithAuthentication:auth method:@"POST" uriId:@"/some/identifier" body:nil error:NULL];
         XCTAssertNotNil(header);
         if ((i % 4) == 0) {
-            // Every 4th signature calculation try to get the status
+            // Every 4th auth code calculation try to get the status
             status = [_helper fetchActivationStatus];
             XCTAssertNotNil(status);
             // Everything should be OK, because getting the status fires signature validation internally.

--- a/src/PowerAuthJni/CoreCredentialsJNI.cpp
+++ b/src/PowerAuthJni/CoreCredentialsJNI.cpp
@@ -55,7 +55,7 @@ CC7_JNI_STATIC_METHOD_PARAMS(jobject, biometry, jobject secureData)
     NH_TRY
     {
         auto cpp_data = jni::CopyFromSecureData(jni, secureData);
-        return jni.toJava(NH_SPECS().coreCredentials, Credentials::knowledge(cpp_data));
+        return jni.toJava(NH_SPECS().coreCredentials, Credentials::biometry(cpp_data));
     }
     NH_CATCH_RT_ONLY(nullptr)
 }


### PR DESCRIPTION
This PR adds support for fake biometric factor key, that allows to test basic biometry-related functionality without actual biometric authentication.

On top of that, there are the following bug-fixes and improvements:
- Android
  - Fixed `CoreCredentials` object construction with biometric factor
  - Fixed saving session's state after authentication code or header calculation
  - Fixed saving session's state after local counter synchronization
  - Expose `CoreSession` object for tests
  - Added more test cases to `AuthenticationCodeTest` class
- iOS
  - Improved test for authentication code calculation, to simulate app restart. 