### PR TITLE
Android: Improved integration tests

### DIFF
--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/model/OfflineSignaturePayload.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/model/OfflineSignaturePayload.java
@@ -16,6 +16,8 @@
 
 package io.getlime.security.powerauth.integration.support.model;
 
+import android.util.Base64;
+
 import androidx.annotation.NonNull;
 
 import com.google.gson.annotations.Expose;
@@ -71,6 +73,10 @@ public class OfflineSignaturePayload {
     }
     public String getParsedData() {
         return getParsedComponents()[0];
+    }
+
+    public byte[] getParsedDataBytes() {
+        return Base64.decode(getParsedData(), Base64.NO_WRAP);
     }
 
     public String getParsedNonce() {

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/AuthenticationCodeTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/AuthenticationCodeTest.java
@@ -41,7 +41,7 @@ import static org.junit.Assert.*;
 public class AuthenticationCodeTest extends BaseTest {
 
     @Test
-    public void testOfflineSignatureCalculation() throws Exception {
+    public void testOfflineAuthCodeCalculation() throws Exception {
 
         final Context context = testHelper.getContext();
 
@@ -50,7 +50,7 @@ public class AuthenticationCodeTest extends BaseTest {
         // Possession + Knowledge factor
         PowerAuthAuthentication authentication = activationHelper.getValidAuthentication();
         for (int iteration = 0; iteration < 10; iteration++) {
-            final String testString = "OFFLINE signature test\n" + testHelper.getRandomGenerator().generateRandomString(10, 32);
+            final String testString = "OFFLINE AuthCode test\n" + testHelper.getRandomGenerator().generateRandomString(10, 32);
             final byte[] dataToSign = testString.getBytes(Charset.defaultCharset());
             final String nonce = testHelper.getRandomGenerator().generateBase64Bytes(16);
             final String offlineAuthCode = AsyncHelper.await((resultCatcher) -> {
@@ -68,11 +68,11 @@ public class AuthenticationCodeTest extends BaseTest {
             });
             assertNotNull(offlineAuthCode);
 
-            // Now verify signature on the server
-            final String dataToVerifySignature = authenticationHelper.normalizeOfflineData(dataToSign, "/offline/test", nonce);
+            // Now verify auth code on the server
+            final String normalizedData = authenticationHelper.normalizeOfflineData(dataToSign, "/offline/test", nonce);
             AuthenticationCodeData authenticationCodeData = new AuthenticationCodeData();
             authenticationCodeData.setActivationId(powerAuthSDK.getActivationIdentifier());
-            authenticationCodeData.setData(dataToVerifySignature);
+            authenticationCodeData.setData(normalizedData);
             authenticationCodeData.setAuthenticationCode(offlineAuthCode);
             authenticationCodeData.setAllowBiometry(false);
 
@@ -85,14 +85,14 @@ public class AuthenticationCodeTest extends BaseTest {
     }
 
     @Test
-    public void testCustomOfflineSignatureCalculation() throws Exception {
-        final int OFFLINE_SIGNATURE_LENGTH = 4;
+    public void testCustomOfflineAuthCodeCalculation() throws Exception {
+        final int OFFLINE_AUTH_CODE_LENGTH = 4;
         // Re-configure test helper
-        testHelper = new PowerAuthTestHelper.Builder()
+        reAssingTestHelper(new PowerAuthTestHelper.Builder()
                 .configurationObserver(new PowerAuthTestHelper.IConfigurationObserver() {
                     @Override
                     public void adjustPowerAuthConfiguration(@NonNull PowerAuthConfiguration.Builder builder) {
-                        builder.offlineAuthenticationCodeComponentLength(OFFLINE_SIGNATURE_LENGTH);
+                        builder.offlineAuthenticationCodeComponentLength(OFFLINE_AUTH_CODE_LENGTH);
                     }
 
                     @Override
@@ -107,11 +107,10 @@ public class AuthenticationCodeTest extends BaseTest {
                     public void adjustPowerAuthKeychainConfiguration(@NonNull PowerAuthKeychainConfiguration.Builder builder) {
                     }
                 })
-                .build();
-        powerAuthSDK = testHelper.getSharedSdk();
-        activationHelper = new ActivationHelper(testHelper);
+                .build()
+        );
 
-        // Create activation and test the signature calculation
+        // Create activation and test the auth code calculation
         activationHelper.createStandardActivation(true, null);
 
         final PowerAuthAuthentication authentication = PowerAuthAuthentication.possession();
@@ -131,40 +130,40 @@ public class AuthenticationCodeTest extends BaseTest {
             });
         });
         assertNotNull(authCode);
-        assertEquals(OFFLINE_SIGNATURE_LENGTH, authCode.length());
+        assertEquals(OFFLINE_AUTH_CODE_LENGTH, authCode.length());
     }
 
     @Test
-    public void testOnlineSignatureCalculation() throws Exception {
+    public void testOnlineAuthCodeCalculation() throws Exception {
         activationHelper.createStandardActivation(ActivationHelper.TF_PERSIST_WITH_FAKE_BIOMETRY, null);
 
         // Count is important, due to fact that we have 8-bit local counter since V3.1
         for (int iteration = 0; iteration < 264; iteration++) {
-            final String testString = "ONLINE signature test\n" + testHelper.getRandomGenerator().generateRandomString(10, 32);
+            final String testString = "ONLINE AuthCode test\n" + testHelper.getRandomGenerator().generateRandomString(10, 32);
 
             // Auth & expected result
             final PowerAuthAuthentication authentication;
-            final AuthCodeType expectedSignatureType;
+            final AuthCodeType expectedAuthCodeType;
             final boolean expectedValidationResult;
             switch (iteration % 4) {
                 case 0:
                     authentication = activationHelper.getValidAuthentication();
-                    expectedSignatureType = AuthCodeType.POSSESSION_KNOWLEDGE;
+                    expectedAuthCodeType = AuthCodeType.POSSESSION_KNOWLEDGE;
                     expectedValidationResult = true;
                     break;
                 case 1:
                     authentication = activationHelper.getPossessionAuthentication();
-                    expectedSignatureType = AuthCodeType.POSSESSION;
+                    expectedAuthCodeType = AuthCodeType.POSSESSION;
                     expectedValidationResult = true;
                     break;
                 case 2:
                     authentication = activationHelper.getBiometricAuthentication(null);
-                    expectedSignatureType = AuthCodeType.POSSESSION_BIOMETRY;
+                    expectedAuthCodeType = AuthCodeType.POSSESSION_BIOMETRY;
                     expectedValidationResult = true;
                     break;
                 default:
                     authentication = activationHelper.getInvalidAuthentication();
-                    expectedSignatureType = AuthCodeType.POSSESSION_KNOWLEDGE;
+                    expectedAuthCodeType = AuthCodeType.POSSESSION_KNOWLEDGE;
                     expectedValidationResult = false;
                     break;
             }
@@ -182,51 +181,19 @@ public class AuthenticationCodeTest extends BaseTest {
             // Method
             final String method = (iteration & 1) == 0 ? "POST" : "GET";
 
-            System.out.println("Iteration " + iteration + ": " + expectedSignatureType + ", " + method);
+            //System.out.println("Iteration " + iteration + ": " + expectedAuthCodeType + ", " + method);
 
             final byte[] dataToSign = testString.getBytes(Charset.defaultCharset());
-            final PowerAuthHttpHeader onlineSignature = powerAuthSDK.authenticationHeaderForRequestWithBody(authentication, method, uriId, dataToSign);
-            assertNotNull(onlineSignature);
-            assertEquals("X-PowerAuth-Authorization", onlineSignature.getKey());
-
-            // Parse header value
-            Map<String, String> sigComponents = authenticationHelper.parseAuthenticationHeader(onlineSignature);
-            final String acVersion = sigComponents.get("pa_version");
-            final String acActivationId = sigComponents.get("pa_activation_id");
-            final String acNonce = sigComponents.get("pa_nonce");
-            final String acAppKey = sigComponents.get("pa_application_key");
-            final String acType;
-            final String acValue;
-            if (getAlgorithmForTest() == PowerAuthAlgorithm.LEGACY_P256) {
-                acType = Objects.requireNonNull(sigComponents.get("pa_signature_type")).toUpperCase();
-                acValue = sigComponents.get("pa_signature");
-            } else {
-                acType = Objects.requireNonNull(sigComponents.get("pa_auth_code_type")).toUpperCase();
-                acValue = sigComponents.get("pa_auth_code");
-            }
-            assertEquals(testHelper.getProtocolVersionForHeader(), acVersion);
-            assertNotNull(acActivationId);
-            assertNotNull(acNonce);
-            assertNotNull(acAppKey);
-            assertNotNull(acType);
-            assertNotNull(acValue);
-
-            // Now verify signature on the server
-            final String dataToVerifySignature = authenticationHelper.normalizeOnlineData(dataToSign, method, uriId, acNonce);
-            AuthenticationCodeData authenticationCodeData = new AuthenticationCodeData();
-            authenticationCodeData.setActivationId(acActivationId);
-            authenticationCodeData.setData(dataToVerifySignature);
-            authenticationCodeData.setAuthenticationCode(acValue);
-            authenticationCodeData.setAuthenticationCodeType(AuthCodeType.valueOf(acType));
-            authenticationCodeData.setAuthenticationVersion(acVersion);
-            authenticationCodeData.setApplicationKey(acAppKey);
+            final PowerAuthHttpHeader onlineHeader = powerAuthSDK.authenticationHeaderForRequestWithBody(authentication, method, uriId, dataToSign);
+            assertNotNull(onlineHeader);
+            assertEquals("X-PowerAuth-Authorization", onlineHeader.getKey());
 
             // Verify on server
-            final AuthenticationResult verifyResult = testHelper.getServerApi().verifyOnlineAuthenticationCode(authenticationCodeData);
+            final AuthenticationResult verifyResult = authenticationHelper.verifyAuthenticationHeader(onlineHeader, dataToSign, uriId, method);
 
             assertNotNull(verifyResult);
             assertEquals(expectedValidationResult, verifyResult.isAuthenticationValid());
-            assertEquals(expectedSignatureType, verifyResult.getAuthenticationCodeType());
+            assertEquals(expectedAuthCodeType, verifyResult.getAuthenticationCodeType());
 
             if ((iteration & 0x3f) == 1) {
                 PowerAuthActivationStatus status = activationHelper.fetchActivationStatus();
@@ -267,7 +234,7 @@ public class AuthenticationCodeTest extends BaseTest {
         status = activationHelper.fetchActivationStatus();
         assertEquals(PowerAuthActivationState.ACTIVE, status.getState());
 
-        // Negative scenario, try to calculate too many signatures that server will never catch.
+        // Negative scenario, try to calculate too many auth code that server will never catch.
         for (int i = 0; i < CTR_LOOKAHEAD + 2; ++i) {
             // calculate header and do not use it
             powerAuthSDK.authenticationHeaderForRequestWithBody(auth, "POST", "/some/identifier", null);
@@ -289,9 +256,9 @@ public class AuthenticationCodeTest extends BaseTest {
         final String uriId = "/test/id";
         final String offlineNonce = "QVZlcnlDbGV2ZXJOb25jZQ==";
 
-        // Just calculate signature on the server.
-        // This is a little bit tricky, because we need to calculate a valid signature, to move server's counter forward. To do that,
-        // we have to calculate also a local signature, but that moves also local counter forward.
+        // Just calculate auth code on the server.
+        // This is a little bit tricky, because we need to calculate a valid auth code, to move server's counter forward. To do that,
+        // we have to calculate also a local auth code, but that moves also local counter forward.
         // To trick the system, we need to keep old persistent data and restore it later.
         byte[] previousState = powerAuthSDK.getCoreSession().getSerializedState();
         for (int i = 0; i < CTR_LOOKAHEAD/2; ++i) {
@@ -308,16 +275,15 @@ public class AuthenticationCodeTest extends BaseTest {
                     }
                 });
             });
-            String normalizedData = authenticationHelper.normalizeOfflineData(dataToAuth, uriId, offlineNonce);
-            // Now verify signature on the server
-            AuthenticationCodeData authenticationCodeData = new AuthenticationCodeData();
-            authenticationCodeData.setActivationId(powerAuthSDK.getActivationIdentifier());
-            authenticationCodeData.setData(normalizedData);
-            authenticationCodeData.setAuthenticationCode(localAuthCode);
-            authenticationCodeData.setAllowBiometry(false);
-
             // Verify on server
-            final AuthenticationResult verifyResult = testHelper.getServerApi().verifyOfflineAuthenticationCode(authenticationCodeData);
+            final AuthenticationResult verifyResult = authenticationHelper.verifyAuthenticationCode(
+                    localAuthCode,
+                    offlineNonce,
+                    dataToAuth,
+                    uriId,
+                    activationHelper.getActivation().getActivationId(),
+                    false,
+                    null);
             assertNotNull(verifyResult);
         }
         // Rollback counter to some previous state, to simulate state when the server's counter is ahead
@@ -342,16 +308,15 @@ public class AuthenticationCodeTest extends BaseTest {
                     }
                 });
             });
-            String normalizedData = authenticationHelper.normalizeOfflineData(dataToAuth, uriId, offlineNonce);
-            // Now verify signature on the server
-            AuthenticationCodeData authenticationCodeData = new AuthenticationCodeData();
-            authenticationCodeData.setActivationId(powerAuthSDK.getActivationIdentifier());
-            authenticationCodeData.setData(normalizedData);
-            authenticationCodeData.setAuthenticationCode(localAuthCode);
-            authenticationCodeData.setAllowBiometry(false);
-
             // Verify on server
-            final AuthenticationResult verifyResult = testHelper.getServerApi().verifyOfflineAuthenticationCode(authenticationCodeData);
+            final AuthenticationResult verifyResult = authenticationHelper.verifyAuthenticationCode(
+                    localAuthCode,
+                    offlineNonce,
+                    dataToAuth,
+                    uriId,
+                    activationHelper.getActivation().getActivationId(),
+                    false,
+                    null);
             assertNotNull(verifyResult);
         }
         // Rollback counter to some previous state, to simulate state when the server's counter is ahead

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/AuthenticationCodeTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/AuthenticationCodeTest.java
@@ -28,8 +28,6 @@ import org.junit.Test;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.Map;
-import java.util.Objects;
 
 import io.getlime.security.powerauth.integration.support.PowerAuthTestHelper;
 import io.getlime.security.powerauth.integration.support.model.AuthenticationCodeData;
@@ -88,7 +86,7 @@ public class AuthenticationCodeTest extends BaseTest {
     public void testCustomOfflineAuthCodeCalculation() throws Exception {
         final int OFFLINE_AUTH_CODE_LENGTH = 4;
         // Re-configure test helper
-        reAssingTestHelper(new PowerAuthTestHelper.Builder()
+        reAssignTestHelper(new PowerAuthTestHelper.Builder()
                 .configurationObserver(new PowerAuthTestHelper.IConfigurationObserver() {
                     @Override
                     public void adjustPowerAuthConfiguration(@NonNull PowerAuthConfiguration.Builder builder) {

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/AuthenticationHelper.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/AuthenticationHelper.java
@@ -17,19 +17,40 @@
 package io.getlime.security.powerauth.integration.tests;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import android.text.TextUtils;
 import android.util.Base64;
 
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
+import io.getlime.security.powerauth.integration.support.AsyncHelper;
+import io.getlime.security.powerauth.integration.support.PowerAuthTestHelper;
+import io.getlime.security.powerauth.integration.support.model.AuthCodeType;
+import io.getlime.security.powerauth.integration.support.model.AuthenticationCodeData;
+import io.getlime.security.powerauth.integration.support.model.AuthenticationResult;
+import io.getlime.security.powerauth.sdk.PowerAuthAlgorithm;
+import io.getlime.security.powerauth.sdk.PowerAuthAuthentication;
 import io.getlime.security.powerauth.sdk.PowerAuthHttpHeader;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class AuthenticationHelper {
+
+    @NonNull
+    final PowerAuthTestHelper testHelper;
+
+    /**
+     * Create helper with test helper object.
+     * @param helper {@link PowerAuthTestHelper} instance.
+     */
+    public AuthenticationHelper(@NonNull PowerAuthTestHelper helper) {
+        testHelper = helper;
+    }
 
     /**
      * Normalize data for online signature verification.
@@ -39,7 +60,7 @@ public class AuthenticationHelper {
      * @param nonce Random nonce.
      * @return Normalized string.
      */
-    public @NonNull String normalizeOnlineData(@NonNull byte[] body, @NonNull String method, @NonNull String uriId, @NonNull String nonce) {
+    public @NonNull String normalizeOnlineData(@Nullable byte[] body, @NonNull String method, @NonNull String uriId, @NonNull String nonce) {
         return normalizeImpl(body, method, uriId, nonce);
     }
 
@@ -50,19 +71,7 @@ public class AuthenticationHelper {
      * @param nonce Random nonce.
      * @return Normalized string.
      */
-    public @NonNull String normalizeOfflineData(@NonNull byte[] body, @NonNull String uriId, @NonNull String nonce) {
-        return normalizeImpl(body, "POST", uriId, nonce);
-    }
-
-    /**
-     * Normalize data for offline signature verification.
-     * @param bodyBase64 Request body in Base64 format
-     * @param uriId URI identifier.
-     * @param nonce Random nonce.
-     * @return Normalized string.
-     */
-    public @NonNull String normalizeOfflineData(@NonNull String bodyBase64, @NonNull String uriId, @NonNull String nonce) {
-        byte[] body = Base64.decode(bodyBase64, Base64.NO_WRAP);
+    public @NonNull String normalizeOfflineData(@Nullable byte[] body, @NonNull String uriId, @NonNull String nonce) {
         return normalizeImpl(body, "POST", uriId, nonce);
     }
 
@@ -74,7 +83,10 @@ public class AuthenticationHelper {
      * @param nonce Random nonce.
      * @return Normalized string.
      */
-    private @NonNull String normalizeImpl(@NonNull byte[] body, @NonNull String method, @NonNull String uriId, @NonNull String nonce) {
+    private @NonNull String normalizeImpl(@Nullable byte[] body, @NonNull String method, @NonNull String uriId, @NonNull String nonce) {
+        if (body == null) {
+            body = new byte[0];
+        }
         String uriIdB64 = Base64.encodeToString(uriId.getBytes(Charset.defaultCharset()), Base64.NO_WRAP);
         String bodyB64 = Base64.encodeToString(body, Base64.NO_WRAP);
         return method + "&" + uriIdB64 + "&" + nonce + "&" + bodyB64;
@@ -104,5 +116,87 @@ public class AuthenticationHelper {
             components.put(componentKey, componentValue);
         }
         return components;
+    }
+
+    /**
+     * Verify authentication header on the server.
+     * @param header Authentication header.
+     * @param body Request body.
+     * @param uriId URI identifier.
+     * @param method HTTP method (e.g. POST, GET, ...)
+     * @return {@link AuthenticationResult} object.
+     * @throws Exception In case of failure.
+     */
+    public AuthenticationResult verifyAuthenticationHeader(@NonNull PowerAuthHttpHeader header,
+                                                           @Nullable byte[] body,
+                                                           @NonNull String uriId,
+                                                           @NonNull String method) throws Exception {
+        // Parse header
+        Map<String, String> headerData = parseAuthenticationHeader(header);
+        // Extract variables
+        final String acVersion = headerData.get("pa_version");
+        final String acActivationId = headerData.get("pa_activation_id");
+        final String acNonce = headerData.get("pa_nonce");
+        final String acAppKey = headerData.get("pa_application_key");
+        final String acType;
+        final String acValue;
+        assertNotNull(acVersion);
+        if (PowerAuthTestHelper.PA_VERSION3_HEADER.equals(acVersion)) {
+            acType = Objects.requireNonNull(headerData.get("pa_signature_type")).toUpperCase();
+            acValue = headerData.get("pa_signature");
+        } else if (PowerAuthTestHelper.PA_VERSION4_HEADER.equals(acVersion)) {
+            acType = Objects.requireNonNull(headerData.get("pa_auth_code_type")).toUpperCase();
+            acValue = headerData.get("pa_auth_code");
+        } else {
+            throw new Exception("Unsupported protocol version " + acVersion);
+        }
+        assertNotNull(acActivationId);
+        assertNotNull(acNonce);
+        assertNotNull(acAppKey);
+        assertNotNull(acType);
+        assertNotNull(acValue);
+
+        // Now verify signature on the server
+        final String dataToVerifySignature = normalizeOnlineData(body, method, uriId, acNonce);
+        AuthenticationCodeData authenticationCodeData = new AuthenticationCodeData();
+        authenticationCodeData.setActivationId(acActivationId);
+        authenticationCodeData.setData(dataToVerifySignature);
+        authenticationCodeData.setAuthenticationCode(acValue);
+        authenticationCodeData.setAuthenticationCodeType(AuthCodeType.valueOf(acType));
+        authenticationCodeData.setAuthenticationVersion(acVersion);
+        authenticationCodeData.setApplicationKey(acAppKey);
+
+        // Verify on server
+        return testHelper.getServerApi().verifyOnlineAuthenticationCode(authenticationCodeData);
+    }
+
+    /**
+     * Verify offline authentication code.
+     * @param authenticationCode Authentication code.
+     * @param offlineNonce Offline nonce.
+     * @param body Authenticated data.
+     * @param uriId URI identifier.
+     * @param activationId Activation identifier.
+     * @param allowBiometry If true, then authentication with biometry is allowed.
+     * @param authComponentLength Optional authentication code component length.
+     * @return {@link AuthenticationResult} object.
+     * @throws Exception In case of failure.
+     */
+    public AuthenticationResult verifyAuthenticationCode(@NonNull String authenticationCode,
+                                                         @NonNull String offlineNonce,
+                                                         @Nullable byte[] body,
+                                                         @NonNull String uriId,
+                                                         @NonNull String activationId,
+                                                         boolean allowBiometry,
+                                                         Long authComponentLength) throws Exception {
+        final String dataToVerifySignature = normalizeOfflineData(body, uriId, offlineNonce);
+        AuthenticationCodeData authenticationCodeData = new AuthenticationCodeData();
+        authenticationCodeData.setActivationId(activationId);
+        authenticationCodeData.setData(dataToVerifySignature);
+        authenticationCodeData.setAuthenticationCode(authenticationCode);
+        authenticationCodeData.setAllowBiometry(allowBiometry);
+        authenticationCodeData.setOfflineAuthenticationCodeComponentLength(authComponentLength);
+
+        return testHelper.getServerApi().verifyOfflineAuthenticationCode(authenticationCodeData);
     }
 }

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BaseSdkTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BaseSdkTest.java
@@ -40,12 +40,7 @@ import io.getlime.security.powerauth.system.PowerAuthSystem;
 
 import static org.junit.Assert.*;
 
-public class BaseSdkTest extends BaseTest{
-
-    @Test
-    public void configurationSelfTest() {
-        assertEquals(getAlgorithmForTest(), getCurrentAlgorithm());
-    }
+public class BaseSdkTest extends BaseTest {
 
     @PowerAuthAlgorithm
     public int getCurrentAlgorithm() {

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BaseSdkTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BaseSdkTest.java
@@ -24,11 +24,7 @@ import io.getlime.security.powerauth.sdk.PowerAuthActivationState;
 import io.getlime.security.powerauth.sdk.PowerAuthActivationStatus;
 import io.getlime.security.powerauth.sdk.PowerAuthAlgorithm;
 import io.getlime.security.powerauth.networking.response.*;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -36,52 +32,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 import io.getlime.security.powerauth.exception.PowerAuthErrorCodes;
 import io.getlime.security.powerauth.exception.PowerAuthErrorException;
 import io.getlime.security.powerauth.integration.support.AsyncHelper;
-import io.getlime.security.powerauth.integration.support.PowerAuthTestHelper;
 import io.getlime.security.powerauth.integration.support.model.Activation;
 import io.getlime.security.powerauth.integration.support.model.ActivationDetail;
 import io.getlime.security.powerauth.networking.interfaces.ICancelable;
 import io.getlime.security.powerauth.sdk.PowerAuthActivation;
-import io.getlime.security.powerauth.sdk.PowerAuthSDK;
-import io.getlime.security.powerauth.system.PowerAuthLog;
 import io.getlime.security.powerauth.system.PowerAuthSystem;
 
 import static org.junit.Assert.*;
 
-@RunWith(Parameterized.class)
-public class BaseSdkTest {
-
-    @Parameterized.Parameter(0) public String alg;
-    @Parameterized.Parameters(name = " {0} ")
-    public static Iterable<Object[]> testParameters() {
-        return TestParameters.getParameters();
-    }
-
-    @PowerAuthAlgorithm
-    public int getAlgorithmForTest() {
-        return PowerAuthTestHelper.getAlgorithmForName(alg);
-    }
-
-    private PowerAuthTestHelper testHelper;
-    private PowerAuthSDK powerAuthSDK;
-    private ActivationHelper activationHelper;
-
-    @Before
-    public void setUp() throws Exception {
-        PowerAuthLog.setEnabled(true);
-        PowerAuthLog.setVerbose(true);
-        testHelper = new PowerAuthTestHelper.Builder()
-                .powerAuthAlgorithm(getAlgorithmForTest())
-                .build();
-        powerAuthSDK = testHelper.getSharedSdk();
-        activationHelper = new ActivationHelper(testHelper);
-    }
-
-    @After
-    public void tearDown() {
-        if (activationHelper != null) {
-            activationHelper.cleanupAfterTest();
-        }
-    }
+public class BaseSdkTest extends BaseTest{
 
     @Test
     public void configurationSelfTest() {

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BaseTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BaseTest.java
@@ -23,6 +23,7 @@ import androidx.annotation.NonNull;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -36,7 +37,7 @@ import io.getlime.security.powerauth.system.PowerAuthLog;
  * Base class for parameterized PowerAuth integration and unit tests.
  */
 @RunWith(Parameterized.class)
-class BaseTest {
+public abstract class BaseTest {
 
     @Parameterized.Parameter(0) public String alg;
     @Parameterized.Parameters(name = " {0} ")
@@ -85,7 +86,7 @@ class BaseTest {
      * this new instance.
      * @param newHelper New instance of test helper.
      */
-    public void reAssingTestHelper(@NonNull PowerAuthTestHelper newHelper) {
+    public void reAssignTestHelper(@NonNull PowerAuthTestHelper newHelper) {
         testHelper = newHelper;
         powerAuthSDK = testHelper.getSharedSdk();
         activationHelper = new ActivationHelper(testHelper);

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BaseTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BaseTest.java
@@ -19,6 +19,8 @@ package io.getlime.security.powerauth.integration.tests;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import androidx.annotation.NonNull;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -61,7 +63,7 @@ class BaseTest {
                 .build();
         powerAuthSDK = testHelper.getSharedSdk();
         activationHelper = new ActivationHelper(testHelper);
-        authenticationHelper = new AuthenticationHelper();
+        authenticationHelper = new AuthenticationHelper(testHelper);
         assertEquals(getAlgorithmForTest(), getCurrentAlgorithm());
         if (isRequestFailureSimulatorAvailable()) {
             clearAllSimulateFailures();
@@ -76,6 +78,18 @@ class BaseTest {
         if (isRequestFailureSimulatorAvailable()) {
             clearAllSimulateFailures();
         }
+    }
+
+    /**
+     * Keep new instance {@link PowerAuthTestHelper} and create all supporting objects, with using
+     * this new instance.
+     * @param newHelper New instance of test helper.
+     */
+    public void reAssingTestHelper(@NonNull PowerAuthTestHelper newHelper) {
+        testHelper = newHelper;
+        powerAuthSDK = testHelper.getSharedSdk();
+        activationHelper = new ActivationHelper(testHelper);
+        authenticationHelper = new AuthenticationHelper(testHelper);
     }
 
     @PowerAuthAlgorithm

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BaseTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BaseTest.java
@@ -81,7 +81,7 @@ class BaseTest {
     }
 
     /**
-     * Keep new instance {@link PowerAuthTestHelper} and create all supporting objects, with using
+     * Keep new instance of {@link PowerAuthTestHelper} and create all supporting objects, with using
      * this new instance.
      * @param newHelper New instance of test helper.
      */

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/DsaSignatureTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/DsaSignatureTest.java
@@ -16,7 +16,6 @@
 
 package io.getlime.security.powerauth.integration.tests;
 
-import androidx.annotation.BoolRes;
 import androidx.annotation.NonNull;
 import android.text.TextUtils;
 import android.util.Base64;
@@ -24,21 +23,15 @@ import android.util.Base64;
 import io.getlime.security.powerauth.exception.PowerAuthErrorCodes;
 import io.getlime.security.powerauth.exception.PowerAuthErrorException;
 import io.getlime.security.powerauth.integration.support.model.Activation;
-import io.getlime.security.powerauth.integration.support.model.ActivationDetail;
 import io.getlime.security.powerauth.integration.support.model.AuthenticationCodeData;
 import io.getlime.security.powerauth.integration.support.model.AuthenticationResult;
 import io.getlime.security.powerauth.integration.support.model.SignatureFormat;
 import io.getlime.security.powerauth.integration.support.model.SignatureType;
 import io.getlime.security.powerauth.networking.interfaces.ICancelable;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.security.KeyException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -46,7 +39,6 @@ import java.util.Map;
 import java.util.Objects;
 
 import io.getlime.security.powerauth.integration.support.AsyncHelper;
-import io.getlime.security.powerauth.integration.support.PowerAuthTestHelper;
 import io.getlime.security.powerauth.integration.support.model.OfflineSignaturePayload;
 import io.getlime.security.powerauth.networking.response.IDataSignatureListener;
 import io.getlime.security.powerauth.networking.response.IDigitalSignatureListener;
@@ -57,7 +49,6 @@ import io.getlime.security.powerauth.sdk.PowerAuthAlgorithm;
 import io.getlime.security.powerauth.sdk.PowerAuthAuthentication;
 import io.getlime.security.powerauth.sdk.PowerAuthDevicePublicKeyData;
 import io.getlime.security.powerauth.sdk.PowerAuthDevicePublicKeyFormat;
-import io.getlime.security.powerauth.sdk.PowerAuthSDK;
 import io.getlime.security.powerauth.sdk.PowerAuthSignatureKeyId;
 import io.getlime.security.powerauth.sdk.PowerAuthSignatureKeyType;
 import io.getlime.security.powerauth.sdk.impl.JsonSerialization;
@@ -66,41 +57,7 @@ import static org.junit.Assert.*;
 
 import com.google.gson.reflect.TypeToken;
 
-@RunWith(Parameterized.class)
-public class DsaSignatureTest {
-
-    @Parameterized.Parameter(0) public String alg;
-    @Parameterized.Parameters(name = " {0} ")
-    public static Iterable<Object[]> testParameters() {
-        return TestParameters.getParameters();
-    }
-
-    @PowerAuthAlgorithm
-    public int getAlgorithmForTest() {
-        return PowerAuthTestHelper.getAlgorithmForName(alg);
-    }
-
-    private PowerAuthTestHelper testHelper;
-    private PowerAuthSDK powerAuthSDK;
-    private ActivationHelper activationHelper;
-    private AuthenticationHelper authenticationHelper;
-
-    @Before
-    public void setUp() throws Exception {
-        testHelper = new PowerAuthTestHelper.Builder()
-                .powerAuthAlgorithm(getAlgorithmForTest())
-                .build();
-        powerAuthSDK = testHelper.getSharedSdk();
-        activationHelper = new ActivationHelper(testHelper);
-        authenticationHelper = new AuthenticationHelper();
-    }
-
-    @After
-    public void tearDown() {
-        if (activationHelper != null) {
-            activationHelper.cleanupAfterTest();
-        }
-    }
+public class DsaSignatureTest extends BaseTest {
 
     @Test
     public void testExportDevicePublicKey() throws Exception {
@@ -312,7 +269,7 @@ public class DsaSignatureTest {
         }
         // Well, we have a data for offline signature, so let's try to verify it.
         String uriId = "/operation/authorize/offline";
-        byte[] body = payload.getParsedData().getBytes(StandardCharsets.UTF_8);
+        byte[] body = payload.getParsedDataBytes();
         String nonce = payload.getParsedNonce();
         String offlineAuthCode = AsyncHelper.await(resultCatcher -> {
             powerAuthSDK.offlineAuthenticationCode(testHelper.getContext(), authentication, uriId, body, nonce, new IOfflineAuthenticationCodeListener() {
@@ -327,13 +284,15 @@ public class DsaSignatureTest {
                 }
             });
         });
-        String normalizedData = authenticationHelper.normalizeOfflineData(payload.getParsedData(), uriId, nonce);
-        AuthenticationCodeData authenticationCodeData = new AuthenticationCodeData();
-        authenticationCodeData.setActivationId(powerAuthSDK.getActivationIdentifier());
-        authenticationCodeData.setData(normalizedData);
-        authenticationCodeData.setAuthenticationCode(offlineAuthCode);
-        authenticationCodeData.setAllowBiometry(false);
-        AuthenticationResult authenticationResult = testHelper.getServerApi().verifyOfflineAuthenticationCode(authenticationCodeData);
+        AuthenticationResult authenticationResult = authenticationHelper.verifyAuthenticationCode(
+                offlineAuthCode,
+                nonce,
+                payload.getParsedDataBytes(),
+                uriId,
+                activationHelper.getActivation().getActivationId(),
+                false,
+                null
+        );
         assertTrue(authenticationResult.isAuthenticationValid());
     }
 


### PR DESCRIPTION
- `AuthenticationHelper` now supports header and code verification
- `BaseSdkTest`, `DsaSignatureTest` and `AuthenticationCodeTest` now extends `BaseTest`
- Get rid of "signature" terminology from authentication code tests