### PR TITLE
Android support for secure vault keys

### DIFF
--- a/docs/Migration-from-1.9-to-2.0.md
+++ b/docs/Migration-from-1.9-to-2.0.md
@@ -41,6 +41,7 @@ Notable changes on Android:
     - `signDataWithDevicePrivateKey()` - use `calculateDigitalSignature()` method where you can specify the key used for signing.
     - `signJwtWithDevicePrivateKey()` - use `calculateJwsSignature()` method where you can specify the key used for signing.
     - `verifyServerSignedData()` - use `verifyDigitalSignature()` method where you can specify the key used for verification.
+    - `fetchEncryptionKey()` - method is effective only if PowerAuthSDK is running at protocol 3.3 and will be removed once we drop support for this legacy protocol. Meanwhile you can migrate to the new `fetchSecureVaultKey()` method providing a better flexibility for secure vault operations.
     - `saveSerializedState()` - method is now private
     - `restoreState()` - method is now private
     - `getSession()` - access to a low-level session object is no longer available. Let us know if you have a problem with this.

--- a/docs/PowerAuth-SDK-for-Android.md
+++ b/docs/PowerAuth-SDK-for-Android.md
@@ -1372,9 +1372,7 @@ The last check is fully under your control. By keeping the biometric settings fl
 
 ### Enable Biometric Authentication
 
-In case an activation does not yet have biometry-related factor data, and you would like to enable biometric authentication support, the device must first retrieve the original private key from the secure vault for key derivation. As a result, you have to use a successful 2FA with a password to enable biometric authentication support.
-
-Use the following code to enable biometric authentication using biometric authentication:
+In case an activation does not yet have biometry-related factor data, and you would like to enable biometric authentication support, use the following code:
 
 ```kotlin
 // Prepare biometric prompt.
@@ -1724,17 +1722,74 @@ As you can see, the E2EE is quite a non-trivial task. We recommend contacting us
 
 ## Secure Vault
 
-PowerAuth SDK for Android has basic support for an encrypted secure vault. At this moment, the only supported method allows your application to establish an encryption / decryption key with a given index. The index represents a "key number" - your identifier for a given key. Different business logic purposes should have encryption keys with different index values.
+Secure Vault lets an application obtain **a base KDK** (Key Derivation Key) after a successful strong user authentication.
+The base KDK is not an encryption or MAC key and cannot be used directly — instead, the application can derive purpose-specific keys from it.
+This functionality is available only when the activation is already on **protocol version 4.0**.
 
-On the server side, all secure vault-related work is concentrated in a `/pa/v3/vault/unlock` endpoint of PowerAuth Standard RESTful API. To receive data from this response, the call must be authenticated with at least 2FA (using a password or PIN).
+Use Secure Vault when you need a stable, high-entropy root for deriving multiple scoped keys (encryption, MAC, wrapping keys, etc.) tied to the user’s successful strong authentication, **without persisting** those child keys. The PowerAuth Mobile SDK guarantees that the base KDKs remain stable during the lifetime of an activation.
 
-<!-- begin box warning -->
-The secure vault mechanism does not support biometry by default. Use PIN code or password-based authentication for unlocking the secure vault, or ask your server developers to enable biometry for vault unlock call by configuring the PowerAuth Server instance.
-<!-- end -->
+### Key identifiers
 
-### Obtaining Encryption Key
+Two base KDKs are available, depending on the authentication factors used:
 
-To obtain an encryption key with a given index, use the following code:
+- `KNOWLEDGE` - available after successful authentication with possession + knowledge factors.
+- `KNOWLEDGE_OR_BIOMETRY` - available after any successful 2FA authentication. This key is at least as strong as `KNOWLEDGE` and can be used wherever a biometry-backed flow is acceptable.
+
+### Obtaining the "KNOWLEDGE" base KDK
+
+```kotlin
+// 2FA authentication. It uses device-related key and user PIN code.
+val authentication = PowerAuthAuthentication.possessionWithPassword("1234")
+val keyIdentifier = PowerAuthSecureVaultKeyId.KNOWLEDGE
+
+// Fetch the encryption key with the given index
+powerAuthSDK.fetchSecureVaultKey(context, authentication, keyIdentifier, object: IFetchSecureVaultKeyListener {
+    override fun onFetchSecureVaultKeySucceed(vaultKey: PowerAuthSecureVaultKey) {
+        // Derive a 32-byte key
+        val derivedKey = vaultKey.deriveKey(1000, 32)
+        val keyData = derivedKey.sensitiveData
+    }
+
+    override fun onFetchSecureVaultKeyFailed(throwable: Throwable) {
+        // Report error
+    }
+})
+```
+
+### Obtaining the "KNOWLEDGE_OR_BIOMETRY" base KDK
+
+```kotlin
+// 2FA authentication. It uses device-related key and user PIN code.
+// Alternatively, you can obtain authentication object with biometric authentication 
+// using authenticateUsingBiometrics() function.  
+val authentication = PowerAuthAuthentication.possessionWithPassword("1234")
+val keyIdentifier = PowerAuthSecureVaultKeyId.KNOWLEDGE_OR_BIOMETRY
+
+// Fetch the encryption key with the given index
+powerAuthSDK.fetchSecureVaultKey(context, authentication, keyIdentifier, object: IFetchSecureVaultKeyListener {
+    override fun onFetchSecureVaultKeySucceed(vaultKey: PowerAuthSecureVaultKey) {
+        // Derive a 32-byte key
+        val derivedKey = vaultKey.deriveKey(1000, 32)
+        val keyData = derivedKey.sensitiveData
+    }
+
+    override fun onFetchSecureVaultKeyFailed(throwable: Throwable) {
+        // Report error
+    }
+})
+```
+
+### Security Recommendations
+
+- Do **not** store derived keys on the device. Always acquire the base KDK when needed and derive the keys for each specific purpose.
+- **Destroy** the base KDK as soon as possible.
+- Never reuse a derived key for multiple purposes (e.g., don’t use one key for both encryption and authentication).
+- When encrypting different data sets, **derive a new** key with a different index.
+- If your application uses multiple keys, maintain a **registry of derivation indices** to avoid accidental key reuse.
+
+### Obtaining Legacy Encryption Key
+
+If your activation is still using **PowerAuth protocol 3.3**, you can obtain the legacy encryption key as follows:
 
 ```kotlin
 // 2FA authentication. It uses device-related key and user PIN code.
