### PR TITLE
Discontinue usage of EEK

### DIFF
--- a/docs/Migration-from-1.9-to-2.0.md
+++ b/docs/Migration-from-1.9-to-2.0.md
@@ -107,10 +107,6 @@ Notable changes on Android:
 - The following functions now takes or returns `SecureData` instead of `byte[]`:
   - `PowerAuthSDK.persistActivationWithPassword()`
   - `PowerAuthSDK.addBiometryFactor()`
-  - `PowerAuthSDK.setExternalEncryptionKey()`
-  - `PowerAuthSDK.addExternalEncryptionKey()`
-  - `PowerAuthConfiguration.getExternalEncryptionKey()`
-  - `PowerAuthConfiguration.Builder.externalEncryptionKey()`
   - `PowerAuthAuthentication.getBiometryFactorRelatedKey()`
   - `PowerAuthAuthentication.getOverriddenPossessionKey()`
   - All static functions in `PowerAuthAuthentication` that takes custom possession or biometry key in parameter.
@@ -118,6 +114,13 @@ Notable changes on Android:
   - `CryptoUtils.ecdhComputeSharedSecret()`
   - `BiometricKeyData.getDerivedData()`
   - `BiometricKeyData.getDataToSave()`
+
+- Due to discontinued support for "External Encryption Key" feature, the following methods has been changed:
+  - `PowerAuthSDK.setExternalEncryptionKey()` method has been removed.
+  - `PowerAuthSDK.addExternalEncryptionKey()` method has been removed.
+  - `PowerAuthSDK.removeExternalEncryptionKey()` method now takes EEK as parameter and allows you to remove the key from the activation.
+  - `PowerAuthConfiguration.Builder.externalEncryptionKey()` property is deprecated and no longer used in SDK.
+  - Check [External Encryption Key](PowerAuth-SDK-for-Android.md#external-encryption-key) documentation for the migration.
 
 - Due to removed support of recovery codes, the following classes and methods are no longer available:
   - Methods removed in `PowerAuthSDK`:
@@ -199,10 +202,7 @@ Notable changes on iOS:
   - `PowerAuthCoreEciesMetaData` is removed. You can get the encryption header in more straightforward way. Check the updated E2EE documentation for more details.
 
 - The following functions or properties now takes or returns `PowerAuthCoreData` instead of `Data`:
-  - `PowerAuthSDK.setExternalEncryptionKey()`
-  - `PowerAuthSDK.addExternalEncryptionKey()`
   - `PowerAuthSDK.fetchEncryptionKey()`
-  - `PowerAuthConfiguration.externalEncryptionKey`
   - All static functions in `PowerAuthAuthentication` that takes custom possession or biometry key in parameter.
   - `PowerAuthAuthentication.overridenPossessionKey` property is now `customPossessionKey`
   - `PowerAuthAuthentication.overridenBiometryKey` property is now `customBiometryKey`
@@ -211,6 +211,13 @@ Notable changes on iOS:
 - The following methods in `PowerAuthSDK` class now returns cancelable object allowing you to cancel the pending biometric authentication:
   - `authenticateUsingBiometry(withPrompt:callback:)`
   - `authenticateUsingBiometry(withContext:callback:)`
+
+- Due to discontinued support for "External Encryption Key" feature, the following methods has been changed:
+  - `PowerAuthSDK.setExternalEncryptionKey()` method has been removed.
+  - `PowerAuthSDK.addExternalEncryptionKey()` method has been removed.
+  - `PowerAuthSDK.removeExternalEncryptionKey()` method now takes EEK as parameter and allows you to remove the key from the activation.
+  - `PowerAuthConfiguration.externalEncryptionKey` property is deprecated and no longer used in SDK.
+  - Check [External Encryption Key](PowerAuth-SDK-for-iOS.md#external-encryption-key) documentation for the migration.
 
 - Due to removed support of recovery codes, the following classes and methods are no longer available:
   - Methods removed in `PowerAuthSDK`:

--- a/docs/PowerAuth-SDK-for-Android.md
+++ b/docs/PowerAuth-SDK-for-Android.md
@@ -129,8 +129,6 @@ The `PowerAuthConfiguration.Builder` class provides the following additional met
 
 - `algorithm()` - Alters [algorithm](#algorithms-for-communication) used for the communication with the PowerAuth Server.
 - `offlineAuthenticationCodeComponentLength()` - Alters the default component length for the [offline authentication code](#symmetric-offline-multi-factor-authentication-code). The values between 4 and 8 are allowed. The default value is 8.
-- `externalEncryptionKey()` - See [External Encryption Key](#external-encryption-key) chapter for more details.
-- `disableAutomaticProtocolUpgrade()` - Disables the automatic protocol upgrade. This option should be used only for debugging purposes.
 
 ### Biometric configuration
 
@@ -1262,7 +1260,7 @@ You can use our [Passphrase meter](https://github.com/wultra/passphrase-meter) l
 
 ## Working with sensitive data
 
-The PowerAuth mobile SDK is using `SecureData` class for manage the cryptographically sensitive data, such as encryption keys. You can encounter this class in several public API functions, such as functions for managing an [external encryption key](#external-encryption-key). This chapter explains how to use the `SecureData` object properly.
+The PowerAuth mobile SDK is using `SecureData` class for manage the cryptographically sensitive data, such as encryption keys. You can encounter this class in several public API functions, such as functions for [Secure Vault](#secure-vault). This chapter explains how to use the `SecureData` object properly.
 
 ### Create instance of `SecureData`
 
@@ -1914,25 +1912,20 @@ Note that by removing tokens locally, you will lose control of the tokens stored
 
 ## External Encryption Key
 
-The `PowerAuthSDK` allows you to specify an external encryption key (called EEK in our terminology) that can additionally protect the knowledge and the biometry factor keys. This feature is typically used to create a chain of activations where one instance of `PowerAuthSDK` is primary and unlocks access to all secondary activations.
+<!-- begin box warning -->
+Support for the External Encryption Key (EEK) was discontinued in PowerAuth Mobile SDK version 2.0.
+<!-- end -->
 
-The external encryption key has to be set before the activation is created, or can be added later. The internal state of `PowerAuthSDK` contains information that the factor keys are protected with EEK, so EEK must be known at the time of PowerAuth authentication code is calculated. You have three options on how to configure the key:
+In earlier SDK versions, `PowerAuthSDK` allowed you to specify an external encryption key (EEK) to provide an additional layer of protection for the knowledge and biometry factor keys. This mechanism was primarily used to create a chain of activations, where one primary `PowerAuthSDK` instance unlocked access to one or more secondary activations.
 
-1. Assign EEK into `PowerAuthConfiguration.Builder` at the time of `PowerAuthSDK` object creation.
-   - This is the most convenient way of using EEK, but the key must be known at the time of the `PowerAuthSDK` instantiation.
-   - Once the `PowerAuthSDK` instance creates a new activation, then the factor keys will be automatically protected with EEK.
-   
-2. Use `PowerAuthSDK.setExternalEncryptionKey()` to set EEK after the `PowerAuthSDK` instance is created.
-   - This is useful in case EEK is not known during the `PowerAuthSDK` instance creation.
-   - You can set the key in any `PowerAuthSDK` state, but be aware that the method will fail in case the instance has a valid activation that doesn't use EEK.
-   - It's safe to set the same EEK multiple times.
+If the activation in your application is still using EEK, please use the following code at your application’s startup to remove it:
 
-3. Use `PowerAuthSDK.addExternalEncryptionKey()` to add EEK and protect the factor keys in case `PowerAuthSDK` has already a valid activation.
-   - This method is useful in case `PowerAuthSDK` already has a valid activation, but it doesn't use EEK yet.
-   - The method automatically adds EEK into the internal configuration structure, but be aware, that all future `PowerAuthSDK` usages (e.g. after app restart) require setting EEK by configuration, or by the `setExternalEncryptionKey()` method.
-
-You can remove EEK from an existing activation if the key is no longer required. To do this, use the `PowerAuthSDK.removeExternalEncryptionKey()` method. Be aware, that EEK must be set by configuration, or by the `setExternalEncryptionKey()` method before you call the remove method. You can also use the `PowerAuthSDK.hasExternalEncryptionKey()` function to test whether the key is already set and in use.
-
+```kotlin
+if (powerAuthSDK.hasExternalEncryptionKey()) {
+    val eek = SecureData(eekBytes)
+    powerAuthSDK.removeExternalEncryptionKey(eek)
+}
+```
 
 ## Synchronized Time
 

--- a/docs/PowerAuth-SDK-for-iOS.md
+++ b/docs/PowerAuth-SDK-for-iOS.md
@@ -144,7 +144,6 @@ The `PowerAuthConfiguration` has the following additional properties:
 
 - `algorithm` - Alters [algorithm](#algorithms-for-communication) used for the communication with the PowerAuth Server.
 - `offlineAuthenticationCodeComponentLength` - Alters the default component length for the [offline authentication code](#symmetric-offline-multi-factor-authentication-code). The values between 4 and 8 are allowed. The default value is 8.
-- `externalEncryptionKey` - See [External Encryption Key](#external-encryption-key) chapter for more details.
 - `keychainKey_Biometry` - Specifies the 'key' used to store the `PowerAuthSDK` instance’s biometry-related key in the biometry keychain. If not set, the `instanceId` is applied. Do not alter this configuration unless you have a valid reason to do so.
 
 ### Biometric configuration
@@ -1105,7 +1104,7 @@ You can use our [Passphrase meter](https://github.com/wultra/passphrase-meter) l
 
 ## Working with sensitive data
 
-The PowerAuth mobile SDK is using `PowerAuthCoreData` object for manage the cryptographically sensitive data, such as encryption keys. You can encounter this object in several public API functions, such as functions for managing an [external encryption key](#external-encryption-key). This chapter explains how to use the `PowerAuthCoreData` object properly.
+The PowerAuth mobile SDK is using `PowerAuthCoreData` object for manage the cryptographically sensitive data, such as encryption keys. You can encounter this object in several public API functions, such as functions for [Secure Vault](#secure-vault). This chapter explains how to use the `PowerAuthCoreData` object properly.
 
 ### Create instance of `PowerAuthCoreData`
 
@@ -1974,25 +1973,20 @@ if let token = tokenStore.localToken(withName: "MyToken") {
 
 ## External Encryption Key
 
-The `PowerAuthSDK` allows you to specify an external encryption key (called EEK in our terminology) that can additionally protect the knowledge and the biometry factor keys. This feature is typically used to create a chain of activations where one instance of `PowerAuthSDK` is primary and unlocks access to all secondary activations.
+<!-- begin box warning -->
+Support for the External Encryption Key (EEK) was discontinued in PowerAuth Mobile SDK version 2.0.
+<!-- end -->
 
-The external encryption key has to be set before the activation is created, or can be added later. The internal state of `PowerAuthSDK` contains information that the factor keys are protected with EEK, so EEK must be known at the time of PowerAuth authentication code is calculated. You have three options on how to configure the key:
+In earlier SDK versions, `PowerAuthSDK` allowed you to specify an external encryption key (EEK) to provide an additional layer of protection for the knowledge and biometry factor keys. This mechanism was primarily used to create a chain of activations, where one primary `PowerAuthSDK` instance unlocked access to one or more secondary activations.
 
-1. Assign EEK into `externalEncryptionKey` property of `PowerAuthConfiguration` at the time of `PowerAuthSDK` object creation.
-   - This is the most convenient way of using EEK, but the key must be known at the time of the `PowerAuthSDK` instantiation.
-   - Once the `PowerAuthSDK` instance creates a new activation, then the factor keys will be automatically protected with EEK.
-   
-2. Use `PowerAuthSDK.setExternalEncryptionKey()` to set EEK after the `PowerAuthSDK` instance is created.
-   - This is useful in case EEK is not known during the `PowerAuthSDK` instance creation.
-   - You can set the key in any `PowerAuthSDK` state, but be aware that the method will fail in case the instance has a valid activation that doesn't use EEK.
-   - It's safe to set the same EEK multiple times.
+If the activation in your application is still using EEK, please use the following code at your application’s startup to remove it:
 
-3. Use `PowerAuthSDK.addExternalEncryptionKey()` to add EEK and protect the factor keys in case `PowerAuthSDK` has already a valid activation.
-   - This method is useful in case `PowerAuthSDK` already has a valid activation, but it doesn't use EEK yet.
-   - The method automatically adds EEK into the internal configuration structure, but be aware, that all future `PowerAuthSDK` usages (e.g. after app restart) require setting EEK by configuration, or by the `setExternalEncryptionKey()` method.
-
-You can remove EEK from an existing activation if the key is no longer required. To do this, use the `PowerAuthSDK.removeExternalEncryptionKey()` method. Be aware, that EEK must be set by configuration, or by the `setExternalEncryptionKey()` method before you call the remove method. You can also use the `PowerAuthSDK.hasExternalEncryptionKey` property to test whether the key is already set and in use.
-
+```swift
+if powerAuthSDK.hasExternalEncryptionKey {
+    let eek = PowerAuthCoreData(withData: eekBytes)
+    try powerAuthSDK.removeExternalEncryptionKey(eek)
+}
+```
 
 ## Share Activation Data
 
@@ -2177,7 +2171,7 @@ In other cases, you receive an error via an exception, like in this example:
 
 ```swift
 do {
-    try powerAuthSDK.removeExternalEncryptionKey()
+    let header = try powerAuthSDK.authenticationHeaderForRequestWithBody(with: auth, method: "POST", uriId: "/payment/create", body: requestBodyData)
 } catch let error as NSError {
     // Handle 'error' here
 }

--- a/include/PowerAuth/Session.h
+++ b/include/PowerAuth/Session.h
@@ -404,6 +404,30 @@ public:
                            const std::string& data_type,
                            SignatureKeyId key_to_use,
                            bool use_compact_form) const;
+    
+public:
+    // --------------------------------------------------------------------------------------------
+    // External Encryption Key (EEK)
+    //
+    // This feature has been discontinued in SDK 2.0, so the following functions provides just a
+    // minimum functionality required for the feature removal.
+    // --------------------------------------------------------------------------------------------
+    
+    /// Get information whether EEK is still present in V3 persistent data.
+    /// - Returns: `true` if V3 persistent data still contains factor keys protected with EEK.
+    bool hasExternalEncryptionKey() const noexcept;
+    
+    /// Remove EEK if factor keys are still protected with EEK. The method throws an exception
+    /// if activation is not present, or if factor keys are not protected with EEK.
+    ///
+    /// - Parameter eek: EEK previously used for the factor keys protection.
+    void removeExternalEncryptionKey(const cc7::ByteRange& eek);
+    
+    /// Add external encryption key for testing purposes. The method should not be used in the
+    /// release build. The legacy activation must be present and the size of EEK must match the size
+    /// of factor keys used in V3.3 protocol version (e.g. 16 bytes).
+    /// - Parameter eek: EEK to apply.
+    void addExternalEncryptionKeyForTest(const cc7::ByteRange& eek);
 
 public:
     // --------------------------------------------------------------------------------------------

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/ActivationHelper.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/ActivationHelper.java
@@ -573,24 +573,26 @@ public class ActivationHelper {
      * @throws Exception In case of other failure.
      */
     public boolean validateUserPassword(@NonNull final Password password) throws Exception {
-        return AsyncHelper.await(resultCatcher -> powerAuthSDK.validatePassword(testHelper.getContext(), password, new IValidatePasswordListener() {
-            @Override
-            public void onPasswordValid() {
-                resultCatcher.completeWithResult(true);
-            }
-
-            @Override
-            public void onPasswordValidationFailed(@NonNull Throwable t) {
-                if (t instanceof ErrorResponseApiException) {
-                    final ErrorResponseApiException apiException = (ErrorResponseApiException)t;
-                    if (apiException.getResponseCode() == 401) {
-                        resultCatcher.completeWithResult(false);
-                        return;
-                    }
+        return AsyncHelper.await(resultCatcher -> {
+            powerAuthSDK.validatePassword(testHelper.getContext(), password, new IValidatePasswordListener() {
+                @Override
+                public void onPasswordValid() {
+                    resultCatcher.completeWithResult(true);
                 }
-                resultCatcher.completeWithError(t);
-            }
-        }));
+
+                @Override
+                public void onPasswordValidationFailed(@NonNull Throwable t) {
+                    if (t instanceof ErrorResponseApiException) {
+                        final ErrorResponseApiException apiException = (ErrorResponseApiException)t;
+                        if (apiException.getResponseCode() == 401) {
+                            resultCatcher.completeWithResult(false);
+                            return;
+                        }
+                    }
+                    resultCatcher.completeWithError(t);
+                }
+            });
+        });
     }
 
     /**

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/EEKTests.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/EEKTests.java
@@ -30,10 +30,7 @@ import org.junit.Test;
 
 import androidx.annotation.NonNull;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import android.util.Base64;
 
@@ -121,15 +118,8 @@ public class EEKTests extends BaseTest{
     }
 
     void expectFail(@PowerAuthErrorCodes int errorCode, TestClosure closure) {
-        try {
-            closure.test();
-        } catch (Exception exception) {
-            if (exception instanceof PowerAuthErrorException) {
-                assertEquals(errorCode, ((PowerAuthErrorException)exception).getPowerAuthErrorCode());
-            } else {
-                fail("Unexpected exception type: " + exception);
-            }
-        }
+        PowerAuthErrorException exception = assertThrows(PowerAuthErrorException.class, closure::test);
+        assertEquals(errorCode, exception.getPowerAuthErrorCode());
     }
 
     boolean validateOnlineSignature(PowerAuthAuthentication authentication) throws Exception {

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/EEKTests.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/EEKTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Wultra s.r.o.
+ * Copyright 2026 Wultra s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,154 +16,160 @@
 
 package io.getlime.security.powerauth.integration.tests;
 
+import io.getlime.security.powerauth.core.CoreProtocolVersion;
+import io.getlime.security.powerauth.core.CoreSession;
+import io.getlime.security.powerauth.core.CryptoUtils;
 import io.getlime.security.powerauth.core.SecureData;
+import io.getlime.security.powerauth.exception.PowerAuthErrorCodes;
+import io.getlime.security.powerauth.exception.PowerAuthErrorException;
+import io.getlime.security.powerauth.integration.support.AsyncHelper;
+import io.getlime.security.powerauth.integration.support.model.AuthenticationResult;
+import io.getlime.security.powerauth.networking.response.IOfflineAuthenticationCodeListener;
 import io.getlime.security.powerauth.sdk.*;
-import org.junit.After;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import androidx.annotation.NonNull;
-import androidx.test.ext.junit.runners.AndroidJUnit4;
-import io.getlime.security.powerauth.integration.support.PowerAuthTestHelper;
-import io.getlime.security.powerauth.integration.support.RandomGenerator;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-@RunWith(AndroidJUnit4.class)
-public class EEKTests {
+import android.util.Base64;
 
-    private PowerAuthTestHelper testHelper;
-    private PowerAuthSDK powerAuthSDK;
-    private ActivationHelper activationHelper;
+import java.nio.charset.StandardCharsets;
 
-    @After
-    public void tearDown() {
-        if (activationHelper != null) {
-            activationHelper.cleanupAfterTest();
+public class EEKTests extends BaseTest{
+
+    @Test
+    public void testExternalEncryptionKeyDiscontinue() throws Exception {
+        // Generate EEKs
+        final SecureData goodEEK = CoreSession.generateFactorKekForProtocolVersion(CoreProtocolVersion.V3);
+        final SecureData badEEK = CoreSession.generateFactorKekForProtocolVersion(CoreProtocolVersion.V4);
+        // Before activation, EEK flag is always false.
+        assertFalse(powerAuthSDK.hasExternalEncryptionKey());
+
+        // Attempts to remove or add, should fail for all protocol versions
+        try {
+            powerAuthSDK.removeExternalEncryptionKey(goodEEK);
+            fail();
+        } catch (PowerAuthErrorException exception) {
+            assertEquals(PowerAuthErrorCodes.MISSING_ACTIVATION, exception.getPowerAuthErrorCode());
+        }
+        try {
+            powerAuthSDK.addExternalEncryptionKeyForTest(goodEEK);
+            fail();
+        } catch (PowerAuthErrorException exception) {
+            assertEquals(PowerAuthErrorCodes.MISSING_ACTIVATION, exception.getPowerAuthErrorCode());
+        }
+
+        // Now create activation
+        activationHelper.createStandardActivation(ActivationHelper.TF_PERSIST_WITH_FAKE_BIOMETRY, null);
+
+        // By default, EEK is not set
+        assertFalse(powerAuthSDK.hasExternalEncryptionKey());
+        assertTrue(activationHelper.validateUserPassword(activationHelper.getValidPassword()));
+        assertTrue(validateOfflineSignature(activationHelper.getValidAuthentication()));
+        assertTrue(validateOfflineSignature(activationHelper.getBiometricAuthentication(null)));
+
+        if (getAlgorithmForTest() == PowerAuthAlgorithm.LEGACY_P256) {
+            // V3 activations
+            // Try to remove EEK first
+            expectFail(PowerAuthErrorCodes.INVALID_ACTIVATION_STATE, () -> powerAuthSDK.removeExternalEncryptionKey(goodEEK));
+            expectFail(PowerAuthErrorCodes.WRONG_PARAMETER, () -> powerAuthSDK.addExternalEncryptionKeyForTest(badEEK));
+            // Try with good EEK
+            powerAuthSDK.addExternalEncryptionKeyForTest(goodEEK);
+            assertTrue(powerAuthSDK.hasExternalEncryptionKey());
+            // validate signatures
+            expectFail(PowerAuthErrorCodes.INVALID_ACTIVATION_STATE, () -> validateOnlineSignature(activationHelper.getValidAuthentication()));
+            assertFalse(validateOfflineSignature(activationHelper.getValidAuthentication()));
+            assertFalse(validateOfflineSignature(activationHelper.getBiometricAuthentication(null)));
+
+            // simulate app restart
+            powerAuthSDK = activationHelper.reCreateSdk();
+
+            // validate EEK presence
+            assertTrue(powerAuthSDK.hasExternalEncryptionKey());
+            // validate signatures (should not work)
+            expectFail(PowerAuthErrorCodes.INVALID_ACTIVATION_STATE, () -> validateOnlineSignature(activationHelper.getValidAuthentication()));
+            assertFalse(validateOfflineSignature(activationHelper.getValidAuthentication()));
+            assertFalse(validateOfflineSignature(activationHelper.getBiometricAuthentication(null)));
+
+            // Try to remove wrong sized EEK
+            expectFail(PowerAuthErrorCodes.WRONG_PARAMETER, () -> powerAuthSDK.removeExternalEncryptionKey(badEEK));
+            assertTrue(powerAuthSDK.hasExternalEncryptionKey());
+            // Try with good EEK
+            powerAuthSDK.removeExternalEncryptionKey(goodEEK);
+
+            // EEK is no longer present
+            assertFalse(powerAuthSDK.hasExternalEncryptionKey());
+            // And signatures should work
+            assertTrue(validateOnlineSignature(activationHelper.getValidAuthentication()));
+            assertTrue(validateOfflineSignature(activationHelper.getValidAuthentication()));
+            assertTrue(validateOfflineSignature(activationHelper.getBiometricAuthentication(null)));
+
+        } else {
+            // V4 activations
+            // All EEK related methods should fail
+            expectFail(PowerAuthErrorCodes.INVALID_ACTIVATION_STATE, () -> powerAuthSDK.addExternalEncryptionKeyForTest(goodEEK));
+            expectFail(PowerAuthErrorCodes.INVALID_ACTIVATION_STATE, () -> powerAuthSDK.removeExternalEncryptionKey(goodEEK));
         }
     }
 
-    @Test
-    public void testModifyEEK() throws Exception {
-        // Setup
-        testHelper = new PowerAuthTestHelper.Builder().build();
-        powerAuthSDK = testHelper.getSharedSdk();
-        activationHelper = new ActivationHelper(testHelper);
-
-        // Test
-        activationHelper.createStandardActivation(true, null);
-        assertFalse(powerAuthSDK.hasExternalEncryptionKey());
-        assertTrue(activationHelper.validateUserPassword(activationHelper.getValidPassword()));
-
-        final SecureData eek = SecureData.capture(new RandomGenerator().generateBytes(16));
-        powerAuthSDK.addExternalEncryptionKey(eek);
-
-        assertTrue(powerAuthSDK.hasExternalEncryptionKey());
-        assertTrue(activationHelper.validateUserPassword(activationHelper.getValidPassword()));
-
-        powerAuthSDK.removeExternalEncryptionKey();
-        assertFalse(powerAuthSDK.hasExternalEncryptionKey());
-        assertTrue(activationHelper.validateUserPassword(activationHelper.getValidPassword()));
+    interface TestClosure {
+        void test() throws Exception;
     }
 
-    @Test
-    public void testEEKFromConfiguration() throws Exception {
-        // Setup
-        final byte[] eek = new RandomGenerator().generateBytes(16);
-        testHelper = new PowerAuthTestHelper.Builder()
-                .configurationObserver(new PowerAuthTestHelper.IConfigurationObserver() {
-                    @Override
-                    public void adjustPowerAuthConfiguration(@NonNull PowerAuthConfiguration.Builder builder) {
-                        builder.externalEncryptionKey(SecureData.copy(eek));
-                    }
-
-                    @Override
-                    public void adjustPowerAuthBiometricConfiguration(@NonNull PowerAuthBiometricConfiguration.Builder builder) {
-                    }
-
-                    @Override
-                    public void adjustPowerAuthClientConfiguration(@NonNull PowerAuthClientConfiguration.Builder builder) {
-                    }
-
-                    @Override
-                    public void adjustPowerAuthKeychainConfiguration(@NonNull PowerAuthKeychainConfiguration.Builder builder) {
-                    }
-                })
-                .build();
-        powerAuthSDK = testHelper.getSharedSdk();
-        activationHelper = new ActivationHelper(testHelper);
-
-        // Test
-        assertTrue(powerAuthSDK.hasExternalEncryptionKey());
-        activationHelper.createStandardActivation(true, null);
-        assertTrue(powerAuthSDK.hasExternalEncryptionKey());
-        assertTrue(activationHelper.validateUserPassword(activationHelper.getValidPassword()));
-
-        powerAuthSDK.removeExternalEncryptionKey();
-        assertFalse(powerAuthSDK.hasExternalEncryptionKey());
-        assertTrue(activationHelper.validateUserPassword(activationHelper.getValidPassword()));
+    void expectFail(@PowerAuthErrorCodes int errorCode, TestClosure closure) {
+        try {
+            closure.test();
+        } catch (Exception exception) {
+            if (exception instanceof PowerAuthErrorException) {
+                assertEquals(errorCode, ((PowerAuthErrorException)exception).getPowerAuthErrorCode());
+            } else {
+                fail("Unexpected exception type: " + exception);
+            }
+        }
     }
 
-    @Test
-    public void testSetEEKAfterActivation() throws Exception {
-        // Setup
-        testHelper = new PowerAuthTestHelper.Builder().build();
-        powerAuthSDK = testHelper.getSharedSdk();
-        activationHelper = new ActivationHelper(testHelper);
-
-        // Test
-        final SecureData eek = SecureData.capture(new RandomGenerator().generateBytes(16));
-
-        // At first, create activation without EEK and add manually
-        activationHelper.createStandardActivation(true, null);
-        final ActivationHelper.HelperState activationHelperState = activationHelper.getHelperState();
-
-        assertFalse(powerAuthSDK.hasExternalEncryptionKey());
-        assertTrue(activationHelper.validateUserPassword(activationHelper.getValidPassword()));
-
-        powerAuthSDK.addExternalEncryptionKey(eek);
-        assertTrue(powerAuthSDK.hasExternalEncryptionKey());
-        assertTrue(activationHelper.validateUserPassword(activationHelper.getValidPassword()));
-
-        // Now re-instantiate PowerAuthSDK (e.g. with no-EEK in configuration)
-        testHelper = new PowerAuthTestHelper.Builder().build(true);
-        powerAuthSDK = testHelper.getSharedSdk();
-        activationHelper = new ActivationHelper(testHelper, activationHelperState);
-
-        assertTrue(powerAuthSDK.hasValidActivation());
-        assertFalse(powerAuthSDK.hasExternalEncryptionKey());
-
-        // Try to fetch activation status. This should work also without an EEK.
-        PowerAuthActivationStatus status = activationHelper.fetchActivationStatus();
-        assertEquals(PowerAuthActivationState.ACTIVE, status.getState());
-
-        // Now set an EEK
-        powerAuthSDK.setExternalEncryptionKey(eek);
-        assertTrue(powerAuthSDK.hasExternalEncryptionKey());
-        assertTrue(activationHelper.validateUserPassword(activationHelper.getValidPassword()));
+    boolean validateOnlineSignature(PowerAuthAuthentication authentication) throws Exception {
+        final String uriId = "/test/online";
+        final byte[] body = "HELLO".getBytes(StandardCharsets.UTF_8);
+        final String method = "POST";
+        PowerAuthHttpHeader header = powerAuthSDK.authenticationHeaderForRequestWithBody(authentication, method, uriId, body);
+        AuthenticationResult result = authenticationHelper.verifyAuthenticationHeader(header, body, uriId, method);
+        return result.isAuthenticationValid();
     }
 
-    @Test
-    public void testSetEEKBeforeActivation() throws Exception {
-        // Setup
-        testHelper = new PowerAuthTestHelper.Builder().build();
-        powerAuthSDK = testHelper.getSharedSdk();
-        activationHelper = new ActivationHelper(testHelper);
+    boolean validateOfflineSignature(PowerAuthAuthentication authentication) throws Exception {
+        final boolean enableBiometry = authentication.useBiometricFactor();
+        final String uriId = "/test/offline";
+        final byte[] body = "HELLO".getBytes(StandardCharsets.UTF_8);
+        final String nonce = Base64.encodeToString(CryptoUtils.randomBytes((16)), Base64.NO_WRAP);
+        String authCode = AsyncHelper.await(resultCatcher -> {
+            powerAuthSDK.offlineAuthenticationCode(testHelper.getContext(), authentication, uriId, body, nonce, new IOfflineAuthenticationCodeListener() {
+                @Override
+                public void onOfflineAuthenticationCodeSucceed(@NonNull String authenticationCode) {
+                    resultCatcher.completeWithResult(authenticationCode);
+                }
 
-        // Test
-        final SecureData eek = SecureData.capture(new RandomGenerator().generateBytes(16));
-        assertFalse(powerAuthSDK.hasExternalEncryptionKey());
-        powerAuthSDK.setExternalEncryptionKey(eek);
-        assertTrue(powerAuthSDK.hasExternalEncryptionKey());
-
-        // At first, create activation without EEK and add manually
-        activationHelper.createStandardActivation(true, null);
-        assertTrue(activationHelper.validateUserPassword(activationHelper.getValidPassword()));
-
-        powerAuthSDK.removeExternalEncryptionKey();
-        assertFalse(powerAuthSDK.hasExternalEncryptionKey());
-        assertTrue(activationHelper.validateUserPassword(activationHelper.getValidPassword()));
+                @Override
+                public void onOfflineAuthenticationCodeFailed(@NonNull PowerAuthErrorException error) {
+                    resultCatcher.completeWithResult(null);
+                }
+            });
+        });
+        if (authCode == null) {
+            return false;
+        }
+        AuthenticationResult result = authenticationHelper.verifyAuthenticationCode(
+                authCode,
+                nonce,
+                body,
+                uriId,
+                activationHelper.getActivation().getActivationId(),
+                enableBiometry,
+                null);
+        return result.isAuthenticationValid();
     }
 }

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/sdk/PowerAuthConfigurationBuilderTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/sdk/PowerAuthConfigurationBuilderTest.java
@@ -174,26 +174,19 @@ public class PowerAuthConfigurationBuilderTest {
                 .build();
         assertEquals(4, configuration.getOfflineAuthenticationCodeComponentLength());
         // Invalid values
-        try {
-            new PowerAuthConfiguration.Builder(
-                    null,
-                    "http://wultra.com",
-                    sdkConfiguration)
-                    .offlineAuthenticationCodeComponentLength(3)
-                    .build();
-            fail("Should not work");
-        } catch (PowerAuthErrorException exception) {
-            assertEquals(PowerAuthErrorCodes.WRONG_PARAMETER, exception.getPowerAuthErrorCode());
-        }
-        try {
-             new PowerAuthConfiguration.Builder(
-                    null,
-                    "http://wultra.com",
-                    sdkConfiguration)
-                    .offlineAuthenticationCodeComponentLength(9)
-                    .build();
-        } catch (PowerAuthErrorException exception) {
-            assertEquals(PowerAuthErrorCodes.WRONG_PARAMETER, exception.getPowerAuthErrorCode());
-        }
+        PowerAuthErrorException exception = assertThrows(PowerAuthErrorException.class, () -> new PowerAuthConfiguration.Builder(
+                null,
+                "http://wultra.com",
+                sdkConfiguration)
+                .offlineAuthenticationCodeComponentLength(3)
+                .build());
+        assertEquals(PowerAuthErrorCodes.WRONG_PARAMETER, exception.getPowerAuthErrorCode());
+        exception = assertThrows(PowerAuthErrorException.class, () -> new PowerAuthConfiguration.Builder(
+                null,
+                "http://wultra.com",
+                sdkConfiguration)
+                .offlineAuthenticationCodeComponentLength(9)
+                .build());
+        assertEquals(PowerAuthErrorCodes.WRONG_PARAMETER, exception.getPowerAuthErrorCode());
     }
 }

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/sdk/PowerAuthConfigurationBuilderTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/sdk/PowerAuthConfigurationBuilderTest.java
@@ -19,30 +19,118 @@ package io.getlime.security.powerauth.sdk;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import io.getlime.security.powerauth.core.SecureData;
+import io.getlime.security.powerauth.exception.PowerAuthErrorCodes;
+import io.getlime.security.powerauth.exception.PowerAuthErrorException;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.nio.charset.Charset;
-import java.util.Objects;
 
 import static org.junit.Assert.*;
 
 @RunWith(AndroidJUnit4.class)
 public class PowerAuthConfigurationBuilderTest {
 
+    static final String sdkConfiguration =
+        "ARDV9ZPCmbBxQOuvwBEet0nnEIYRtwiuK6sEI58YecWmHcYEAUEEIOUWfl7mNjd72rmyrWcqNnPB" +
+        "8rT75WuAZDopD+5wSM7ibOvJ8zVolKJ3G45VvxFsBPxut118YPpNqyuKnpnuAAJhBLxTNONEcqW+" +
+        "Pgeps0YK3rGN2fDxkR/91Ovpl4H09ob1J59EP1N5RXIAxgDPjqTr9iLxAFQ/Sh+dJcmNT1CAUB12" +
+        "S0BCK2W0U3/q9CKbzzJMuNGRWTa9yIfqT78udJq4CAOHtjCCB7IwCwYJYIZIAWUDBAMSA4IHoQCr" +
+        "+GhdgN4woE6dXE0EAWI1/AgWrFgN5ty3p+m42q0g+VhvZLv5DvtPwEDyBxa1+gEuMdNaMNmYih36" +
+        "2DpZZof5kWgLLX59hV+4SfYrJgvMf4I+221hiUmdC19S+n8MHhi148WPdTQ6XS+P+qDEp8xKRIbp" +
+        "ZnL189QcHuxSWY5mHZYLJ8vOTQeTEifRT2S6n+mcqybT5mTiiSh0q/tumcHMmydEWbc82/kA4vPJ" +
+        "PwQ2hYRjUCZgKIHFklxmLlVNd2AMsx+KD/Fa/QPki79uAoAN+4E395MXUBz904l/ry+OD1dw/12n" +
+        "f0qOMcS0GgHzlDVfL6Nl/UEHZ8WNB70ryLyayUxLLG0vmFOhKJAZ4yJKkfKm32Ku8tUupn2QpJ7X" +
+        "drU7mop8dATcEOT3T6sFDoopCAbIoAJmU98uiauwIopCUVrOU1KoWYvW8LFSH/UlGXg6BdEfEvMW" +
+        "cQtBfHE/BgQLHmYVaaXqXCitL7Bz4FhDEpcVOWoxwcX/VN4/S8449Du/1LLUx5qAcS8iip8/YzUN" +
+        "4CYwuJmRPj1RM3m7IQlYrDaxHZ2ZZXYdoFUTkYEakYOyX2Iut6YaPO1A4my2Z2Avl/XzD3kN/wYI" +
+        "gig8gcp+QpJ1Za1+gK+J6ydMxT8h5oEv2vCTDEiwb2aHAX1kW8Kep0u+RtemZdOV6LUrBkvdGjTD" +
+        "0L3T/3cLZj6nzkS9VVje4qdWvUhkwPAldpYKpN0orAjyPKlp9h/qzSj859/uVTPN2gPhEgN0l1CB" +
+        "Fa781KALGIfMGY2sv2Z3WWPNtlwdiH9U7074TBNpWg1HD7ztZxr8lKbYTc38X54//UZwWjG8qAtT" +
+        "1KZh/WQJ1vN0AMmpbBmXf7vQfIhiMF5HJEgtshWPmUVGtG2CR37sTUFDRljZZycfVbIY7T6PQHQ2" +
+        "GE8lDUT9jUl4lGJq/1ebUfGvxY0jE1S8RAz7SxC9LTuf398NBj68AguH7kTk+YblkWhUPYHlpSNs" +
+        "MRERc9vYM+8YQ5+HOUvZLBUjSuEs9UAXSndcu6nXQILPYCAoHfgmR+XBQC0TTW29v070YRuOy6Gn" +
+        "AZxwLe6bbAGhoI5Pij8U3siEKCJFRSDeYdHYvDIeErnqzisnWcN8m3XWaVD/2My0jYd1Gc9v34JJ" +
+        "rbMS1PnqXGh8/s+Wz3gHnt3Qj9OaHXVy0JaDA15A62/G1rN1bXuriSLylYeRzlGuAEwS9oseTX/v" +
+        "rFvB8KiXFGNLJiJOl4AXkNi7tL1tkkWivffqa2NYZyazY2wbTkOpcHw7Z/gnOD5As7GQCQrySX/W" +
+        "bOfT5bTzD6RoYX6DUosf9v3kG58miSOCM9NnE7otgr9znNv7uHBN3ukqx7WZYib+wmN+EsM4ZZbV" +
+        "/M5YPQUlXzfLqCT7c1Tk/VVA2QJVKHwHAIBJZKaqs6i1wtyr1bVcFZpcQ4oabk3nl0vecZOYdEhW" +
+        "rKwBzVfW2FVFPsx4s3mFGLxTs4TUWj+G21DimE6WQuKsztIKanoPkda+uAfwWvEL/B2e71jurp8P" +
+        "yFSz2zD1rl36opHfBRkmlOY+s5TI7IgxTjvHdoY1m7DlfdmorEAiJnLmklCpPzVjMM08RZgsLcZk" +
+        "ilbDxkSF4Yb0UuAYZKaZEpGRZUAPhzxV3NessgB3FO/hjXZ9Jh2IwZecgfZRVLVvjgfXgGwjCMBI" +
+        "mRvSublX4p3qtD7iaHBqDEQL41IAhAC1v3LbS5AM7f12kiwS3byrcCQ0zDFTK4nTbSsWHQW5imMC" +
+        "0TqlsDGWLiupRZWBtpPXMqY9Z7NNqHkHVIh3D6b0S1vFdCU1ApEm9K9XWxtBi2x+tyWQ6HKDW2R8" +
+        "MbuY8/2Izver6rlnFsncLIUL8FVLZHJ2QlWAEM+gpeYzIKXm0eGyq0ZlzPoiAt6ivyTcENVbuQg5" +
+        "dZHRP7q6NH/DH+t64pycJjJNLB7xH44LnVc8SyC36wmeow7g4m7p2RSbJVN+xVeD1mlviQyRvLPa" +
+        "XKsm5xIIWX5t6zDprXMBLkj2UkiuoM6Hmed0vkS2erzGwKa6OcxhfHwoCBQgGiMSOJ2G/OVNgMmL" +
+        "HmoH2MR7SqlczO0hlKd3q4DYTZ+fogkOeo6PrG9Wr0mC9uX0QXpVGFq/3rhGTpqH4iPcfk0taTtK" +
+        "oabLyEb5MbzwY7Z2uw9Eqe2hPcJqpmVjkg5nCm4itufLp4uPDLqNx7yYb31M4vlCyLjLkjDcBLTu" +
+        "CAlaDiZlDPJpp308GcargrdBWRft5w5KUmrpcFu1uqLQZpuPPgNW1xzoCDjRQOk5jsnnH2sb6/z4" +
+        "68cPvlRCgPZQzQ2zvRPku31bTirR1iVI6zLlKZxyFEd7jgP+DwfvezWGx2VM3yrFhZSZlOXiEPgV" +
+        "5uAOvhpuCfnHrw1BKMyaikaRin7btLfU84Wvz909btyTs6hJzhT2plYYpp5wwXrl3KKhJDMAET+f" +
+        "qoFkbMm5o9KVPgYm4TXjSyx1CjgUtShxqyz8TEuYII0OFtFprstzE1dvuzi//fHM4tqQlb1RMVca" +
+        "tVMMcg+gxS6ZiSO0V/uZTchFQeCBe0rkIphL0MdbMS1A4st2YehkIz4OA4fXCKDadKmrGS/WszTL" +
+        "gNw2gg3ql3DlaKj/rwSKNjCCCjIwCwYJYIZIAWUDBAMTA4IKIQCc8aFWGLZ7eVG2adMiexGqyrPu" +
+        "eRRZ7nsq1R29Q2cIMYPWyaTEguOMU5wiGC97cXeerl/sC3gLDWAIznEVdhfFw8FmsNwDBtz7d4jO" +
+        "mFLEBt79QmJECPkvDcGKi5vicSjpGq4I55pGN0RjZNkuIM8lyGRlxft0FlS71xQwphY/37SXPuzA" +
+        "7P2gNfhzPT53OTJTRhxlKq61Sp26981+fHfAkMvL+2vegKSnhW14GnOeIQ5oabMNrF9niYrJWcT3" +
+        "CY+5TLWajHH0oqTtHh/UY3M6xl9lOlXmemOX+PXh1ce3xdPHJgGp6eBW+1tXal8TJYbXBdYfBY18" +
+        "rUVRVLj2Hb0YrUmuSjtZ5a5lzh0iiqjhKWEOMdMU44ZaqqBm+/KT4SYCZ/w3dgVwzmDNIR5QN8S8" +
+        "VRX13dZL45RMewL/mk2aZg7BdEYoy5hsRycP8dF491NQg5JxOt7338FRwDzzvCximmOh5Su1RHvm" +
+        "/CEgrZ3+2ee/5Wgpj+d4nVnwMvzr0lrlQA/XPh0FBJJ/XOfXw08HoT0xM0aADqCIP7XwVfuw6DQd" +
+        "n6L0XltZGE0pWDVfN98LDP/EEJLEvaPx1zJGhnFGYdaqDByolYhh2u52HrBZUpY+yBu1fAOLTkR6" +
+        "r7Rt01hAOGM7ciPfaFKRTtAMRbjOTJ0Jhmlk+Wh4DQWGTWJL4hOvSC8c4Qc7l657/6MS/Mcm3GND" +
+        "1tcW4F7ebWo9ybbQCsyg3vITlf5tI8OcHir3QMbcUYiqzI5vO0MnvF4aKH1Uk0raOuHgknBKCUUB" +
+        "liH/BuT2zdq+/46m1uxXcwe2rLPWAABXAqRmCpXwOX7aw1mNFHXSuSm7e3OPw/85rspns5Ppb5mI" +
+        "1kB1JOuh34bxzZeNHqbPYH5ng8xhTp6i/oSe8a3a28jqDX/7cvy332bllxmm3p4SZDQlmCX2A06e" +
+        "VjcNNwxQUbApqsiQgCRMO6CiJPRap2zcpxNwYtUpwDFqtxBnbXWXLxVnCtllpgxEEC6RLia13ds3" +
+        "R/o5+dQz0g3ZlSQSjyda0NxMshWScdrnKz64WFpXEM1StuhhHFmXTxc7Cp3EjaHnheHJLAzVWMXu" +
+        "YHaM23e41SNobVaDTxn2ngyc0q9isg0h2YZybq7vIOzXbkUOQM0Zha3BinZVhMG4F6ddaCNuEAoE" +
+        "QUOSGHwFFB1sZh+0gBze/2Z9KNIh+kvvt5u376DzCZALVpLxDGVDa09ZWDC5YChTHmV3k5NkbJ9B" +
+        "oM47KGqh8P4D24axTN6rAKN0eoQHsYf7/OPwgtehneefGX3JoWGsBDmOM0ti0kUpVwQVc/8GyRQl" +
+        "6RFt8wwgNSbFSi+kWdKg+ee7JmP1biUselWk0nKbZ+I49L9ZSuPYDL3HdeniKBzTMmG5SxaXa7sD" +
+        "LOmvTW82iuwFDp5mic7SxlaoqvIChGdvYGEpa6oGrArSM1yu7kbRbVyRgouTMIMfjPBwP+hhoC39" +
+        "w073xKGMNzpqFxZtcNjj5cWcBop7h/n+uXLHatFpTS8nnrxnNd5Bc1UdMKtzpL2+AHs6AYbnZd75" +
+        "O9Tmib40CII8/S0oASTFiLBEo4k5vaKk/84wU/kYWQoLYMsJ3Q3+NIzygW3GefzTbCla//pd8gDG" +
+        "eX9peMs6woFxaV9OPq0gmu/MAveD6Mjz+VyPU69lMgdq6Bsste6M6xUeMKNvE5Wm7ZiReS3AYisU" +
+        "NeNa3k7q5nfe5lvkKoFkHPhjDw25eGFY7n/KQ0uoM6hOaeWSv2Lq2oEUhw/dYIokbVoeHW0zWc5J" +
+        "/WYVbCfUL0U6ci/D6Wz6GfiPpe7j+JrwVFUVDF4P6ZZzTqo6Oum7lZpC5LCmLdWWTacGGaBp0H9S" +
+        "kcxi+Nppv5PtSe4KJOpni0VdFILjvZQT332Zn8K36KYjyeOjiq8SyxC/fpTM+bWBSq/4iuIdLxHo" +
+        "J00fnGawIvQKYrRZCx+BJ93xlKnMsEslfjb6kwmI/gd1Rbcxl/5uTTYrwDD3T4YDjKi52gMpejph" +
+        "fbXll/+zBPrGbLoyZpJetVtDEOumiaLNRtD5vIeOLbaYF65IO46wcbo7Kg3kGojdNJbl+4bZKBnU" +
+        "0NmdOOW/GwmbhvKyoLw0Gu+XaT39xWGyPV25CmUOpi/oSGiCSbSt3QTnrkeeFC6ELEE5p/UklUEd" +
+        "nRacb089piy08jn1KS5phs9TEmzdygt7YIepde/4UJDgC45judJ0Jn5nsowttk9rho3KP3nyUrep" +
+        "MZ4nTgkaf5CREpde6G8zZE5VKL2/DWWlSvAnk0gAR/6+BqqD9VEFSjhCNSMr0Y46SulTGALselZ0" +
+        "CCMx6VbUd2NMkIW7wnmzsV9zon96GcfrzDDcrK76LhzKMC/rzj+Cf1/Gms/rek1uk+H0QsnRGPWK" +
+        "oT7N9TNJPoSjKBlRCWhyu5jIQ1oT91l0bilGmAFocnamISRFouS+K1cbSJY0t+mb+raT4SeyG5gA" +
+        "nTpquEXeslVKwfaCPd/B4LBqFwD209ckP7Fg9BO40Hlu9QBPg/GLn5yhpD7gO+mpu6hJIDMKIkIB" +
+        "6E+dUB9DOh1G5EC7k3Eqba2znMjgCeRGHjjozvj/s1xttDPrT/wLZGqqhOVkyhzAsEh0lrbijvKg" +
+        "yu+4x3PShsoceLD66vC8uAPcMVU7tWuUXHVa1JiMwkltXePACSIwGxRlIbvF+j5wv7CNel0c18PI" +
+        "4NgPFVXfQFF4be/xAr8mb3jZz3yKewJvc5oW9D98GoYMh5UH4RN9OIaXd9GHSZ3vKKuUf6RcvP8Q" +
+        "tlBWlH73/OiQ1H7pFWyd7t+pEb+RzFUUoLVrW0oEB45g3UNNqb/zysgaHBbglVs8qbvTJ9Wlm2mx" +
+        "nINWrJsBLPTPUjXNBKMTMm1Brf4UOrKtHAQqySMJ3GlpM2hjq2FkThHNEbZPfFCIU3K0ucbcMSH5" +
+        "8YtLk2PSkytguOoKoHDXmJ+GS5Iy0JHoJt3tjfvHGsfzXu3zd7V5OozD/yqRfHioYXPW+QkU9dFy" +
+        "UNQAp1UaSNXXLRFGCak9vuTKMa3CT+uLp2SDoWWZv9W//DaPCiM/nIpQcCy8yeepqcQrSeVGSwLM" +
+        "ZcSUm13OXBaYlVcHWTosq08sizIX7uEeyJrT0rSVHZLx14YEh/WbQnx2TKTSVArgJ+RzCCL1+cqL" +
+        "aSVdHURZ0fyC5XA5AHcXQz5wtbO8Kgb3IC0d9O1SdTL2F5mzbYz86i3hXDNP/OQ4DmKCRti9RsjL" +
+        "xuILKkGQrvMqXTdnPVVFwJQ+3T4YZ2tPnisVKePJpCxpeZWLo+VaTQSvxbMYml97kfP4Bd3+8ngH" +
+        "q+jg3A2xFmu0Kv2CJY8eKi+Hjg5DYbqWQNUXHbv7uUuVHCgJmT6azse4x357y4qEdzXDrslMvPyg" +
+        "jcmIgTBMNVsGjO7JhZR4g5WmUvQ7/BveNv0KXX7MLoeWqbGVq+m3Ap14pZ387ajzR+35W8aDRWgY" +
+        "gKU17hnlpfo=";
+
     @Test
     public void testBasicParameters() throws Exception {
         PowerAuthConfiguration configuration = new PowerAuthConfiguration.Builder(
                 "com.wultra.android.powerauth.test",
                 "http://wultra.com",
-                "ARDDj6EB6iAUtNmNxKM/BsbaEEs5bP+yVmyjfhQDoox3LDwBAUEEQQ7CWNKAi0EgCfOvd/srfqz4oqhTMLwsT4r7sPLRfqICRw9cCMs/Uoo/F2rIz+KKEcBxbnH9bMk8Ju3K1wmjbA==")
+                sdkConfiguration)
                 .build();
         assertNotNull(configuration);
         assertEquals("com.wultra.android.powerauth.test", configuration.getInstanceId());
         assertEquals("http://wultra.com", configuration.getBaseEndpointUrl());
-        assertEquals("ARDDj6EB6iAUtNmNxKM/BsbaEEs5bP+yVmyjfhQDoox3LDwBAUEEQQ7CWNKAi0EgCfOvd/srfqz4oqhTMLwsT4r7sPLRfqICRw9cCMs/Uoo/F2rIz+KKEcBxbnH9bMk8Ju3K1wmjbA==", configuration.getConfiguration());
+        assertEquals(sdkConfiguration, configuration.getConfiguration());
         assertNull(configuration.getExternalEncryptionKey());
-        assertTrue(configuration.validateConfiguration());
     }
 
     @Test
@@ -50,14 +138,13 @@ public class PowerAuthConfigurationBuilderTest {
         PowerAuthConfiguration configuration = new PowerAuthConfiguration.Builder(
                 null,
                 "http://wultra.com",
-                "ARDDj6EB6iAUtNmNxKM/BsbaEEs5bP+yVmyjfhQDoox3LDwBAUEEQQ7CWNKAi0EgCfOvd/srfqz4oqhTMLwsT4r7sPLRfqICRw9cCMs/Uoo/F2rIz+KKEcBxbnH9bMk8Ju3K1wmjbA==")
+                sdkConfiguration)
                 .build();
         assertNotNull(configuration);
         assertEquals(PowerAuthConfiguration.DEFAULT_INSTANCE_ID, configuration.getInstanceId());
         assertEquals("http://wultra.com", configuration.getBaseEndpointUrl());
-        assertEquals("ARDDj6EB6iAUtNmNxKM/BsbaEEs5bP+yVmyjfhQDoox3LDwBAUEEQQ7CWNKAi0EgCfOvd/srfqz4oqhTMLwsT4r7sPLRfqICRw9cCMs/Uoo/F2rIz+KKEcBxbnH9bMk8Ju3K1wmjbA==", configuration.getConfiguration());
+        assertEquals(sdkConfiguration, configuration.getConfiguration());
         assertNull(configuration.getExternalEncryptionKey());
-        assertTrue(configuration.validateConfiguration());
         assertEquals(8, configuration.getOfflineAuthenticationCodeComponentLength());
     }
 
@@ -67,18 +154,14 @@ public class PowerAuthConfigurationBuilderTest {
         PowerAuthConfiguration configuration = new PowerAuthConfiguration.Builder(
                 null,
                 "http://wultra.com",
-                "ARDDj6EB6iAUtNmNxKM/BsbaEEs5bP+yVmyjfhQDoox3LDwBAUEEQQ7CWNKAi0EgCfOvd/srfqz4oqhTMLwsT4r7sPLRfqICRw9cCMs/Uoo/F2rIz+KKEcBxbnH9bMk8Ju3K1wmjbA==")
+                sdkConfiguration)
                 .externalEncryptionKey(expectedEEK)
                 .build();
         assertNotNull(configuration);
         assertEquals(PowerAuthConfiguration.DEFAULT_INSTANCE_ID, configuration.getInstanceId());
         assertEquals("http://wultra.com", configuration.getBaseEndpointUrl());
-        assertEquals("ARDDj6EB6iAUtNmNxKM/BsbaEEs5bP+yVmyjfhQDoox3LDwBAUEEQQ7CWNKAi0EgCfOvd/srfqz4oqhTMLwsT4r7sPLRfqICRw9cCMs/Uoo/F2rIz+KKEcBxbnH9bMk8Ju3K1wmjbA==", configuration.getConfiguration());
-        assertEquals(expectedEEK, configuration.getExternalEncryptionKey());
-        assertTrue(configuration.validateConfiguration());
-        // Test EEK after modify
-        expectedEEK.getSensitiveData()[0] = 'X';
-        assertEquals('0', Objects.requireNonNull(configuration.getExternalEncryptionKey()).getSensitiveData()[0]);
+        assertEquals(sdkConfiguration, configuration.getConfiguration());
+        assertNull(configuration.getExternalEncryptionKey());
     }
 
     @Test
@@ -86,24 +169,31 @@ public class PowerAuthConfigurationBuilderTest {
         PowerAuthConfiguration configuration = new PowerAuthConfiguration.Builder(
                 null,
                 "http://wultra.com",
-                "ARDDj6EB6iAUtNmNxKM/BsbaEEs5bP+yVmyjfhQDoox3LDwBAUEEQQ7CWNKAi0EgCfOvd/srfqz4oqhTMLwsT4r7sPLRfqICRw9cCMs/Uoo/F2rIz+KKEcBxbnH9bMk8Ju3K1wmjbA==")
+                sdkConfiguration)
                 .offlineAuthenticationCodeComponentLength(4)
                 .build();
         assertEquals(4, configuration.getOfflineAuthenticationCodeComponentLength());
         // Invalid values
-        configuration = new PowerAuthConfiguration.Builder(
-                null,
-                "http://wultra.com",
-                "ARDDj6EB6iAUtNmNxKM/BsbaEEs5bP+yVmyjfhQDoox3LDwBAUEEQQ7CWNKAi0EgCfOvd/srfqz4oqhTMLwsT4r7sPLRfqICRw9cCMs/Uoo/F2rIz+KKEcBxbnH9bMk8Ju3K1wmjbA==")
-                .offlineAuthenticationCodeComponentLength(3)
-                .build();
-        assertFalse(configuration.validateConfiguration());
-        configuration = new PowerAuthConfiguration.Builder(
-                null,
-                "http://wultra.com",
-                "ARDDj6EB6iAUtNmNxKM/BsbaEEs5bP+yVmyjfhQDoox3LDwBAUEEQQ7CWNKAi0EgCfOvd/srfqz4oqhTMLwsT4r7sPLRfqICRw9cCMs/Uoo/F2rIz+KKEcBxbnH9bMk8Ju3K1wmjbA==")
-                .offlineAuthenticationCodeComponentLength(9)
-                .build();
-        assertFalse(configuration.validateConfiguration());
+        try {
+            new PowerAuthConfiguration.Builder(
+                    null,
+                    "http://wultra.com",
+                    sdkConfiguration)
+                    .offlineAuthenticationCodeComponentLength(3)
+                    .build();
+            fail("Should not work");
+        } catch (PowerAuthErrorException exception) {
+            assertEquals(PowerAuthErrorCodes.WRONG_PARAMETER, exception.getPowerAuthErrorCode());
+        }
+        try {
+             new PowerAuthConfiguration.Builder(
+                    null,
+                    "http://wultra.com",
+                    sdkConfiguration)
+                    .offlineAuthenticationCodeComponentLength(9)
+                    .build();
+        } catch (PowerAuthErrorException exception) {
+            assertEquals(PowerAuthErrorCodes.WRONG_PARAMETER, exception.getPowerAuthErrorCode());
+        }
     }
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreSession.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreSession.java
@@ -414,6 +414,31 @@ public class CoreSession extends NativeObject {
                                                   @NonNull CoreCredentials credentials,
                                                   @CoreSignatureKeyId int keyId) throws CoreException;
 
+    // EEK
+
+    /**
+     * Get information whether EEK is still present in V3 persistent data.
+     * @return {@code true} if V3 persistent data still contains factor keys protected with EEK.
+     */
+    public native boolean hasExternalEncryptionKey();
+
+    /**
+     * Remove EEK if factor keys are still protected with EEK. The method throws an exception
+     * if activation is not present, or if factor keys are not protected with EEK.
+     * @param eek EEK previously used for the factor keys protection.
+     * @throws CoreException In case of failure.
+     */
+    public native void removeExternalEncryptionKey(@NonNull SecureData eek) throws CoreException;
+
+    /**
+     * Add external encryption key for testing purposes. The method should not be used in the
+     * release build. The legacy activation must be present and the size of EEK must match the size
+     * of factor keys used in V3.3 protocol version (e.g. 16 bytes).
+     * @param eek EEK to apply.
+     * @throws CoreException In case of failure.
+     */
+    public native void addExternalEncryptionKeyForTest(@NonNull SecureData eek) throws CoreException;
+
     // Services
 
     /**

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthConfiguration.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthConfiguration.java
@@ -16,11 +16,13 @@
 
 package io.getlime.security.powerauth.sdk;
 
+import android.annotation.SuppressLint;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import io.getlime.security.powerauth.core.CoreAlgorithm;
 import io.getlime.security.powerauth.core.CoreConfig;
 import io.getlime.security.powerauth.core.CoreException;
 import io.getlime.security.powerauth.core.SecureData;
@@ -72,10 +74,12 @@ public class PowerAuthConfiguration {
     }
 
     /**
-     * @return Encryption key provided by an external context, used to encrypt possession and biometry related factor keys under the hood.
+     * Property is deprecated. EEK is no longer supported in SDK.
+     * @return Always {@code null}.
+     * @deprecated EEK is no longer supported in SDK.
      */
+    @Deprecated // 2.0.0
     public @Nullable SecureData getExternalEncryptionKey() {
-        // TODO: EEK
         return null;
     }
 
@@ -156,7 +160,6 @@ public class PowerAuthConfiguration {
         private final @NonNull String configuration;
         // optional
         private String instanceId;
-        private SecureData externalEncryptionKey = null;    // TODO: EEK
         private int offlineAuthenticationCodeComponentLength = MAX_OFFLINE_AUTHENTICATION_CODE_COMPONENT_LENGTH;
         private @PowerAuthAlgorithm int algorithm = PowerAuthAlgorithm.DEFAULT;
 
@@ -199,12 +202,13 @@ public class PowerAuthConfiguration {
         }
 
         /**
-         * Set external encryption key provided by an external context, used to encrypt possession and biometry related factor keys under the hood.
-         * @param externalEncryptionKey Encryption key provided by an external context, used to encrypt possession and biometry related factor keys under the hood.
+         * Property is deprecated. EEK is no longer supported in SDK>
+         * @param externalEncryptionKey Encryption key provided by an external context.
          * @return {@link Builder}
+         * @deprecated EEK is no longer supported in SDK.
          */
+        @Deprecated // 2.0.0
         public @NonNull Builder externalEncryptionKey(@NonNull SecureData externalEncryptionKey) {
-            this.externalEncryptionKey = externalEncryptionKey.copy();
             return this;
         }
 
@@ -280,10 +284,22 @@ public class PowerAuthConfiguration {
     @NonNull
     CoreConfig getCoreConfiguration(@NonNull byte[] deviceSpecificData) throws PowerAuthErrorException {
         try {
-            return CoreConfig.build(configuration, deviceSpecificData, instanceId, algorithm);
+            return CoreConfig.build(configuration, deviceSpecificData, instanceId, toCoreAlgorithm(algorithm));
         } catch (CoreException e) {
             throw new PowerAuthErrorException(PowerAuthErrorCodes.WRONG_PARAMETER, "Invalid SDK configuration", e);
         }
     }
 
+    /**
+     * Convert {@link PowerAuthAlgorithm} into {@link CoreAlgorithm} constant.
+     * @param algorithm {@link PowerAuthAlgorithm} constant.
+     * @return {@link CoreAlgorithm} constant.
+     */
+    @SuppressLint("WrongConstant")
+    @CoreAlgorithm
+    private static int toCoreAlgorithm(@PowerAuthAlgorithm int algorithm) {
+        // @PowerAuthAlgorithm is defined from @CoreAlgorithm constants, so direct return
+        // with suppressed warning is OK.
+        return algorithm;
+    }
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -2810,41 +2810,42 @@ public class PowerAuthSDK {
      * @return true if EEK (external encryption key) is set.
      */
     public boolean hasExternalEncryptionKey() {
-        // TODO: EEK
-        return false;
+        return mSession.hasExternalEncryptionKey();
     }
 
     /**
-     * Sets a known external encryption key to the internal configuration. This method
-     * is useful, when the activation is using EEK, but the key was not known during the PowerAuthSDK
-     * creation. You can restore the activation without the EEK and use it for a very limited set of
-     * operations, like the getting activation status. The data signing will also work correctly,
-     * but only for a possession factor, which is by design not protected with EEK.
-     *
-     * @param externalEncryptionKey EEK to be set to the internal configuration.
+     * Remove EEK if factor keys are still protected with EEK. The method throws an exception
+     * if activation is not present, or if factor keys are not protected with EEK.
+     * @param eek EEK previously used for the factor keys protection.
      * @throws PowerAuthErrorException In case of failure.
      */
-    public void setExternalEncryptionKey(@NonNull SecureData externalEncryptionKey) throws PowerAuthErrorException {
-        // TODO: EEK
+    public void removeExternalEncryptionKey(@NonNull SecureData eek) throws PowerAuthErrorException {
+        try {
+            mSession.removeExternalEncryptionKey(eek);
+            saveSerializedState();
+        } catch (CoreException exception) {
+            throw PowerAuthErrorException.wrapException(exception);
+        }
     }
 
     /**
-     * Add a new external encryption key permanently to the activated PowerAuthSDK and to the internal configuration.
-     * The method is useful for scenarios, when you need to add the EEK additionally, after the activation.
-     * @param externalEncryptionKey External Encryption key to add.
-     * @throws PowerAuthErrorException In case of failure.
+     * Add external encryption key for testing purposes. The method should not be used in the
+     * release build. The legacy activation must be present and the size of EEK must match the size
+     * of factor keys used in V3.3 protocol version (e.g. 16 bytes).
+     * @param eek EEK to apply.
+     * @throws PowerAuthErrorException In case of failure,
      */
-    public void addExternalEncryptionKey(@NonNull SecureData externalEncryptionKey) throws PowerAuthErrorException {
-        // TODO: EEK
-    }
-
-    /**
-     * Remove existing external encryption key from the activated PowerAuthSDK and from the configuration object. The valid
-     * activation must be present and EEK must be set at the time of call (e.g. {@link #hasExternalEncryptionKey()} returns true).
-     * @throws PowerAuthErrorException In case of failure.
-     */
-    public void removeExternalEncryptionKey() throws PowerAuthErrorException {
-        // TODO: EEK
+    public void addExternalEncryptionKeyForTest(@NonNull SecureData eek) throws PowerAuthErrorException {
+        if (BuildConfig.DEBUG) {
+            try {
+                mSession.addExternalEncryptionKeyForTest(eek);
+                saveSerializedState();
+            } catch (CoreException exception) {
+                throw PowerAuthErrorException.wrapException(exception);
+            }
+        } else {
+            throw new PowerAuthErrorException(PowerAuthErrorCodes.INVALID_ACTIVATION_STATE, "Function is not available in release SDK build");
+        }
     }
 
     // Server status

--- a/proj-xcode/PowerAuth2.xcodeproj/project.pbxproj
+++ b/proj-xcode/PowerAuth2.xcodeproj/project.pbxproj
@@ -45,6 +45,8 @@
 		BF0825AB2632E64600B34E24 /* PowerAuthActivationCode.m in Sources */ = {isa = PBXBuildFile; fileRef = BF0825A72632E64600B34E24 /* PowerAuthActivationCode.m */; };
 		BF0899E22A97408500AF29E5 /* PowerAuthTimeSynchronizationService.h in Headers */ = {isa = PBXBuildFile; fileRef = BF0899E02A97408500AF29E5 /* PowerAuthTimeSynchronizationService.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF0899E32A97408500AF29E5 /* PowerAuthTimeSynchronizationService.h in Headers */ = {isa = PBXBuildFile; fileRef = BF0899E02A97408500AF29E5 /* PowerAuthTimeSynchronizationService.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BF112ECA2F3B528E00D578F0 /* PowerAuthConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BF112EC32F3B528300D578F0 /* PowerAuthConfigurationTests.m */; };
+		BF112ECB2F3B528E00D578F0 /* PowerAuthConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BF112EC32F3B528300D578F0 /* PowerAuthConfigurationTests.m */; };
 		BF11504B2E184A5B008601DE /* PA2CoreHttpClient.h in Headers */ = {isa = PBXBuildFile; fileRef = BF1150492E184A5B008601DE /* PA2CoreHttpClient.h */; };
 		BF11504C2E184A5B008601DE /* PA2CoreHttpClient.m in Sources */ = {isa = PBXBuildFile; fileRef = BF11504A2E184A5B008601DE /* PA2CoreHttpClient.m */; };
 		BF11504D2E184A5B008601DE /* PA2CoreHttpClient.h in Headers */ = {isa = PBXBuildFile; fileRef = BF1150492E184A5B008601DE /* PA2CoreHttpClient.h */; };
@@ -552,6 +554,7 @@
 		BF0825A62632E64600B34E24 /* PowerAuthActivationCode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PowerAuthActivationCode.h; sourceTree = "<group>"; };
 		BF0825A72632E64600B34E24 /* PowerAuthActivationCode.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PowerAuthActivationCode.m; sourceTree = "<group>"; };
 		BF0899E02A97408500AF29E5 /* PowerAuthTimeSynchronizationService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PowerAuthTimeSynchronizationService.h; sourceTree = "<group>"; };
+		BF112EC32F3B528300D578F0 /* PowerAuthConfigurationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PowerAuthConfigurationTests.m; sourceTree = "<group>"; };
 		BF1150492E184A5B008601DE /* PA2CoreHttpClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PA2CoreHttpClient.h; sourceTree = "<group>"; };
 		BF11504A2E184A5B008601DE /* PA2CoreHttpClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PA2CoreHttpClient.m; sourceTree = "<group>"; };
 		BF1ED06C283CEB2700D6B380 /* PowerAuthKeychainAuthentication.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PowerAuthKeychainAuthentication.h; sourceTree = "<group>"; };
@@ -1081,6 +1084,7 @@
 				BF667EC52835A0B2006E97F8 /* PowerAuthCustomHeaderRequestInterceptorTests.m */,
 				BF667EC62835A0B2006E97F8 /* PowerAuthBasicHttpAuthenticationRequestInterceptorTests.m */,
 				BF215F01287D8C9300EC3F3E /* PowerAuthAuthenticationTests.m */,
+				BF112EC32F3B528300D578F0 /* PowerAuthConfigurationTests.m */,
 				BF28C1C32982A05100E2CD8E /* PowerAuthUserInfoTests.m */,
 				BF667EC72835A0B2006E97F8 /* Info.plist */,
 			);
@@ -1779,6 +1783,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BF112ECA2F3B528E00D578F0 /* PowerAuthConfigurationTests.m in Sources */,
 				BF667ED52835A13F006E97F8 /* AsyncHelper.m in Sources */,
 				BF369FCA285370DD0004C454 /* PA2GroupedTaskTests.m in Sources */,
 				BF28C1C42982A05100E2CD8E /* PowerAuthUserInfoTests.m in Sources */,
@@ -1860,6 +1865,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BF112ECB2F3B528E00D578F0 /* PowerAuthConfigurationTests.m in Sources */,
 				BF667ED42835A13E006E97F8 /* AsyncHelper.m in Sources */,
 				BF369FCB285370DD0004C454 /* PA2GroupedTaskTests.m in Sources */,
 				BF28C1C52982A05100E2CD8E /* PowerAuthUserInfoTests.m in Sources */,

--- a/proj-xcode/PowerAuth2/PowerAuthConfiguration.h
+++ b/proj-xcode/PowerAuth2/PowerAuthConfiguration.h
@@ -92,7 +92,8 @@ typedef NS_ENUM(NSInteger, PowerAuthAlgorithm) {
 @property (nonatomic, strong, nonnull) NSString *keychainKey_Biometry;
 
 /// Encryption key provided by an external context, used to encrypt possession and biometry related factor keys under the hood.
-@property (nonatomic, strong, nullable) PowerAuthCoreData * externalEncryptionKey;
+/// @deprecated EEK is no longer used in SDK.
+@property (nonatomic, strong, nullable) PowerAuthCoreData * externalEncryptionKey PA2_DEPRECATED(2.0);
 
 /// Algorithm selected for communication with the server.
 @property (nonatomic, assign) PowerAuthAlgorithm algorithm;

--- a/proj-xcode/PowerAuth2/PowerAuthConfiguration.m
+++ b/proj-xcode/PowerAuth2/PowerAuthConfiguration.m
@@ -18,6 +18,7 @@
 // PA2_SHARED_SOURCE PowerAuth2ForExtensions .
 
 #import <PowerAuth2/PowerAuthConfiguration.h>
+#import <PowerAuth2/PowerAuthLog.h>
 @import PowerAuthCore;
 
 @implementation PowerAuthConfiguration
@@ -77,7 +78,6 @@
         c->_configuration = _configuration;
         c->_algorithm = _algorithm;
         c->_keychainKey_Biometry = _keychainKey_Biometry;
-        c->_externalEncryptionKey = _externalEncryptionKey;
         c->_disableAutomaticProtocolUpgrade = _disableAutomaticProtocolUpgrade;
         c->_offlineAuthenticationCodeComponentLength = _offlineAuthenticationCodeComponentLength;
         c->_sharingConfiguration = [_sharingConfiguration copy];
@@ -94,6 +94,19 @@
 - (NSUInteger) offlineSignatureComponentLength
 {
     return _offlineAuthenticationCodeComponentLength;
+}
+
+// PA2_DEPRECATED(2.0.0)
+- (void) setExternalEncryptionKey:(PowerAuthCoreData *)externalEncryptionKey
+{
+    if (externalEncryptionKey) {
+        PowerAuthLog(@"WARNING: EEK is not supported in this version of SDK");
+    }
+}
+// PA2_DEPRECATED(2.0.0)
+- (PowerAuthCoreData*) externalEncryptionKey
+{
+    return nil;
 }
 
 @end

--- a/proj-xcode/PowerAuth2/PowerAuthSDK.h
+++ b/proj-xcode/PowerAuth2/PowerAuthSDK.h
@@ -1114,35 +1114,29 @@
 
 @interface PowerAuthSDK (EEK)
 
-/**
- Contains YES if EEK (external encryption key) is set.
- */
+/// Contains YES if factor keys in a legacy activation are still protected with EEK.
 @property (nonatomic, readonly) BOOL hasExternalEncryptionKey;
 
-/**
- Sets a known external encryption key to the internal configuration. This method
- is useful, when the activation is using EEK, but the key was not known during the PowerAuthSDK
- creation. You can restore the activation without the EEK and use it for a very limited set of
- operations, like the getting activation status. The data signing will also work correctly,
- but only for a possession factor, which is by design not protected with EEK.
- @param externalEncryptionKey EEK to be set to the internal configuration.
- */
-- (BOOL) setExternalEncryptionKey:(nonnull PowerAuthCoreData *)externalEncryptionKey
-                            error:(NSError * _Nullable * _Nullable)error;
+/// Remove EEK if factor keys are still protected with EEK. The method returns an error
+/// if activation is not present, or if factor keys are not protected with EEK.
+///
+/// - Parameters:
+///   - externalEncryptionKey: EEK previously used for the factor keys protection.
+///   - error: Pointer where error is set in case of failure.
+/// - Returns: YES in case of success, NO otherwise.
+- (BOOL) removeExternalEncryptionKey:(nonnull PowerAuthCoreData *)externalEncryptionKey
+                               error:(NSError * _Nullable * _Nullable)error;
 
-/**
- Add a new external encryption key permanently to the activated PowerAuthSDK and to the configuration object. The method
- is is useful for scenarios, when you need to add the EEK additionally, after the activation.
- @param externalEncryptionKey A new key to add. The data object must contain exactly 16 bytes.
- */
-- (BOOL) addExternalEncryptionKey:(nonnull PowerAuthCoreData *)externalEncryptionKey
-                            error:(NSError * _Nullable * _Nullable)error;
-
-/**
- Remove existing external encryption key from the activated PowerAuthSDK and from the configuration object. The valid
- activation must be present and EEK must be set at the time of call (e.g. 'hasExternalEncryptionKey' returns true).
- */
-- (BOOL) removeExternalEncryptionKey:(NSError * _Nullable * _Nullable)error;
+/// Add external encryption key for testing purposes. The method should not be used in the
+/// release build. The legacy activation must be present and the size of EEK must match the size
+/// of factor keys used in V3.3 protocol version (e.g. 16 bytes).
+///
+/// - Parameters:
+///   - eek: EEK to apply
+///   - error: Pointer where error is set in case of failure.
+/// - Returns: YES in case of success, NO otherwise.
+- (BOOL) addExternalEncryptionKeyForTest:(nonnull PowerAuthCoreData *)externalEncryptionKey
+                                   error:(NSError * _Nullable * _Nullable)error;
 
 @end
 

--- a/proj-xcode/PowerAuth2/PowerAuthSDK.m
+++ b/proj-xcode/PowerAuth2/PowerAuthSDK.m
@@ -1890,92 +1890,31 @@ static PowerAuthSDK * s_inst;
 
 - (BOOL) hasExternalEncryptionKey
 {
-//    return [_sessionInterface readBoolTaskWithSession:^BOOL(PowerAuthCoreSession * session) {
-//        return [session hasExternalEncryptionKey];
-//    }];
-    // TODO: eek
-    return NO;
+    return [_sessionInterface readBoolTaskWithSession:^BOOL(PowerAuthCoreSession * session, NSError ** error) {
+        return [session hasExternalEncryptionKey];
+    } error:nil];
 }
 
-- (BOOL) setExternalEncryptionKey:(PowerAuthCoreData *)externalEncryptionKey error:(NSError **)error
+- (BOOL) removeExternalEncryptionKey:(PowerAuthCoreData *)externalEncryptionKey
+                               error:(NSError * _Nullable __autoreleasing *)error
 {
-//    NSError * failure = [_sessionInterface writeTaskWithSession:^NSError* (PowerAuthCoreSession * session) {
-//        PowerAuthCoreErrorCode ec = [session setExternalEncryptionKey:externalEncryptionKey];
-//        switch (ec) {
-//            case PowerAuthCoreErrorCode_Ok:
-//                _configuration.externalEncryptionKey = externalEncryptionKey;
-//                return nil;
-//            case PowerAuthCoreErrorCode_WrongParam:
-//                return PA2MakeError(PowerAuthErrorCode_WrongParameter, @"Invalid key size");
-//            case PowerAuthCoreErrorCode_WrongState:
-//                return PA2MakeError(PowerAuthErrorCode_InvalidActivationState, @"Activation is not using EEK");
-//            default:
-//                return PA2MakeError(PowerAuthErrorCode_Encryption, @"Failed to set EEK");
-//        }
-//    }];
-//    if (failure && error) {
-//        *error = failure;
-//    }
-//    return !failure;
-    // TODO: eek
-    return NO;
+    return [_sessionInterface writeBoolTaskWithSession:^BOOL(PowerAuthCoreSession * session, NSError ** error) {
+        return [session removeExternalEncryptionKey:externalEncryptionKey error:error];
+    } error:error];
 }
 
-- (BOOL) addExternalEncryptionKey:(PowerAuthCoreData *)externalEncryptionKey error:(NSError **)error
+- (BOOL) addExternalEncryptionKeyForTest:(PowerAuthCoreData *)externalEncryptionKey
+                                   error:(NSError * _Nullable __autoreleasing *)error
 {
-//    NSError * failure = [_sessionInterface writeTaskWithSession:^NSError* (PowerAuthCoreSession * session) {
-//        PowerAuthCoreErrorCode ec = [session addExternalEncryptionKey:externalEncryptionKey];
-//        switch (ec) {
-//            case PowerAuthCoreErrorCode_Ok:
-//                _configuration.externalEncryptionKey = externalEncryptionKey;
-//                return nil;
-//            case PowerAuthCoreErrorCode_WrongParam:
-//                return PA2MakeError(PowerAuthErrorCode_WrongParameter, @"Invalid key size");
-//            case PowerAuthCoreErrorCode_WrongState:
-//                if (session.hasExternalEncryptionKey) {
-//                    return PA2MakeError(PowerAuthErrorCode_InvalidActivationState, @"EEK is already set");
-//                } else {
-//                    return PA2MakeError(session.hasValidActivation ? PowerAuthErrorCode_InvalidActivationState : PowerAuthErrorCode_MissingActivation, nil);
-//                }
-//            default:
-//                return PA2MakeError(PowerAuthErrorCode_Encryption, @"Failed to add EEK");
-//        }
-//    }];
-//    if (failure && error) {
-//        *error = failure;
-//    }
-//    return !failure;
-    // TODO: eek
+#if DEBUG
+    return [_sessionInterface writeBoolTaskWithSession:^BOOL(PowerAuthCoreSession * session, NSError ** error) {
+        return [session addExternalEncryptionKeyForTest:externalEncryptionKey error:error];
+    } error:error];
+#else
+    PA2SetError(error, PowerAuthErrorCode_Other, @"Function is not available in release SDK build");
     return NO;
+#endif
 }
-
-- (BOOL) removeExternalEncryptionKey:(NSError **)error
-{
-//    NSError * failure = [_sessionInterface writeTaskWithSession:^NSError* (PowerAuthCoreSession * session) {
-//        PowerAuthCoreErrorCode ec = [session removeExternalEncryptionKey];
-//        switch (ec) {
-//            case PowerAuthCoreErrorCode_Ok:
-//                _configuration.externalEncryptionKey = nil;
-//                return nil;
-//            case PowerAuthCoreErrorCode_WrongState:
-//                if (!session.hasExternalEncryptionKey) {
-//                    return PA2MakeError(PowerAuthErrorCode_InvalidActivationState, @"EEK is not set");
-//                } else {
-//                    return PA2MakeError(session.hasValidActivation ? PowerAuthErrorCode_InvalidActivationState : PowerAuthErrorCode_MissingActivation, nil);
-//                }
-//            default:
-//                // [session removeExternalEncryptionKey] never return WrongParam, so the default case is OK here.
-//                return PA2MakeError(PowerAuthErrorCode_Encryption, @"Failed to remove EEK");
-//        }
-//    }];
-//    if (failure && error) {
-//        *error = failure;
-//    }
-//    return !failure;
-    // TODO: eek
-    return NO;
-}
-
 @end
 
 #pragma mark - User Info

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKBaseTests.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKBaseTests.m
@@ -881,145 +881,111 @@
 }
 
 // MARK: - EEK
-// TODO: eek
-/*
-- (void) testExternalEncryptionKey
+
+- (void) testExternalEncryptionKeyDiscontinue
 {
     CHECK_TEST_CONFIG();
     
-    //
-    // This validates EEK usage.
-    //
+    NSError * error = nil;
+    BOOL result = NO;
     
-    PowerAuthSdkActivation * activation = [_helper createActivation:YES];
+    PowerAuthCoreData * goodEEK = [PowerAuthCoreSession generateFactorKekForProtocolVersion:PowerAuthCoreProtocolVersion_V3 error:nil];
+    PowerAuthCoreData * badEEK = [PowerAuthCoreSession generateFactorKekForProtocolVersion:PowerAuthCoreProtocolVersion_V4 error:nil];
+    
+    // Before activation, EEK flag is always false.
+    XCTAssertFalse(_sdk.hasExternalEncryptionKey);
+    
+    // Attempts to remove or add, should fail for all protocol versions
+    result = [_sdk removeExternalEncryptionKey:goodEEK error:&error];
+    XCTAssertFalse(result);
+    XCTAssertEqual(PowerAuthErrorCode_MissingActivation, error.powerAuthErrorCode);
+    
+    result = [_sdk addExternalEncryptionKeyForTest:goodEEK error:&error];
+    XCTAssertFalse(result);
+    XCTAssertEqual(PowerAuthErrorCode_MissingActivation, error.powerAuthErrorCode);
+    
+    PowerAuthSdkActivation * activation = [_helper createActivationWithFlags:TestActivationFlags_PersistWithFakeBiometry activationOtp:nil];
     if (!activation) {
         return;
     }
     
+    // By default, EEK is not set
     XCTAssertFalse(_sdk.hasExternalEncryptionKey);
     XCTAssertTrue([_helper checkForCorePassword:activation.credentials.password]);
-    
-    PowerAuthCoreData * eek = [PowerAuthCoreSession generateSignatureUnlockKey];
-    
-    NSError * error = nil;
-    BOOL result = [_sdk addExternalEncryptionKey:eek error:&error];
+    // Check biometry
+    result = [_helper validateAuthentication:_helper.authPossessionWithBiometry data:[@"data" dataUsingEncoding:NSUTF8StringEncoding] method:@"POST" uriId:@"/hello/hacker" online:YES cripple:0];
     XCTAssertTrue(result);
-    XCTAssertNil(error);
     
-    XCTAssertTrue(_sdk.hasExternalEncryptionKey);
-    XCTAssertTrue([_helper checkForCorePassword:activation.credentials.password]);
-    
-    result = [_sdk removeExternalEncryptionKey:&error];
-    XCTAssertTrue(result);
-    XCTAssertNil(error);
-    
-    XCTAssertFalse(_sdk.hasExternalEncryptionKey);
-    XCTAssertTrue([_helper checkForCorePassword:activation.credentials.password]);
-}
-
-- (void) testEEKFromConfiguration
-{
-    CHECK_TEST_CONFIG();
+    if (self.powerAuthAlgorithm == PowerAuthAlgorithm_LEGACY_P256) {
+        // V3 activations
         
-    //
-    // This validates EEK usage from the beginning.
-    //
-    
-    PowerAuthCoreData * eek = [PowerAuthCoreSession generateSignatureUnlockKey];
-    PowerAuthConfiguration * newConfig = [_sdk.configuration copy];
-    newConfig.externalEncryptionKey = eek;
-    _sdk = [_helper reCreateSdkInstanceWithConfiguration:newConfig biometricConfiguration:nil keychainConfiguration:nil clientConfiguration:nil];
-    XCTAssertTrue(_sdk.hasExternalEncryptionKey);
-    
-    PowerAuthSdkActivation * activation = [_helper createActivation:YES];
-    if (!activation) {
-        return;
+        // Try to remove EEK first
+        result = [_sdk removeExternalEncryptionKey:goodEEK error:&error];
+        XCTAssertFalse(result);
+        XCTAssertEqual(PowerAuthErrorCode_InvalidActivationState, error.powerAuthErrorCode);
+        // Try to add wrong sized EEK
+        result = [_sdk addExternalEncryptionKeyForTest:badEEK error:&error];
+        XCTAssertFalse(result);
+        XCTAssertEqual(PowerAuthErrorCode_WrongParameter, error.powerAuthErrorCode);
+        // Try with good EEK
+        error = nil;
+        result = [_sdk addExternalEncryptionKeyForTest:goodEEK error:&error];
+        XCTAssertTrue(result);
+        XCTAssertNil(error);
+        
+        XCTAssertTrue(_sdk.hasExternalEncryptionKey);
+        error = [AsyncHelper synchronizeAsynchronousBlock:^(AsyncHelper *waiting) {
+            [_sdk testCorePassword:activation.credentials.password callback:^(NSError * error) {
+                [waiting reportCompletion:error];
+            }];
+        }];
+        XCTAssertEqual(PowerAuthErrorCode_InvalidActivationState, error.powerAuthErrorCode);
+        
+        // simulate app restart
+        _sdk = [_helper reCreateSdkInstance];
+        
+        XCTAssertTrue(_sdk.hasExternalEncryptionKey);
+        // auth codes should not work
+        XCTAssertFalse([_helper checkForCorePassword:activation.credentials.password]);
+        // biometry
+        result = [_helper validateAuthentication:_helper.authPossessionWithBiometry data:[@"B10" dataUsingEncoding:NSUTF8StringEncoding] method:@"POST" uriId:@"/hello/hacker" online:YES cripple:0];
+        XCTAssertFalse(result);
+        // knowledge - offline
+        result = [_helper validateAuthentication:_helper.authPossessionWithKnowledge data:[@"0ffl1n3" dataUsingEncoding:NSUTF8StringEncoding] method:@"POST" uriId:@"/hello/hacker" online:NO cripple:0];
+        XCTAssertFalse(result);
+        
+        // Try to remove wrong sized EEK
+        result = [_sdk removeExternalEncryptionKey:badEEK error:&error];
+        XCTAssertFalse(result);
+        XCTAssertEqual(PowerAuthErrorCode_WrongParameter, error.powerAuthErrorCode);
+        XCTAssertTrue(_sdk.hasExternalEncryptionKey);
+        
+        // Try with good EEK
+        error = nil;
+        result = [_sdk removeExternalEncryptionKey:goodEEK error:&error];
+        XCTAssertTrue(result);
+        XCTAssertNil(error);
+        
+        XCTAssertFalse(_sdk.hasExternalEncryptionKey);
+        XCTAssertTrue([_helper checkForCorePassword:activation.credentials.password]);
+        // biometry
+        result = [_helper validateAuthentication:_helper.authPossessionWithBiometry data:[@"data" dataUsingEncoding:NSUTF8StringEncoding] method:@"POST" uriId:@"/hello/hacker" online:YES cripple:0];
+        XCTAssertTrue(result);
+        // knowledge - offline
+        result = [_helper validateAuthentication:_helper.authPossessionWithKnowledge data:[@"0ffl1n3" dataUsingEncoding:NSUTF8StringEncoding] method:@"POST" uriId:@"/hello/hacker" online:NO cripple:0];
+        XCTAssertTrue(result);
+
+    } else {
+        // V4 activations
+        // All EEK related methods should fail
+        result = [_sdk addExternalEncryptionKeyForTest:goodEEK error:&error];
+        XCTAssertFalse(result);
+        XCTAssertEqual(PowerAuthErrorCode_InvalidActivationState, error.powerAuthErrorCode);
+        result = [_sdk removeExternalEncryptionKey:goodEEK error:&error];
+        XCTAssertFalse(result);
+        XCTAssertEqual(PowerAuthErrorCode_InvalidActivationState, error.powerAuthErrorCode);
     }
-    
-    XCTAssertTrue([_helper checkForCorePassword:activation.credentials.password]);
-    
-    NSError * error = nil;
-    BOOL result = [_sdk removeExternalEncryptionKey:&error];
-    XCTAssertTrue(result);
-    XCTAssertNil(error);
-    XCTAssertFalse(_sdk.hasExternalEncryptionKey);
-
-    XCTAssertTrue([_helper checkForCorePassword:activation.credentials.password]);
 }
-
-- (void) testSetEEKBeforeActivation
-{
-    CHECK_TEST_CONFIG();
-    
-    //
-    // This validates when EEK is set before activation is created.
-    //
-    XCTAssertFalse(_sdk.hasExternalEncryptionKey);
-    PowerAuthCoreData * eek = [PowerAuthCoreSession generateSignatureUnlockKey];
-    NSError * error = nil;
-    BOOL result = [_sdk setExternalEncryptionKey:eek error:&error];
-    XCTAssertTrue(result);
-    XCTAssertNil(error);
-    XCTAssertTrue(_sdk.hasExternalEncryptionKey);
-    
-    PowerAuthSdkActivation * activation = [_helper createActivation:YES];
-    if (!activation) {
-        return;
-    }
-    
-    XCTAssertTrue([_helper checkForCorePassword:activation.credentials.password]);
-    
-    result = [_sdk removeExternalEncryptionKey:&error];
-    XCTAssertTrue(result);
-    XCTAssertNil(error);
-    XCTAssertFalse(_sdk.hasExternalEncryptionKey);
-
-    XCTAssertTrue([_helper checkForCorePassword:activation.credentials.password]);
-}
-
-- (void) testSetEEKAfterActivation
-{
-    CHECK_TEST_CONFIG();
-    
-    //
-    // This validates when EEK is set after activation is created.
-    //
-    
-    PowerAuthSdkActivation * activation = [_helper createActivation:YES];
-    if (!activation) {
-        return;
-    }
-    
-    XCTAssertFalse(_sdk.hasExternalEncryptionKey);
-    XCTAssertTrue([_helper checkForCorePassword:activation.credentials.password]);
-    
-    PowerAuthCoreData * eek = [PowerAuthCoreSession generateSignatureUnlockKey];
-    
-    NSError * error = nil;
-    BOOL result = [_sdk addExternalEncryptionKey:eek error:&error];
-    XCTAssertTrue(result);
-    XCTAssertNil(error);
-    
-    XCTAssertTrue(_sdk.hasExternalEncryptionKey);
-    XCTAssertTrue([_helper checkForCorePassword:activation.credentials.password]);
-
-    // Now re-instantiate SDK and try to set EEK manually
-    PowerAuthConfiguration * newConfig = [_sdk.configuration copy];
-    newConfig.externalEncryptionKey = nil;
-    _sdk = [_helper reCreateSdkInstanceWithConfiguration:newConfig biometricConfiguration:nil keychainConfiguration:nil clientConfiguration:nil];
-    XCTAssertFalse(_sdk.hasExternalEncryptionKey);
-    // Activation status should work
-    PowerAuthActivationStatus * status = [_helper fetchActivationStatus];
-    XCTAssertEqual(PowerAuthActivationState_Active, status.state);
-    // Now set EEK
-    result = [_sdk setExternalEncryptionKey:eek error:&error];
-    XCTAssertTrue(result);
-    XCTAssertNil(error);
-    
-    XCTAssertTrue(_sdk.hasExternalEncryptionKey);
-    XCTAssertTrue([_helper checkForCorePassword:activation.credentials.password]);
-}
-*/
 
 // MARK: - Request synchronization
 

--- a/proj-xcode/PowerAuth2Tests/PowerAuthConfigurationTests.m
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthConfigurationTests.m
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+@import PowerAuth2;
+@import PowerAuthCore;
+
+@interface PowerAuthConfigurationTests : XCTestCase
+@property (nonatomic, strong) NSString * goodSdkConfiguration;
+@property (nonatomic, strong) PowerAuthCoreData * goodEEK;
+@property (nonatomic, strong) PowerAuthCoreData * badEEK;
+@end
+
+
+@implementation PowerAuthConfigurationTests
+
+- (void) setUp
+{
+    _goodSdkConfiguration =
+        @"ARDV9ZPCmbBxQOuvwBEet0nnEIYRtwiuK6sEI58YecWmHcYEAUEEIOUWfl7mNjd72rmyrWcqNnPB"
+        @"8rT75WuAZDopD+5wSM7ibOvJ8zVolKJ3G45VvxFsBPxut118YPpNqyuKnpnuAAJhBLxTNONEcqW+"
+        @"Pgeps0YK3rGN2fDxkR/91Ovpl4H09ob1J59EP1N5RXIAxgDPjqTr9iLxAFQ/Sh+dJcmNT1CAUB12"
+        @"S0BCK2W0U3/q9CKbzzJMuNGRWTa9yIfqT78udJq4CAOHtjCCB7IwCwYJYIZIAWUDBAMSA4IHoQCr"
+        @"+GhdgN4woE6dXE0EAWI1/AgWrFgN5ty3p+m42q0g+VhvZLv5DvtPwEDyBxa1+gEuMdNaMNmYih36"
+        @"2DpZZof5kWgLLX59hV+4SfYrJgvMf4I+221hiUmdC19S+n8MHhi148WPdTQ6XS+P+qDEp8xKRIbp"
+        @"ZnL189QcHuxSWY5mHZYLJ8vOTQeTEifRT2S6n+mcqybT5mTiiSh0q/tumcHMmydEWbc82/kA4vPJ"
+        @"PwQ2hYRjUCZgKIHFklxmLlVNd2AMsx+KD/Fa/QPki79uAoAN+4E395MXUBz904l/ry+OD1dw/12n"
+        @"f0qOMcS0GgHzlDVfL6Nl/UEHZ8WNB70ryLyayUxLLG0vmFOhKJAZ4yJKkfKm32Ku8tUupn2QpJ7X"
+        @"drU7mop8dATcEOT3T6sFDoopCAbIoAJmU98uiauwIopCUVrOU1KoWYvW8LFSH/UlGXg6BdEfEvMW"
+        @"cQtBfHE/BgQLHmYVaaXqXCitL7Bz4FhDEpcVOWoxwcX/VN4/S8449Du/1LLUx5qAcS8iip8/YzUN"
+        @"4CYwuJmRPj1RM3m7IQlYrDaxHZ2ZZXYdoFUTkYEakYOyX2Iut6YaPO1A4my2Z2Avl/XzD3kN/wYI"
+        @"gig8gcp+QpJ1Za1+gK+J6ydMxT8h5oEv2vCTDEiwb2aHAX1kW8Kep0u+RtemZdOV6LUrBkvdGjTD"
+        @"0L3T/3cLZj6nzkS9VVje4qdWvUhkwPAldpYKpN0orAjyPKlp9h/qzSj859/uVTPN2gPhEgN0l1CB"
+        @"Fa781KALGIfMGY2sv2Z3WWPNtlwdiH9U7074TBNpWg1HD7ztZxr8lKbYTc38X54//UZwWjG8qAtT"
+        @"1KZh/WQJ1vN0AMmpbBmXf7vQfIhiMF5HJEgtshWPmUVGtG2CR37sTUFDRljZZycfVbIY7T6PQHQ2"
+        @"GE8lDUT9jUl4lGJq/1ebUfGvxY0jE1S8RAz7SxC9LTuf398NBj68AguH7kTk+YblkWhUPYHlpSNs"
+        @"MRERc9vYM+8YQ5+HOUvZLBUjSuEs9UAXSndcu6nXQILPYCAoHfgmR+XBQC0TTW29v070YRuOy6Gn"
+        @"AZxwLe6bbAGhoI5Pij8U3siEKCJFRSDeYdHYvDIeErnqzisnWcN8m3XWaVD/2My0jYd1Gc9v34JJ"
+        @"rbMS1PnqXGh8/s+Wz3gHnt3Qj9OaHXVy0JaDA15A62/G1rN1bXuriSLylYeRzlGuAEwS9oseTX/v"
+        @"rFvB8KiXFGNLJiJOl4AXkNi7tL1tkkWivffqa2NYZyazY2wbTkOpcHw7Z/gnOD5As7GQCQrySX/W"
+        @"bOfT5bTzD6RoYX6DUosf9v3kG58miSOCM9NnE7otgr9znNv7uHBN3ukqx7WZYib+wmN+EsM4ZZbV"
+        @"/M5YPQUlXzfLqCT7c1Tk/VVA2QJVKHwHAIBJZKaqs6i1wtyr1bVcFZpcQ4oabk3nl0vecZOYdEhW"
+        @"rKwBzVfW2FVFPsx4s3mFGLxTs4TUWj+G21DimE6WQuKsztIKanoPkda+uAfwWvEL/B2e71jurp8P"
+        @"yFSz2zD1rl36opHfBRkmlOY+s5TI7IgxTjvHdoY1m7DlfdmorEAiJnLmklCpPzVjMM08RZgsLcZk"
+        @"ilbDxkSF4Yb0UuAYZKaZEpGRZUAPhzxV3NessgB3FO/hjXZ9Jh2IwZecgfZRVLVvjgfXgGwjCMBI"
+        @"mRvSublX4p3qtD7iaHBqDEQL41IAhAC1v3LbS5AM7f12kiwS3byrcCQ0zDFTK4nTbSsWHQW5imMC"
+        @"0TqlsDGWLiupRZWBtpPXMqY9Z7NNqHkHVIh3D6b0S1vFdCU1ApEm9K9XWxtBi2x+tyWQ6HKDW2R8"
+        @"MbuY8/2Izver6rlnFsncLIUL8FVLZHJ2QlWAEM+gpeYzIKXm0eGyq0ZlzPoiAt6ivyTcENVbuQg5"
+        @"dZHRP7q6NH/DH+t64pycJjJNLB7xH44LnVc8SyC36wmeow7g4m7p2RSbJVN+xVeD1mlviQyRvLPa"
+        @"XKsm5xIIWX5t6zDprXMBLkj2UkiuoM6Hmed0vkS2erzGwKa6OcxhfHwoCBQgGiMSOJ2G/OVNgMmL"
+        @"HmoH2MR7SqlczO0hlKd3q4DYTZ+fogkOeo6PrG9Wr0mC9uX0QXpVGFq/3rhGTpqH4iPcfk0taTtK"
+        @"oabLyEb5MbzwY7Z2uw9Eqe2hPcJqpmVjkg5nCm4itufLp4uPDLqNx7yYb31M4vlCyLjLkjDcBLTu"
+        @"CAlaDiZlDPJpp308GcargrdBWRft5w5KUmrpcFu1uqLQZpuPPgNW1xzoCDjRQOk5jsnnH2sb6/z4"
+        @"68cPvlRCgPZQzQ2zvRPku31bTirR1iVI6zLlKZxyFEd7jgP+DwfvezWGx2VM3yrFhZSZlOXiEPgV"
+        @"5uAOvhpuCfnHrw1BKMyaikaRin7btLfU84Wvz909btyTs6hJzhT2plYYpp5wwXrl3KKhJDMAET+f"
+        @"qoFkbMm5o9KVPgYm4TXjSyx1CjgUtShxqyz8TEuYII0OFtFprstzE1dvuzi//fHM4tqQlb1RMVca"
+        @"tVMMcg+gxS6ZiSO0V/uZTchFQeCBe0rkIphL0MdbMS1A4st2YehkIz4OA4fXCKDadKmrGS/WszTL"
+        @"gNw2gg3ql3DlaKj/rwSKNjCCCjIwCwYJYIZIAWUDBAMTA4IKIQCc8aFWGLZ7eVG2adMiexGqyrPu"
+        @"eRRZ7nsq1R29Q2cIMYPWyaTEguOMU5wiGC97cXeerl/sC3gLDWAIznEVdhfFw8FmsNwDBtz7d4jO"
+        @"mFLEBt79QmJECPkvDcGKi5vicSjpGq4I55pGN0RjZNkuIM8lyGRlxft0FlS71xQwphY/37SXPuzA"
+        @"7P2gNfhzPT53OTJTRhxlKq61Sp26981+fHfAkMvL+2vegKSnhW14GnOeIQ5oabMNrF9niYrJWcT3"
+        @"CY+5TLWajHH0oqTtHh/UY3M6xl9lOlXmemOX+PXh1ce3xdPHJgGp6eBW+1tXal8TJYbXBdYfBY18"
+        @"rUVRVLj2Hb0YrUmuSjtZ5a5lzh0iiqjhKWEOMdMU44ZaqqBm+/KT4SYCZ/w3dgVwzmDNIR5QN8S8"
+        @"VRX13dZL45RMewL/mk2aZg7BdEYoy5hsRycP8dF491NQg5JxOt7338FRwDzzvCximmOh5Su1RHvm"
+        @"/CEgrZ3+2ee/5Wgpj+d4nVnwMvzr0lrlQA/XPh0FBJJ/XOfXw08HoT0xM0aADqCIP7XwVfuw6DQd"
+        @"n6L0XltZGE0pWDVfN98LDP/EEJLEvaPx1zJGhnFGYdaqDByolYhh2u52HrBZUpY+yBu1fAOLTkR6"
+        @"r7Rt01hAOGM7ciPfaFKRTtAMRbjOTJ0Jhmlk+Wh4DQWGTWJL4hOvSC8c4Qc7l657/6MS/Mcm3GND"
+        @"1tcW4F7ebWo9ybbQCsyg3vITlf5tI8OcHir3QMbcUYiqzI5vO0MnvF4aKH1Uk0raOuHgknBKCUUB"
+        @"liH/BuT2zdq+/46m1uxXcwe2rLPWAABXAqRmCpXwOX7aw1mNFHXSuSm7e3OPw/85rspns5Ppb5mI"
+        @"1kB1JOuh34bxzZeNHqbPYH5ng8xhTp6i/oSe8a3a28jqDX/7cvy332bllxmm3p4SZDQlmCX2A06e"
+        @"VjcNNwxQUbApqsiQgCRMO6CiJPRap2zcpxNwYtUpwDFqtxBnbXWXLxVnCtllpgxEEC6RLia13ds3"
+        @"R/o5+dQz0g3ZlSQSjyda0NxMshWScdrnKz64WFpXEM1StuhhHFmXTxc7Cp3EjaHnheHJLAzVWMXu"
+        @"YHaM23e41SNobVaDTxn2ngyc0q9isg0h2YZybq7vIOzXbkUOQM0Zha3BinZVhMG4F6ddaCNuEAoE"
+        @"QUOSGHwFFB1sZh+0gBze/2Z9KNIh+kvvt5u376DzCZALVpLxDGVDa09ZWDC5YChTHmV3k5NkbJ9B"
+        @"oM47KGqh8P4D24axTN6rAKN0eoQHsYf7/OPwgtehneefGX3JoWGsBDmOM0ti0kUpVwQVc/8GyRQl"
+        @"6RFt8wwgNSbFSi+kWdKg+ee7JmP1biUselWk0nKbZ+I49L9ZSuPYDL3HdeniKBzTMmG5SxaXa7sD"
+        @"LOmvTW82iuwFDp5mic7SxlaoqvIChGdvYGEpa6oGrArSM1yu7kbRbVyRgouTMIMfjPBwP+hhoC39"
+        @"w073xKGMNzpqFxZtcNjj5cWcBop7h/n+uXLHatFpTS8nnrxnNd5Bc1UdMKtzpL2+AHs6AYbnZd75"
+        @"O9Tmib40CII8/S0oASTFiLBEo4k5vaKk/84wU/kYWQoLYMsJ3Q3+NIzygW3GefzTbCla//pd8gDG"
+        @"eX9peMs6woFxaV9OPq0gmu/MAveD6Mjz+VyPU69lMgdq6Bsste6M6xUeMKNvE5Wm7ZiReS3AYisU"
+        @"NeNa3k7q5nfe5lvkKoFkHPhjDw25eGFY7n/KQ0uoM6hOaeWSv2Lq2oEUhw/dYIokbVoeHW0zWc5J"
+        @"/WYVbCfUL0U6ci/D6Wz6GfiPpe7j+JrwVFUVDF4P6ZZzTqo6Oum7lZpC5LCmLdWWTacGGaBp0H9S"
+        @"kcxi+Nppv5PtSe4KJOpni0VdFILjvZQT332Zn8K36KYjyeOjiq8SyxC/fpTM+bWBSq/4iuIdLxHo"
+        @"J00fnGawIvQKYrRZCx+BJ93xlKnMsEslfjb6kwmI/gd1Rbcxl/5uTTYrwDD3T4YDjKi52gMpejph"
+        @"fbXll/+zBPrGbLoyZpJetVtDEOumiaLNRtD5vIeOLbaYF65IO46wcbo7Kg3kGojdNJbl+4bZKBnU"
+        @"0NmdOOW/GwmbhvKyoLw0Gu+XaT39xWGyPV25CmUOpi/oSGiCSbSt3QTnrkeeFC6ELEE5p/UklUEd"
+        @"nRacb089piy08jn1KS5phs9TEmzdygt7YIepde/4UJDgC45judJ0Jn5nsowttk9rho3KP3nyUrep"
+        @"MZ4nTgkaf5CREpde6G8zZE5VKL2/DWWlSvAnk0gAR/6+BqqD9VEFSjhCNSMr0Y46SulTGALselZ0"
+        @"CCMx6VbUd2NMkIW7wnmzsV9zon96GcfrzDDcrK76LhzKMC/rzj+Cf1/Gms/rek1uk+H0QsnRGPWK"
+        @"oT7N9TNJPoSjKBlRCWhyu5jIQ1oT91l0bilGmAFocnamISRFouS+K1cbSJY0t+mb+raT4SeyG5gA"
+        @"nTpquEXeslVKwfaCPd/B4LBqFwD209ckP7Fg9BO40Hlu9QBPg/GLn5yhpD7gO+mpu6hJIDMKIkIB"
+        @"6E+dUB9DOh1G5EC7k3Eqba2znMjgCeRGHjjozvj/s1xttDPrT/wLZGqqhOVkyhzAsEh0lrbijvKg"
+        @"yu+4x3PShsoceLD66vC8uAPcMVU7tWuUXHVa1JiMwkltXePACSIwGxRlIbvF+j5wv7CNel0c18PI"
+        @"4NgPFVXfQFF4be/xAr8mb3jZz3yKewJvc5oW9D98GoYMh5UH4RN9OIaXd9GHSZ3vKKuUf6RcvP8Q"
+        @"tlBWlH73/OiQ1H7pFWyd7t+pEb+RzFUUoLVrW0oEB45g3UNNqb/zysgaHBbglVs8qbvTJ9Wlm2mx"
+        @"nINWrJsBLPTPUjXNBKMTMm1Brf4UOrKtHAQqySMJ3GlpM2hjq2FkThHNEbZPfFCIU3K0ucbcMSH5"
+        @"8YtLk2PSkytguOoKoHDXmJ+GS5Iy0JHoJt3tjfvHGsfzXu3zd7V5OozD/yqRfHioYXPW+QkU9dFy"
+        @"UNQAp1UaSNXXLRFGCak9vuTKMa3CT+uLp2SDoWWZv9W//DaPCiM/nIpQcCy8yeepqcQrSeVGSwLM"
+        @"ZcSUm13OXBaYlVcHWTosq08sizIX7uEeyJrT0rSVHZLx14YEh/WbQnx2TKTSVArgJ+RzCCL1+cqL"
+        @"aSVdHURZ0fyC5XA5AHcXQz5wtbO8Kgb3IC0d9O1SdTL2F5mzbYz86i3hXDNP/OQ4DmKCRti9RsjL"
+        @"xuILKkGQrvMqXTdnPVVFwJQ+3T4YZ2tPnisVKePJpCxpeZWLo+VaTQSvxbMYml97kfP4Bd3+8ngH"
+        @"q+jg3A2xFmu0Kv2CJY8eKi+Hjg5DYbqWQNUXHbv7uUuVHCgJmT6azse4x357y4qEdzXDrslMvPyg"
+        @"jcmIgTBMNVsGjO7JhZR4g5WmUvQ7/BveNv0KXX7MLoeWqbGVq+m3Ap14pZ387ajzR+35W8aDRWgY"
+        @"gKU17hnlpfo=";
+    _goodEEK = [PowerAuthCoreSession generateFactorKekForProtocolVersion:PowerAuthCoreProtocolVersion_V3 error:nil];
+    _badEEK = [PowerAuthCoreSession generateFactorKekForProtocolVersion:PowerAuthCoreProtocolVersion_V4 error:nil];
+}
+
+- (void) testDiscontinuedEEK
+{
+    PowerAuthConfiguration * config = [[PowerAuthConfiguration alloc] initWithInstanceId:@"default"
+                                                                         baseEndpointUrl:@"https://test.server.org/powerauth"
+                                                                           configuration:self.goodSdkConfiguration];
+    XCTAssertTrue([config validateConfiguration]);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    config.externalEncryptionKey = _goodEEK;
+    XCTAssertTrue([config validateConfiguration]);
+    config.externalEncryptionKey = _badEEK;
+    XCTAssertTrue([config validateConfiguration]);
+#pragma clang diagnostic pop
+}
+
+@end

--- a/proj-xcode/PowerAuthCore/PowerAuthCoreSession.h
+++ b/proj-xcode/PowerAuthCore/PowerAuthCoreSession.h
@@ -526,12 +526,36 @@
 
 #pragma mark - External Encryption Key
 
-/**
- Returns true if EEK (external encryption key) is set.
- 
- This function access the session's state, so read access must be guaranteed.
- */
+/// Contains YES if EEK (external encryption key) is set.
+///
+/// This function access the session's state, so read access must be guaranteed.
 @property (nonatomic, assign, readonly) BOOL hasExternalEncryptionKey;
+
+
+/// Remove EEK if factor keys are still protected with EEK. The method throws an exception
+/// if activation is not present, or if factor keys are not protected with EEK.
+///
+/// This function changes the session's state, so write access must be guaranteed.
+///
+/// - Parameters:
+///   - eek: EEK previously used for the factor keys protection.
+///   - error: Pointer where error is set in case of failure.
+/// - Returns: YES in case of success, NO otherwise.
+- (BOOL) removeExternalEncryptionKey:(nonnull PowerAuthCoreData*)eek
+                               error:(NSError *_Nullable*_Nullable)error;
+
+/// Add external encryption key for testing purposes. The method should not be used in the
+/// release build. The legacy activation must be present and the size of EEK must match the size
+/// of factor keys used in V3.3 protocol version (e.g. 16 bytes).
+///
+/// This function changes the session's state, so write access must be guaranteed.
+///
+/// - Parameters:
+///   - eek: EEK to apply
+///   - error: Pointer where error is set in case of failure.
+/// - Returns: YES in case of success, NO otherwise.
+- (BOOL) addExternalEncryptionKeyForTest:(nonnull PowerAuthCoreData*)eek
+                                   error:(NSError *_Nullable*_Nullable)error;
 
 #pragma mark - Services
 

--- a/proj-xcode/PowerAuthCore/PowerAuthCoreSession.mm
+++ b/proj-xcode/PowerAuthCore/PowerAuthCoreSession.mm
@@ -804,7 +804,44 @@ static void _ReportError(PowerAuthCoreError code, NSString * message, NSError **
 
 - (BOOL) hasExternalEncryptionKey
 {
-    return NO;
+    if (![self requireReadAccess:nil]) {
+        return NO;
+    }
+    return _session->hasExternalEncryptionKey();
+}
+
+- (BOOL) removeExternalEncryptionKey:(nonnull PowerAuthCoreData*)eek
+                               error:(NSError *_Nullable*_Nullable)error
+{
+    if (![self requireWriteAccess:error]) {
+        return NO;
+    }
+    try {
+        _session->removeExternalEncryptionKey(eek.byteArrayRef);
+        return YES;
+    } catch (...) {
+        if (error) {
+            *error = BuildNSErrorFromException();
+        }
+        return NO;
+    }
+}
+
+- (BOOL) addExternalEncryptionKeyForTest:(nonnull PowerAuthCoreData*)eek
+                                   error:(NSError *_Nullable*_Nullable)error
+{
+    if (![self requireWriteAccess:error]) {
+        return NO;
+    }
+    try {
+        _session->addExternalEncryptionKeyForTest(eek.byteArrayRef);
+        return YES;
+    } catch (...) {
+        if (error) {
+            *error = BuildNSErrorFromException();
+        }
+        return NO;
+    }
 }
 
 #pragma mark - Services

--- a/src/PowerAuth/Session.cpp
+++ b/src/PowerAuth/Session.cpp
@@ -17,6 +17,8 @@
 #include <PowerAuth/Session.h>
 #include "task/GetActivationStatusTask.h"
 #include "task/ProtocolUpgradeTask.h"
+// EEK
+#include "v3/LegacyUKE.h"
 
 namespace powerAuth {
 
@@ -412,6 +414,80 @@ RequestPtr Session::jwsSignData(const CredentialsPtr& credentials,
 {
     LOCK_GUARD();
     return _context->signatureService().jwsSignData(credentials, data_to_sign, data_type, key_to_use, use_compact_form);
+}
+
+// MARK: - EEK
+
+bool Session::hasExternalEncryptionKey() const noexcept
+{
+    LOCK_GUARD();
+    auto& sd = _context->sessionData();
+    if (sd.hasPersistentData(Version_V3)) {
+        return sd.persistentData().v3().flags.usesExternalKey == 1;
+    }
+    return false;
+}
+
+/// Enables or disables EEK in V3 persistent data.
+/// - Parameters:
+///   - pd: Persistent data structure.
+///   - eek: External encryption key.
+///   - enable: Set 1 to enable, or 0 to disable EEK.
+static void EEK_SetEnabled(PersistentData::V3& pd, const cc7::ByteRange& eek, cc7::byte enable)
+{
+    auto& uke = algorithms().v3.uke();
+    auto has_biometry = !pd.cBiometryKey.empty();
+    cc7::ByteArray knowledge;
+    cc7::ByteArray biometry;
+    if (enable) {
+        knowledge = uke.wrap(eek, pd.cKnowledgeKey);
+        if (has_biometry) {
+            biometry = uke.wrap(eek, pd.cBiometryKey);
+        }
+    } else {
+        knowledge = uke.unwrap(eek, pd.cKnowledgeKey);
+        if (has_biometry) {
+            biometry = uke.unwrap(eek, pd.cBiometryKey);
+        }
+    }
+    // Update PD
+    pd.cKnowledgeKey = knowledge;
+    pd.cBiometryKey = biometry;
+    pd.flags.usesExternalKey = enable;
+}
+
+void Session::removeExternalEncryptionKey(const cc7::ByteRange &eek)
+{
+    LOCK_GUARD();
+    auto& sd = _context->sessionData();
+    if (!sd.hasPersistentData()) {
+        throw Exception(EC_MissingActivation);
+    }
+    if (!sd.hasPersistentData(Version_V3)) {
+        throw Exception(EC_WrongActivationState, "Removing EEK requires legacy activation");
+    }
+    auto& pd = sd.persistentData().v3();
+    if (!pd.flags.usesExternalKey) {
+        throw Exception(EC_WrongActivationState, "EEK is not present in activation data");
+    }
+    EEK_SetEnabled(pd, eek, 0);
+}
+
+void Session::addExternalEncryptionKeyForTest(const cc7::ByteRange &eek)
+{
+    LOCK_GUARD();
+    auto& sd = _context->sessionData();
+    if (!sd.hasPersistentData()) {
+        throw Exception(EC_MissingActivation);
+    }
+    if (!sd.hasPersistentData(Version_V3)) {
+        throw Exception(EC_WrongActivationState, "Adding EEK requires legacy activation");
+    }
+    auto& pd = sd.persistentData().v3();
+    if (pd.flags.usesExternalKey) {
+        throw Exception(EC_WrongActivationState, "EEK is already present in activation data");
+    }
+    EEK_SetEnabled(pd, eek, 1);
 }
 
 // MARK: - Utilities

--- a/src/PowerAuth/v3/AuthenticationServiceV3.cpp
+++ b/src/PowerAuth/v3/AuthenticationServiceV3.cpp
@@ -53,6 +53,11 @@ HttpHeader AuthenticationServiceV3::calculateOnlineAuthenticationHeader(const Cr
         throw Exception(EC_PendingProtocolUpgrade, "Authentication header calculation is not allowed during pending protocol upgrade");
     }
     
+    auto& pd = _session_data->persistentData().v3();
+    if (pd.flags.usesExternalKey) {
+        throw Exception(EC_WrongActivationState, "Authentication header calculation is not allowed while EEK is set");
+    }
+    
     auto nonce = cc7::crypto::GetRandomData(v3::ONLINE_AUTH_CODE_NONCE_LENGTH);
     AuthenticationHeaderData header_data {
         Version_V3,
@@ -67,7 +72,6 @@ HttpHeader AuthenticationServiceV3::calculateOnlineAuthenticationHeader(const Cr
                                                                        body,
                                                                        _configuration->applicationSecret());
     
-    auto& pd = _session_data->persistentData().v3();
     auto secrets = _key_provider->unlockSecretKeys(credentials);
     auto factor_keys = prepareFactorKeys(*secrets, credentials.factors());
     auto auth_code = CalculateOnlineAuthenticationCode(factor_keys, pd.authCodeCounterData, normalized_data);
@@ -100,15 +104,18 @@ std::string AuthenticationServiceV3::calculateOfflineAuthenticationCode(const Cr
         throw Exception(EC_PendingProtocolUpgrade, "Offline authentication code calculation is not allowed during protocol upgrade");
     }
     
+    auto& pd = _session_data->persistentData().v3();
+    if (pd.flags.usesExternalKey) {
+        throw Exception(EC_WrongActivationState, "Offline authentication code calculation is not allowed while EEK is set");
+    }
+    
     auto normalized_data = common::NormalizeDataForAuthCodeCalculation("POST",
                                                                        auth_data.uriIdentifier,
                                                                        auth_data.offlineNonce,
                                                                        data,
                                                                        common::PA_OFFLINE_APP_SECRET);
     
-    auto& pd = _session_data->persistentData().v3();
     auto secrets = _key_provider->unlockSecretKeys(credentials);
-    
     auto factor_keys = prepareFactorKeys(*secrets, credentials.factors());
     auto auth_code = CalculateOfflineAuthenticationCode(factor_keys, pd.authCodeCounterData, normalized_data, auth_data.authenticationCodeLength);
     

--- a/src/PowerAuthJni/CoreSessionJNI.cpp
+++ b/src/PowerAuthJni/CoreSessionJNI.cpp
@@ -530,6 +530,37 @@ CC7_JNI_METHOD_PARAMS(jobject, jwsSignData, jbyteArray data, jstring dataType, j
     NH_CATCH(nullptr)
 }
 
+// EEK
+
+CC7_JNI_METHOD(jboolean, hasExternalEncryptionKey)
+{
+    NH_TRY
+    {
+        return THIS_OBJ()->hasExternalEncryptionKey();
+    }
+    NH_CATCH_RT_ONLY(false)
+}
+
+CC7_JNI_METHOD_PARAMS(void, removeExternalEncryptionKey, jobject eek)
+{
+    NH_TRY
+    {
+        jni.requireParameter(eek, "eek");
+        THIS_OBJ()->removeExternalEncryptionKey(CopyFromSecureData(jni, eek));
+    }
+    NH_CATCH()
+}
+
+CC7_JNI_METHOD_PARAMS(void, addExternalEncryptionKeyForTest, jobject eek)
+{
+    NH_TRY
+    {
+        jni.requireParameter(eek, "eek");
+        THIS_OBJ()->addExternalEncryptionKeyForTest(CopyFromSecureData(jni, eek));
+    }
+    NH_CATCH()
+}
+
 // Services
 
 CC7_JNI_METHOD(jobject, getEncryptorFactory)


### PR DESCRIPTION
This PR discontinues active usage of EEK feature (External Encryption Key). After this change, application developers can only safely remove EEK from the activation. There's no option to add the key back to the activation. The removal process works only for V3 activations.

The change is implemented for both platforms.