@@ -1755,6 +1810,9 @@ powerAuthSDK.fetchEncryptionKey(context, authentication, index, object: IFetchEn
     }
 })
 ```
+
+This function is useful if you still have local data encrypted with a key generated by an older SDK version. It is recommended to decrypt the data with the old key and re-encrypt it using the new key, acquired via the `fetchSecureVaultKey()` function.
+
 
 ## Token-Based Authentication
 

--- a/docs/PowerAuth-SDK-for-iOS.md
+++ b/docs/PowerAuth-SDK-for-iOS.md
@@ -1210,9 +1210,7 @@ The last check is fully under your control. By keeping the biometry settings fla
 
 ### Enable Biometry
 
-In case an activation does not yet have biometry-related factor data, and you would like to enable Touch or Face ID support, the device must first retrieve the original private key from the secure vault for the purpose of key derivation. As a result, you have to use a successful 2FA with a password to enable biometry support.
-
-Use the following code to enable biometric authentication:
+In case an activation does not yet have biometry-related factor data, and you would like to enable Touch or Face ID support, use the following code:
 
 ```swift
 // Establish biometric data using the provided password

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/DsaSignatureTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/DsaSignatureTest.java
@@ -312,7 +312,7 @@ public class DsaSignatureTest {
         }
         // Well, we have a data for offline signature, so let's try to verify it.
         String uriId = "/operation/authorize/offline";
-        byte[] body = payload.getParsedData().getBytes(StandardCharsets.UTF_8);
+        byte[] body = Base64.decode(payload.getParsedData(), Base64.NO_WRAP);
         String nonce = payload.getParsedNonce();
         String offlineAuthCode = AsyncHelper.await(resultCatcher -> {
             powerAuthSDK.offlineAuthenticationCode(testHelper.getContext(), authentication, uriId, body, nonce, new IOfflineAuthenticationCodeListener() {

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/SecureVaultKeyTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/SecureVaultKeyTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2026 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.integration.tests;
+
+import androidx.annotation.NonNull;
+
+import org.junit.Test;
+
+import io.getlime.security.powerauth.core.SecureData;
+import io.getlime.security.powerauth.exception.PowerAuthErrorCodes;
+import io.getlime.security.powerauth.exception.PowerAuthErrorException;
+import io.getlime.security.powerauth.integration.support.AsyncHelper;
+import io.getlime.security.powerauth.networking.response.IFetchEncryptionKeyListener;
+import io.getlime.security.powerauth.networking.response.IFetchSecureVaultKeyListener;
+import io.getlime.security.powerauth.sdk.PowerAuthAlgorithm;
+import io.getlime.security.powerauth.sdk.PowerAuthAuthentication;
+import io.getlime.security.powerauth.sdk.PowerAuthSecureVaultKey;
+import io.getlime.security.powerauth.sdk.PowerAuthSecureVaultKeyId;
+
+import static org.junit.Assert.*;
+
+public class SecureVaultKeyTest extends BaseTest {
+
+    @Test
+    public void testVaultEncryptionKeys() throws Exception {
+        activationHelper.createStandardActivation(ActivationHelper.TF_PERSIST_WITH_FAKE_BIOMETRY, null);
+        PowerAuthAuthentication validKnowledge = activationHelper.getValidAuthentication();
+        PowerAuthAuthentication validBiometry = activationHelper.getBiometricAuthentication(null);
+        PowerAuthSecureVaultKey any2fa, knowledge, otherKDK;
+        SecureData legacy, other, another;
+        if (getCurrentAlgorithm() != PowerAuthAlgorithm.LEGACY_P256) {
+            // V4
+            any2fa = fetchVaultEncryptionKey(PowerAuthSecureVaultKeyId.KNOWLEDGE_OR_BIOMETRY, validKnowledge, true);
+            otherKDK = fetchVaultEncryptionKey(PowerAuthSecureVaultKeyId.KNOWLEDGE_OR_BIOMETRY, validKnowledge, true);
+            assertEquals(any2fa, otherKDK);
+            otherKDK = fetchVaultEncryptionKey(PowerAuthSecureVaultKeyId.KNOWLEDGE_OR_BIOMETRY, validBiometry, true);
+            assertEquals(any2fa, otherKDK);
+            knowledge = fetchVaultEncryptionKey(PowerAuthSecureVaultKeyId.KNOWLEDGE, validKnowledge, true);
+            assertNotEquals(any2fa, knowledge);
+            otherKDK = fetchVaultEncryptionKey(PowerAuthSecureVaultKeyId.KNOWLEDGE, validKnowledge, true);
+            assertEquals(knowledge, otherKDK);
+
+            // derive other keys
+            other = any2fa.deriveKey(1000, 32);
+            assertEquals(32, other.length());
+            another = any2fa.deriveKey(1000, 32);
+            assertEquals(another, other);
+
+            other = knowledge.deriveKey(1000, 32);
+            assertEquals(32, other.length());
+            another = knowledge.deriveKey(1000, 32);
+            assertEquals(other, another);
+
+            another = knowledge.deriveKey(1000, 16);
+            assertEquals(16, another.length());
+            assertNotEquals(other, another);
+
+            // Following fetch operations should fail
+            fetchVaultEncryptionKey(PowerAuthSecureVaultKeyId.KNOWLEDGE, validBiometry, false);
+            fetchLegacyVaultKey(validKnowledge, 500, false);
+            fetchLegacyVaultKey(validBiometry, 1000, false);
+            // Min size is 16
+            try {
+                knowledge.deriveKey(1000, 8);
+                fail("Previous statement should fail");
+            } catch (PowerAuthErrorException e) {
+                assertEquals(PowerAuthErrorCodes.WRONG_PARAMETER, e.getPowerAuthErrorCode());
+            }
+        } else {
+            // V3
+            legacy = fetchLegacyVaultKey(validKnowledge, 10, true);
+            assertEquals(16, legacy.length());
+            other = fetchLegacyVaultKey(validKnowledge, 10, true);
+            assertEquals(legacy, other);
+            // Following fetch operations should fail
+            fetchVaultEncryptionKey(PowerAuthSecureVaultKeyId.KNOWLEDGE, validKnowledge, false);
+            fetchVaultEncryptionKey(PowerAuthSecureVaultKeyId.KNOWLEDGE_OR_BIOMETRY, validKnowledge, false);
+            fetchLegacyVaultKey(validBiometry, 10, false);
+        }
+    }
+
+    // Helper functions
+
+    PowerAuthSecureVaultKey fetchVaultEncryptionKey(@PowerAuthSecureVaultKeyId int keyId,
+                                                    PowerAuthAuthentication authentication,
+                                                    boolean shouldPass) throws Exception {
+        PowerAuthSecureVaultKey result = AsyncHelper.await(resultCatcher -> {
+            powerAuthSDK.fetchSecureVaultKey(testHelper.getContext(), authentication, keyId, new IFetchSecureVaultKeyListener() {
+                @Override
+                public void onFetchSecureVaultKeySucceed(@NonNull PowerAuthSecureVaultKey vaultKey) {
+                    resultCatcher.completeWithResult(vaultKey);
+                }
+
+                @Override
+                public void onFetchSecureVaultKeyFailed(@NonNull Throwable throwable) {
+                    resultCatcher.completeWithResult(null);
+                }
+            });
+        });
+        if (shouldPass) {
+            assertNotNull(result);
+        } else {
+            assertNull(result);
+        }
+        return result;
+    }
+
+    SecureData fetchLegacyVaultKey(PowerAuthAuthentication authentication,
+                                   long derivationIndex,
+                                   boolean shouldPass) throws Exception {
+        SecureData result = AsyncHelper.await(resultCatcher -> {
+            powerAuthSDK.fetchEncryptionKey(testHelper.getContext(), authentication, derivationIndex, new IFetchEncryptionKeyListener() {
+                @Override
+                public void onFetchEncryptionKeySucceed(@NonNull SecureData encryptionKey) {
+                    resultCatcher.completeWithResult(encryptionKey);
+                }
+
+                @Override
+                public void onFetchEncryptionKeyFailed(@NonNull Throwable t) {
+                    resultCatcher.completeWithResult(null);
+                }
+            });
+        });
+        if (shouldPass) {
+            assertNotNull(result);
+        } else {
+            assertNull(result);
+        }
+        return result;
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/SecureVaultKeyTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/SecureVaultKeyTest.java
@@ -24,6 +24,7 @@ import io.getlime.security.powerauth.core.SecureData;
 import io.getlime.security.powerauth.exception.PowerAuthErrorCodes;
 import io.getlime.security.powerauth.exception.PowerAuthErrorException;
 import io.getlime.security.powerauth.integration.support.AsyncHelper;
+import io.getlime.security.powerauth.networking.interfaces.ICancelable;
 import io.getlime.security.powerauth.networking.response.IFetchEncryptionKeyListener;
 import io.getlime.security.powerauth.networking.response.IFetchSecureVaultKeyListener;
 import io.getlime.security.powerauth.sdk.PowerAuthAlgorithm;
@@ -99,7 +100,7 @@ public class SecureVaultKeyTest extends BaseTest {
                                                     PowerAuthAuthentication authentication,
                                                     boolean shouldPass) throws Exception {
         PowerAuthSecureVaultKey result = AsyncHelper.await(resultCatcher -> {
-            powerAuthSDK.fetchSecureVaultKey(testHelper.getContext(), authentication, keyId, new IFetchSecureVaultKeyListener() {
+            ICancelable task = powerAuthSDK.fetchSecureVaultKey(testHelper.getContext(), authentication, keyId, new IFetchSecureVaultKeyListener() {
                 @Override
                 public void onFetchSecureVaultKeySucceed(@NonNull PowerAuthSecureVaultKey vaultKey) {
                     resultCatcher.completeWithResult(vaultKey);
@@ -110,6 +111,9 @@ public class SecureVaultKeyTest extends BaseTest {
                     resultCatcher.completeWithResult(null);
                 }
             });
+            if (shouldPass) {
+                assertNotNull(task);
+            }
         });
         if (shouldPass) {
             assertNotNull(result);
@@ -123,7 +127,7 @@ public class SecureVaultKeyTest extends BaseTest {
                                    long derivationIndex,
                                    boolean shouldPass) throws Exception {
         SecureData result = AsyncHelper.await(resultCatcher -> {
-            powerAuthSDK.fetchEncryptionKey(testHelper.getContext(), authentication, derivationIndex, new IFetchEncryptionKeyListener() {
+            ICancelable task = powerAuthSDK.fetchEncryptionKey(testHelper.getContext(), authentication, derivationIndex, new IFetchEncryptionKeyListener() {
                 @Override
                 public void onFetchEncryptionKeySucceed(@NonNull SecureData encryptionKey) {
                     resultCatcher.completeWithResult(encryptionKey);
@@ -134,6 +138,9 @@ public class SecureVaultKeyTest extends BaseTest {
                     resultCatcher.completeWithResult(null);
                 }
             });
+            if (shouldPass) {
+                assertNotNull(task);
+            }
         });
         if (shouldPass) {
             assertNotNull(result);

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreSecureVaultKeyId.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreSecureVaultKeyId.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.core;
+
+import androidx.annotation.IntDef;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import static io.getlime.security.powerauth.core.CoreSecureVaultKeyId.*;
+
+/**
+ * The {@code CoreVaultEncryptionKeyId} enumeration defines the types of vault keys
+ * supported in the PowerAuth Mobile SDK.
+ */
+@Retention(RetentionPolicy.SOURCE)
+@IntDef({ANY_2FA, KNOWLEDGE, LEGACY})
+public @interface CoreSecureVaultKeyId {
+    /**
+     * This type of vault key can be provided after successful 2FA authentication on the server.
+     */
+    int ANY_2FA = 1;
+    /**
+     * This type of vault key can be provided after authentication with the user's password.
+     */
+    int KNOWLEDGE = 2;
+    /**
+     * This is a legacy key available only when PowerAuthSDK is running on a legacy protocol.
+     * The key can be provided after authentication with the user's password.
+     */
+    int LEGACY = 3;
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreSession.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreSession.java
@@ -434,6 +434,39 @@ public class CoreSession extends NativeObject {
     @NonNull
     public native CoreEncryptorFactory getEncryptorFactory();
 
+    // Vault operations
+
+    /**
+     * Fetch vault key from the server. If the requested key is {@link CoreSecureVaultKeyId#LEGACY},
+     * then also apply key derivation with given index. In case of success, the response object
+     * contains instance of {@link SecureData} object.
+     * @param credentials Credentials used for access the key.
+     * @param keyId Vault encryption key to fetch.
+     * @param index Derivation index of the vault key. The value is ignored for non-"legacy" keys.
+     * @return {@link CoreRequest} object containing all required information for accessing the key.
+     * @throws CoreException In case of failure.
+     */
+    @NonNull
+    public native CoreRequest<SecureData> fetchVaultEncryptionKey(@NonNull CoreCredentials credentials,
+                                                                  @CoreSecureVaultKeyId int keyId,
+                                                                  long index) throws CoreException;
+
+    /**
+     * Derive already existing key into new key. If the key type is {@link CoreSecureVaultKeyId#LEGACY},
+     * then throws exception.
+     * @param vaultKey Original key.
+     * @param keyId Identifier of current vault encryption key.
+     * @param index Derivation index of the new key.
+     * @param keySize Size of derived key in bytes. Minimum is 16 bytes.
+     * @return {@link SecureData} object with derived key.
+     * @throws CoreException In case of failure.
+     */
+    @NonNull
+    public native static SecureData deriveVaultEncryptionKey(@NonNull SecureData vaultKey,
+                                                             @CoreSecureVaultKeyId int keyId,
+                                                             long index,
+                                                             int keySize) throws CoreException;
+
     // Utilities
 
     /**

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/response/IFetchSecureVaultKeyListener.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/networking/response/IFetchSecureVaultKeyListener.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.networking.response;
+
+import androidx.annotation.MainThread;
+import androidx.annotation.NonNull;
+
+import io.getlime.security.powerauth.sdk.PowerAuthSecureVaultKey;
+
+/**
+ * Listener for secure vault key retrieval.
+ */
+public interface IFetchSecureVaultKeyListener {
+    /**
+     * Called when secure vault key key is successfully retrieved.
+     *
+     * @param vaultKey the retrieved secure vault key.
+     */
+    @MainThread
+    void onFetchSecureVaultKeySucceed(@NonNull PowerAuthSecureVaultKey vaultKey);
+
+    /**
+     * Called when secure vault key key retrieval fails.
+     *
+     * @param throwable error that occurred during the encryption key retrieval.
+     */
+    @MainThread
+    void onFetchSecureVaultKeyFailed(@NonNull Throwable throwable);
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -369,43 +369,6 @@ public class PowerAuthSDK {
     }
 
     /**
-     * Private, defines callback interface for {@link #fetchEncryptedVaultUnlockKey(Context, PowerAuthAuthentication, String, IFetchEncryptedVaultUnlockKeyListener)}
-     * method.
-     */
-    private interface IFetchEncryptedVaultUnlockKeyListener {
-        /**
-         * Called after the vault key has been successfully acquired.
-         *
-         * @param encryptedEncryptionKey encrypted vault key
-         */
-        @MainThread
-        void onFetchEncryptedVaultUnlockKeySucceed(String encryptedEncryptionKey);
-
-        /**
-         * Called after the vault key was not acquired from the server.
-         *
-         * @param throwable Cause of the failure
-         */
-        @MainThread
-        void onFetchEncryptedVaultUnlockKeyFailed(Throwable throwable);
-    }
-
-    /**
-     * Private method receives an encrypted vault unlock key from the server.
-     *
-     * @param context android context object
-     * @param authentication authentication object, with at least 2 factors defined.
-     * @param reason reason for vault unlock operation (See {@link VaultUnlockReason})
-     * @param listener private listener called with the operation result.
-     * @return {@link ICancelable} object with asynchronous operation.
-     */
-    private @Nullable
-    ICancelable fetchEncryptedVaultUnlockKey(@NonNull final Context context, @NonNull final PowerAuthAuthentication authentication, @NonNull @VaultUnlockReason final String reason, @NonNull final IFetchEncryptedVaultUnlockKeyListener listener) {
-        dispatchCallback(() -> listener.onFetchEncryptedVaultUnlockKeyFailed(new PowerAuthErrorException(PowerAuthErrorCodes.OTHER, "Not implemented")));
-        return null;
-    }
-
-    /**
      * Returns reference to {@code PowerAuthTokenStore} instance. The internal instance is created on demand, when
      * the getter is called for first time.
      *
@@ -2383,46 +2346,6 @@ public class PowerAuthSDK {
 //        keystore.removeBiometricKeyEncryptor(biometricDataMapping.keystoreId);
     }
 
-
-    /**
-     * Generate a derived encryption key with given index.
-     * <p>
-     * This method calls PowerAuth Standard REST API endpoint to obtain the vault encryption key used for subsequent key derivation using given index.
-     *
-     * @param context        Context.
-     * @param authentication Authentication used for vault unlocking call.
-     * @param index          Index of the derived key using KDF.
-     * @param listener       The callback method with the derived encryption key.
-     * @return {@link ICancelable} object associated with the running HTTP request.
-     */
-    public @Nullable
-    ICancelable fetchEncryptionKey(@NonNull final Context context, @NonNull PowerAuthAuthentication authentication, final long index, @NonNull final IFetchEncryptionKeyListener listener) {
-        mCallbackDispatcher.dispatchCallback(() -> listener.onFetchEncryptionKeyFailed(new PowerAuthErrorException(PowerAuthErrorCodes.OTHER, "Not implemented")));
-        return null;
-//        return fetchEncryptedVaultUnlockKey(context, authentication, VaultUnlockReason.FETCH_ENCRYPTION_KEY, new IFetchEncryptedVaultUnlockKeyListener() {
-//
-//            @Override
-//            public void onFetchEncryptedVaultUnlockKeySucceed(String encryptedEncryptionKey) {
-//
-//                // Let's unlock encryption key
-//                final SignatureUnlockKeys keys = new SignatureUnlockKeys(deviceRelatedKey(context), null, null);
-//                final SecureData key = mSession.deriveCryptographicKeyFromVaultKey(encryptedEncryptionKey, keys, index);
-//                if (key != null) {
-//                    listener.onFetchEncryptionKeySucceed(key);
-//                } else {
-//                    // Propagate error
-//                    listener.onFetchEncryptionKeyFailed(new PowerAuthErrorException(PowerAuthErrorCodes.INVALID_ACTIVATION_DATA));
-//                }
-//
-//            }
-//
-//            @Override
-//            public void onFetchEncryptedVaultUnlockKeyFailed(Throwable t) {
-//                listener.onFetchEncryptionKeyFailed(t);
-//            }
-//        });
-    }
-
     /**
      * Validate a user password. This method calls PowerAuth REST API endpoint to validate the password on the server.
      *
@@ -2682,6 +2605,100 @@ public class PowerAuthSDK {
                     // Otherwise just report the failure.
                     callback.onBiometricDialogFailed(error);
                 }
+            }
+        });
+    }
+
+    // Vault keys
+
+    /**
+     * Fetch secure vault key from the server.
+     * @param context Context.
+     * @param authentication Authentication object.
+     * @param keyIdentifier {@link CoreSecureVaultKeyId} identifier.
+     * @param index Derivation index for {@link CoreSecureVaultKeyId#LEGACY} key.
+     * @param listener Completion listener.
+     * @return Cancelable operation with the pending HTTP request.
+     */
+    @Nullable
+    private ICancelable fetchVaultEncryptionKey(@NonNull Context context,
+                                                @NonNull PowerAuthAuthentication authentication,
+                                                @CoreSecureVaultKeyId int keyIdentifier,
+                                                long index,
+                                                INetworkResponseListener<SecureData> listener) {
+        try {
+            CoreCredentials credentials = resolveCredentialsWithAuthentication(authentication);
+            CoreRequest<SecureData> request = mSession.fetchVaultEncryptionKey(credentials, keyIdentifier, index);
+            return mClient.post(request, listener);
+        } catch (PowerAuthErrorException exception) {
+            dispatchCallback(() -> listener.onNetworkError(exception));
+        } catch (CoreException exception) {
+            dispatchCallback(() -> listener.onNetworkError(PowerAuthErrorException.wrapException(exception)));
+        }
+        return null;
+    }
+
+    /**
+     * Generate an derived encryption key with given index. The method is effective only if
+     * PowerAuthSDK is running at protocol version 3.3
+     * <p>
+     * Be aware that the method is subject to remove once PowerAuth Mobile SDK drops support of old
+     * protocol version.
+     *
+     * @param context        Context.
+     * @param authentication Authentication used for vault unlocking call.
+     * @param index          Index of the derived key using KDF.
+     * @param listener       The callback method with the derived encryption key.
+     * @return {@link ICancelable} object associated with the running HTTP request.
+     */
+    @Nullable
+    public ICancelable fetchEncryptionKey(@NonNull final Context context, @NonNull PowerAuthAuthentication authentication, final long index, @NonNull final IFetchEncryptionKeyListener listener) {
+        return fetchVaultEncryptionKey(context, authentication, CoreSecureVaultKeyId.LEGACY, index, new INetworkResponseListener<>() {
+            @Override
+            public void onNetworkResponse(@Nullable SecureData secureData) {
+                SecureData legacyKey = Objects.requireNonNull(secureData);
+                listener.onFetchEncryptionKeySucceed(legacyKey);
+            }
+
+            @Override
+            public void onNetworkError(@NonNull Throwable throwable) {
+                listener.onFetchEncryptionKeyFailed(throwable);
+            }
+
+            @Override
+            public void onCancel() {
+            }
+        });
+    }
+
+    /**
+     * Get a vault encryption key from the server. This method is effective only if PowerAuthSDK is running
+     * at protocol version 4.0 and higher.
+     * @param context Context.
+     * @param authentication Authentication used for vault unlocking call.
+     * @param keyIdentifier Key to retrieve.
+     * @param listener Listener with the callback methods.
+     * @return {@link ICancelable} object associated with the running HTTP request.
+     */
+    public ICancelable fetchSecureVaultKey(@NonNull Context context,
+                                           @NonNull PowerAuthAuthentication authentication,
+                                           @PowerAuthSecureVaultKeyId int keyIdentifier,
+                                           @NonNull IFetchSecureVaultKeyListener listener) {
+        final int keyId = PowerAuthSecureVaultKey.toCoreKeyId(keyIdentifier);
+        return fetchVaultEncryptionKey(context, authentication, keyId, 0, new INetworkResponseListener<>() {
+            @Override
+            public void onNetworkResponse(@Nullable SecureData secureData) {
+                SecureData baseKey = Objects.requireNonNull(secureData);
+                listener.onFetchSecureVaultKeySucceed(new PowerAuthSecureVaultKey(keyIdentifier, baseKey));
+            }
+
+            @Override
+            public void onNetworkError(@NonNull Throwable throwable) {
+                listener.onFetchSecureVaultKeyFailed(throwable);
+            }
+
+            @Override
+            public void onCancel() {
             }
         });
     }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSecureVaultKey.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSecureVaultKey.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.sdk;
+
+import android.annotation.SuppressLint;
+
+import androidx.annotation.NonNull;
+
+import io.getlime.security.powerauth.core.CoreException;
+import io.getlime.security.powerauth.core.CoreSecureVaultKeyId;
+import io.getlime.security.powerauth.core.CoreSession;
+import io.getlime.security.powerauth.core.SecureData;
+import io.getlime.security.powerauth.exception.PowerAuthErrorException;
+
+/**
+ * The {@code PowerAuthSecureVaultKey} class represents a vault encryption key
+ * available for application use. The key is typically obtained as part of
+ * the activation process, allowing the application to encrypt sensitive data
+ * during activation. It can later be retrieved from the server after successful
+ * authentication.
+ */
+public class PowerAuthSecureVaultKey {
+    private final @PowerAuthSecureVaultKeyId int keyIdentifier;
+    private final SecureData baseKey;
+
+    /**
+     * Construct object with key identifier and base secure vault key.
+     * @param keyIdentifier Key identifier.
+     * @param baseKey Base secure vault key.
+     */
+    PowerAuthSecureVaultKey(@PowerAuthSecureVaultKeyId int keyIdentifier,
+                                   @NonNull SecureData baseKey) {
+        this.keyIdentifier = keyIdentifier;
+        this.baseKey = baseKey;
+    }
+
+    /**
+     * @return Key identifier.
+     */
+    @PowerAuthSecureVaultKeyId
+    public int getKeyIdentifier() {
+        return keyIdentifier;
+    }
+
+    /**
+     * Derives another key from this key, allowing creation of a chain of separated keys.
+     *
+     * @param index Derivation index.
+     * @param keySize Size of derived key in bytes. Minimum is 16 bytes.
+     * @return Derived key.
+     * @throws PowerAuthErrorException In case of failure.
+     */
+    @NonNull
+    public SecureData deriveKey(long index, int keySize) throws PowerAuthErrorException {
+        try {
+            return CoreSession.deriveVaultEncryptionKey(baseKey, toCoreKeyId(keyIdentifier), index, keySize);
+        } catch (CoreException exception) {
+            throw PowerAuthErrorException.wrapException(exception);
+        }
+    }
+
+    /**
+     * Internal method converts {@link PowerAuthSecureVaultKeyId} into {@link CoreSecureVaultKeyId}
+     * constant.
+     * @param keyId Constant to convert.
+     * @return Converted constant.
+     */
+    @SuppressLint("WrongConstant")
+    @CoreSecureVaultKeyId
+    static int toCoreKeyId(@PowerAuthSecureVaultKeyId int keyId) {
+        // PowerAuthSecureVaultKeyId is subset to CoreSecureVaultKeyId
+        return keyId;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof PowerAuthSecureVaultKey)) {
+            return false;
+        }
+        PowerAuthSecureVaultKey typed = (PowerAuthSecureVaultKey) obj;
+        return keyIdentifier == typed.keyIdentifier &&
+                baseKey.equals(typed.baseKey);
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSecureVaultKeyId.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSecureVaultKeyId.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.sdk;
+
+import androidx.annotation.IntDef;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import io.getlime.security.powerauth.core.CoreSecureVaultKeyId;
+
+import static io.getlime.security.powerauth.sdk.PowerAuthSecureVaultKeyId.*;
+
+/**
+ * The {@code PowerAuthSecureVaultKeyId} enumeration defines the types of vault keys
+ * supported in the PowerAuth Mobile SDK.
+ */
+@Retention(RetentionPolicy.SOURCE)
+@IntDef({KNOWLEDGE_OR_BIOMETRY, KNOWLEDGE})
+public @interface PowerAuthSecureVaultKeyId {
+    /**
+     * This type of vault key can be provided after successful 2FA authentication on the server.
+     */
+    int KNOWLEDGE_OR_BIOMETRY = CoreSecureVaultKeyId.ANY_2FA;
+    /**
+     * This type of vault key can be provided after authentication with the user's password.
+     */
+    int KNOWLEDGE = CoreSecureVaultKeyId.KNOWLEDGE;
+}

--- a/proj-xcode/PowerAuth2/PowerAuthSDK.h
+++ b/proj-xcode/PowerAuth2/PowerAuthSDK.h
@@ -837,14 +837,8 @@
                                                      index:(UInt64)index
                                                   callback:(nonnull void(^)(PowerAuthCoreData * _Nullable encryptionKey, NSError * _Nullable error))callback;
 
-/// Get a vault encryption key from the server.
-///
-/// Be careful how you use this method, because its functionality depends on the current protocol version. The function has the following limitations:
-///
-/// - If activation is still at protocol version 3.3:
-///   - Only `legacy` key is supported and the returned key has always derivation index set to `0`.
-/// - If activation is already at protocol version 4.0 and newer:
-///   - The `legacy` key is no longer supported.
+/// Get a vault encryption key from the server. This method is effective only if PowerAuthSDK is running
+/// at protocol version 4.0 and higher.
 ///
 /// @param authentication Authentication used for vault unlocking call.
 /// @param keyIdentifier Vault encryption key identifier.

--- a/src/PowerAuthJni/ClassSpecs.cpp
+++ b/src/PowerAuthJni/ClassSpecs.cpp
@@ -111,6 +111,11 @@ ClassSpecs ClassSpecs::buildSpecs(JNI &jni)
             "REMOVED",
             "DEADLOCK"
         });
+        spec.coreSecureVaultKeyId = jni.buildConstantRangeSpec("io/getlime/security/powerauth/core/CoreSecureVaultKeyId", {
+           "ANY_2FA",
+           "KNOWLEDGE",
+           "LEGACY"
+        });
 
         // Exceptions
         spec.coreErrorCode = jni.buildConstantRangeSpec("io/getlime/security/powerauth/core/CoreErrorCode", {
@@ -166,6 +171,7 @@ ClassSpecs ClassSpecs::buildSpecs(JNI &jni)
         jni.releaseSpec(spec.coreDevicePublicKeyFormat);
         jni.releaseSpec(spec.coreEncryptorScope);
         jni.releaseSpec(spec.coreActivationState);
+        jni.releaseSpec(spec.coreSecureVaultKeyId);
         // exception
         jni.releaseSpec(spec.coreErrorCode);
         jni.releaseSpec(spec.coreException);

--- a/src/PowerAuthJni/ClassSpecs.h
+++ b/src/PowerAuthJni/ClassSpecs.h
@@ -304,6 +304,7 @@ struct ClassSpecs
     JniCommon::ConstantSetSpec coreProtocolVersion;
     JniCommon::ConstantRangeSpec coreEncryptorScope;
     JniCommon::ConstantRangeSpec coreActivationState;
+    JniCommon::ConstantRangeSpec coreSecureVaultKeyId;
 
     // handle based objects
     JniCommon::NativeHandleClass password;

--- a/src/PowerAuthJni/CoreSessionJNI.cpp
+++ b/src/PowerAuthJni/CoreSessionJNI.cpp
@@ -541,6 +541,43 @@ CC7_JNI_METHOD(jobject, getEncryptorFactory)
     NH_CATCH_RT_ONLY(nullptr)
 }
 
+// Vault operations
+
+CC7_JNI_METHOD_PARAMS(jobject, fetchVaultEncryptionKey, jobject credentials, jint keyId, jlong index)
+{
+    NH_TRY
+    {
+        jni.requireParameter(credentials, "credentials");
+        auto& spec = NH_SPECS();
+        auto request = THIS_OBJ()->fetchVaultEncryptionKey(jni.fromJava<Credentials>(spec.coreCredentials, credentials),
+                                                           jni.fromJava<SecureVaultKeyId>(spec.coreSecureVaultKeyId, keyId),
+                                                           static_cast<cc7::U64>(index));
+        return BuildCoreRequest(jni, request, [](JNI& jni, const ClassSpecs& specs, const ResponseObjectPtr& response, const JsonValue& response_json) -> jobject {
+            auto result = std::dynamic_pointer_cast<DataResponse>(response);
+            if (!result) {
+                throw Exception(EC_InternalError, "No DataResponse object created");
+            }
+            return CopyToSecureData(jni, result->data());
+        });
+    }
+    NH_CATCH(nullptr)
+}
+
+CC7_JNI_STATIC_METHOD_PARAMS(jobject, deriveVaultEncryptionKey, jobject vaultKey, jint keyId, jlong index, jint keySize)
+{
+    NH_TRY
+    {
+        jni.requireParameter(vaultKey, "vaultKey");
+        auto& specs = NH_SPECS();
+        auto derived = Session::deriveVaultEncryptionKey(CopyFromSecureData(jni, vaultKey),
+                                                         static_cast<cc7::U64>(index),
+                                                         static_cast<size_t>(keySize),
+                                                         jni.fromJava<SecureVaultKeyId>(specs.coreSecureVaultKeyId, keyId));
+        return CopyToSecureData(jni, derived);
+    }
+    NH_CATCH(nullptr)
+}
+
 // Utilities
 
 CC7_JNI_METHOD(jobject, generateFactorKek)


### PR DESCRIPTION
This PR adds support for secure vault keys on Android platform. 

Other changes:
- fix for failing `DsaSignatureTest`.