### PR TITLE
Recovery from failed activation confirm

### DIFF
--- a/include/PowerAuth/ActivationService.h
+++ b/include/PowerAuth/ActivationService.h
@@ -53,7 +53,7 @@ public:
     ///            then the protocol has no such endpoint defined and activation is confirmed immediately.
     /// - Throws:
     ///   - `Exception` in case that activation cannot be confirmed.
-    virtual RequestPtr confirmActivation(InitialCredentialsPtr credentials) = 0;
+    virtual RequestPtr confirmActivation(const InitialCredentialsPtr& credentials) = 0;
     
     /// Calculate human readable fingerprint from device's and server's public keys.
     ///
@@ -78,7 +78,7 @@ public:
     /// - Returns: Request data for remove activation endpoint.
     /// - Throws:
     ///   - `Exception` in case of failure.
-    virtual RequestPtr removeActivation(CredentialsPtr credentials) = 0;
+    virtual RequestPtr removeActivation(const CredentialsPtr& credentials) = 0;
     
     /// Change user's password from old to new one.
     ///
@@ -89,7 +89,7 @@ public:
     ///            then the protocol has no such endpoint defined and password is changed immediately.
     /// - Throws:
     ///   - `Exception` in case of failure.
-    virtual RequestPtr changePassword(PasswordPtr old_password, PasswordPtr new_password) = 0;
+    virtual RequestPtr changePassword(const PasswordPtr& old_password, const PasswordPtr& new_password) = 0;
     
     /// Remove biometric factor.
     ///
@@ -100,7 +100,7 @@ public:
     /// - Throws:
     ///   - `Exception` in case of failure.
 
-    virtual RequestPtr addBiometricFactor(PasswordPtr password, const cc7::ByteRange& new_biometry_kek) = 0;
+    virtual RequestPtr addBiometricFactor(const PasswordPtr& password, const cc7::ByteRange& new_biometry_kek) = 0;
 
     /// Remove biometric factor.
     ///

--- a/include/PowerAuth/ActivationStatus.h
+++ b/include/PowerAuth/ActivationStatus.h
@@ -97,6 +97,13 @@ public:
     /// Contains state of biometric factor on the server.
     BiometricFactor biometricFactor() const noexcept;
 
+    /// Contains information whether the server expects activation confirmation.
+    bool isPendingActivationConfirm() const noexcept;
+    
+    /// Contains information whether the server no longer supports the current algorithm
+    /// used in activation.
+    bool isUnsupportedAlgorithm() const noexcept;
+    
     /// Contains information whether the protocol upgrade is available for activation.
     bool isProtocolUpgradeAvailable() const noexcept;
     
@@ -194,6 +201,7 @@ private:
     cc7::byte _max_fail_count;
     cc7::byte _upgrade_version;
     bool _is_pending_activation_confirm;
+    bool _is_unsupported_algorithm;
     bool _is_pending_upgrade_confirm;
     bool _is_protocol_upgrade_available;
     

--- a/include/PowerAuth/Session.h
+++ b/include/PowerAuth/Session.h
@@ -125,11 +125,11 @@ public:
     
     /// Confirm PowerAuth activation with initial credentials.
     /// - Parameter credentials: Initial credentials.
-    /// - Returns: Request data for confirm activation endpoint. If returned pointer is `nullptr`
+    /// - Returns: Task object for confirm activation endpoint. If returned pointer is `nullptr`
     ///            then the protocol doesn't support activation confirmation.
     /// - Throws:
     ///   - `Exception` in case that activation cannot be confirmed.
-    RequestPtr confirmActivation(InitialCredentialsPtr credentials);
+    TaskPtr confirmActivation(const InitialCredentialsPtr& credentials);
 
     /// Get information whether the session has pending create activation task.
     /// To complete activation, call `confirmActivation()`.

--- a/include/PowerAuth/Task.h
+++ b/include/PowerAuth/Task.h
@@ -111,7 +111,9 @@ protected:
     void setNextRequest(const RequestPtr& request, int tag, int flags);
     
     /// Set task as completed.
-    void setCompleted() noexcept;
+    /// - Parameters:
+    ///   - clear_failure: If `true`, then any previous request failure will be cleared.
+    void setCompleted(bool clear_failure = false) noexcept;
     
     // Overridable methods
     

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BaseSdkTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BaseSdkTest.java
@@ -36,16 +36,12 @@ import io.getlime.security.powerauth.integration.support.model.Activation;
 import io.getlime.security.powerauth.integration.support.model.ActivationDetail;
 import io.getlime.security.powerauth.networking.interfaces.ICancelable;
 import io.getlime.security.powerauth.sdk.PowerAuthActivation;
+import io.getlime.security.powerauth.sdk.PowerAuthAuthentication;
 import io.getlime.security.powerauth.system.PowerAuthSystem;
 
 import static org.junit.Assert.*;
 
 public class BaseSdkTest extends BaseTest {
-
-    @PowerAuthAlgorithm
-    public int getCurrentAlgorithm() {
-        return powerAuthSDK.getCurrentAlgorithm();
-    }
 
     // Using PowerAuthActivation
 
@@ -258,6 +254,97 @@ public class BaseSdkTest extends BaseTest {
                 throw new Exception("Activation is in invalid state after commit. State = " + activationStatus.getState());
             }
         }
+    }
+
+    // Recovery from failed confirm
+
+    /**
+     * Create activation and expect failure at persist step.
+     * @param shouldPass true if process should succeed.
+     * @throws Exception In case of failure.
+     */
+    public void createActivationAndExpectPersistFailure(boolean shouldPass) throws Exception {
+        Activation activationData = activationHelper.initActivation();
+        PowerAuthActivation activation = PowerAuthActivation.Builder.activation(activationData.getActivationCode()).build();
+        CreateActivationResult createResult = AsyncHelper.await(resultCatcher -> {
+            powerAuthSDK.createActivation(activation, new ICreateActivationListener() {
+                @Override
+                public void onActivationCreateSucceed(@NonNull CreateActivationResult result) {
+                    resultCatcher.completeWithResult(result);
+                }
+
+                @Override
+                public void onActivationCreateFailed(@NonNull Throwable t) {
+                    resultCatcher.completeWithError(t);
+                }
+            });
+        });
+        PowerAuthAuthentication initialAuthentication = PowerAuthAuthentication.persistWithPassword(activationHelper.prepareAuthentications().get(0));
+        final AsyncHelper.Execution<Boolean> persistActivation = resultCatcher -> {
+            powerAuthSDK.persistActivationWithAuthentication(testHelper.getContext(), initialAuthentication, new IPersistActivationListener() {
+                @Override
+                public void onPersistActivationSucceeded() {
+                    resultCatcher.completeWithResult(true);
+                }
+
+                @Override
+                public void onPersistActivationFailed(@NonNull Throwable throwable) {
+                    resultCatcher.completeWithResult(false);
+                }
+
+                @Override
+                public void onPersistActivationCancelled(boolean userCancel) {
+                    resultCatcher.completeWithResult(false);
+                }
+            });
+        };
+        boolean success = AsyncHelper.await(persistActivation);
+        assertEquals(shouldPass, success);
+        if (!shouldPass) {
+            // retry the operation
+            clearAllSimulateFailures();
+            success = AsyncHelper.await(persistActivation);
+            assertTrue(success);
+        }
+        activationHelper.cleanupAfterTest();
+        clearAllSimulateFailures();
+    }
+
+    @Test
+    public void testPersistActivationFailRecovery() throws Exception {
+        if (getCurrentAlgorithm() == PowerAuthAlgorithm.LEGACY_P256) {
+            System.out.println("Test not available for  LEGACY_P256");
+            return;
+        }
+        final String confirmEndpoint = "/activation/confirm";
+        final String statusEndpoint = "/activation/status";
+        final String keystoreEndpoint = "/keystore/create";
+
+        // one failure at confirm send, no failure at status
+        simulateNetworkErrorOnSend(confirmEndpoint, 1);
+        createActivationAndExpectPersistFailure(true);
+
+        // one failure at confirm send, one failure at /keystore/create (prerequisite for status)
+        simulateNetworkErrorOnSend(confirmEndpoint, 1);
+        simulateNetworkErrorOnSend(keystoreEndpoint, 1);
+        createActivationAndExpectPersistFailure(false);
+
+        // 2 failures at confirm send, no failure at status. We should recovery from this.
+        simulateNetworkErrorOnSend(confirmEndpoint, 2);
+        createActivationAndExpectPersistFailure(true);
+
+        // 3 failures at confirm send, no failure at status. Out of recovery attempts
+        simulateNetworkErrorOnSend(confirmEndpoint, 3);
+        createActivationAndExpectPersistFailure(false);
+
+        // one failure at confirm, one failure at status. Cannot recovery here
+        simulateNetworkErrorOnSend(confirmEndpoint, 1);
+        simulateNetworkErrorOnSend(statusEndpoint, 1);
+        createActivationAndExpectPersistFailure(false);
+
+        // failure at confirm receive, so the server processed the confirmation
+        simulateNetworkErrorOnReceive(confirmEndpoint);
+        createActivationAndExpectPersistFailure(true);
     }
 
     // Remove activation

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreRequest.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreRequest.java
@@ -255,7 +255,7 @@ public class CoreRequest<TResponse> extends NativeObject {
             this.failure = failure;
         }
         @CoreErrorCode final int errorCode;
-        if (failure instanceof CoreErrorCode) {
+        if (failure instanceof CoreException) {
             errorCode = ((CoreException)failure).getErrorCode();
         } else {
             errorCode = CoreErrorCode.OTHER;

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreRequest.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreRequest.java
@@ -29,7 +29,7 @@ public class CoreRequest<TResponse> extends NativeObject {
     /**
      * Contains last failure produced in the request object.
      */
-    private CoreException failure;
+    private Throwable failure;
 
     /**
      * Contains response object if this kind of request provide some response object.
@@ -48,8 +48,8 @@ public class CoreRequest<TResponse> extends NativeObject {
     private final long responseBuilderHandle;
 
     /**
-     * Construct object with handle to native object. This is a designated constructor used from JNI,
-     * when C++ object is being wrapped into Java object.
+     * Construct object with handle to native request object. This is a designated constructor
+     * used from JNI, when C++ object is being wrapped into Java object.
      *
      * @param nativeObjectHandle Handle to native object.
      */
@@ -58,6 +58,13 @@ public class CoreRequest<TResponse> extends NativeObject {
         this.responseBuilderHandle = NATIVE_NULL;
     }
 
+    /**
+     * Construct object with handle to native request object and with handle to a response object
+     * builder. This is a designated constructor used from JNI, when C++ object is being wrapped
+     * into Java object.
+     * @param nativeObjectHandle Handle to native request object.
+     * @param responseBuilderHandle Handle to native response builder.
+     */
     protected CoreRequest(long nativeObjectHandle, long responseBuilderHandle) {
         super(nativeObjectHandle);
         this.responseBuilderHandle = responseBuilderHandle;
@@ -158,7 +165,7 @@ public class CoreRequest<TResponse> extends NativeObject {
      * @return Exception with reason of request or response processing failure.
      */
     @Nullable
-    public CoreException getFailure() {
+    public Throwable getFailure() {
         return failure;
     }
 
@@ -233,9 +240,29 @@ public class CoreRequest<TResponse> extends NativeObject {
     /**
      * Set request as failed. You have to call this method when the HTTP request ends with
      * external failure, such as non-200 status code is received.
+     * @param errorCode Error code to pass to C++ exception.
+     * @param message Message to pass to the C++ exception.
      */
-    public native void setFailed();
+    private native void setFailed(@CoreErrorCode int errorCode, @Nullable String message);
 
+    /**
+     * Set request as failed. You have to call this method when the HTTP request ends with
+     * external failure, such as non-200 status code is received.
+     * @param failure External exception to keep in the response object.
+     */
+    public void setFailed(@Nullable Throwable failure) {
+        if (failure != null && this.failure == null) {
+            this.failure = failure;
+        }
+        @CoreErrorCode final int errorCode;
+        if (failure instanceof CoreErrorCode) {
+            errorCode = ((CoreException)failure).getErrorCode();
+        } else {
+            errorCode = CoreErrorCode.OTHER;
+        }
+        final String message = failure != null ? failure.getMessage() : null;
+        setFailed(errorCode, message);
+    }
 
     /**
      * Native request preparation function.

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreSession.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreSession.java
@@ -224,12 +224,12 @@ public class CoreSession extends NativeObject {
      *
      * @param password User's password.
      * @param biometryKek Optional biometric factor KEK. If null then this session will not have biometry configured.
-     * @return {@link CoreRequest} object containing all required information for activation confirmation.
+     * @return {@link CoreTask} object for activation confirmation.
      * @throws CoreException In case of failure.
      */
     @Nullable
-    public native CoreRequest<Object> confirmActivation(@NonNull Password password,
-                                                        @Nullable SecureData biometryKek) throws CoreException;
+    public native CoreTask<Object> confirmActivation(@NonNull Password password,
+                                                     @Nullable SecureData biometryKek) throws CoreException;
 
     /**
      * Remove activation from the server.

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreTask.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreTask.java
@@ -35,6 +35,13 @@ public class CoreTask<TResponse> extends NativeObject {
         this.responseBuilderHandle = NATIVE_NULL;
     }
 
+    /**
+     * Construct object with handle to native task object and handle to native response object
+     * builder. This is a designated constructor used from JNI, when C++ object is being wrapped
+     * into Java object.
+     * @param nativeObjectHandle Handle to native task object.
+     * @param responseBuilderHandle Handle to native response object builder.
+     */
     protected CoreTask(long nativeObjectHandle, long responseBuilderHandle) {
         super(nativeObjectHandle);
         this.responseBuilderHandle = responseBuilderHandle;
@@ -55,7 +62,7 @@ public class CoreTask<TResponse> extends NativeObject {
     /**
      * Contains last failure produced in the request object.
      */
-    private CoreException failure;
+    private Throwable failure;
 
     /**
      * Contains response object if this kind of task provide some response object.
@@ -145,7 +152,7 @@ public class CoreTask<TResponse> extends NativeObject {
      * @throws CoreException In case of failure.
      */
     @Nullable
-    public CoreRequest<Object> getNextRequest() throws CoreException {
+    public CoreRequest<TResponse> getNextRequest() throws CoreException {
         try {
             return getNextRequestImpl();
         } catch (CoreException e) {
@@ -161,5 +168,5 @@ public class CoreTask<TResponse> extends NativeObject {
      * @throws CoreException In case of failure.
      */
     @Nullable
-    private native CoreRequest<Object> getNextRequestImpl() throws CoreException;
+    private native CoreRequest<TResponse> getNextRequestImpl() throws CoreException;
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -829,25 +829,25 @@ public class PowerAuthSDK {
             if (password == null) {
                 throw new PowerAuthErrorException(PowerAuthErrorCodes.WRONG_PARAMETER, "Password must be set for persist activation operation");
             }
-            final CoreRequest<Object> request = mSession.confirmActivation(password, authentication.getBiometryFactorRelatedKey());
+            final CoreTask<Object> task = mSession.confirmActivation(password, authentication.getBiometryFactorRelatedKey());
             if (listener == null) {
                 // @Deprecated 2.0.0
                 // Listener is not provided, so application is still using deprecated synchronous API.
-                if (request != null) {
-                    // Persist is unfortunately asynchronous, so we cannot continue. Cancel the request and report error.
-                    request.cancel();
+                if (task != null) {
+                    // Persist is unfortunately asynchronous, so we cannot continue. Cancel the task and report error.
+                    task.cancel();
                     throw new PowerAuthErrorException(PowerAuthErrorCodes.WRONG_PARAMETER, "Synchronous persist is not supported at this protocol version");
                 }
                 return null;
             }
-            if (request == null) {
+            if (task == null) {
                 // This is legit for V3 activations. Persist doesn't require HTTP communication with the server.
                 saveSerializedState();
                 dispatchCallback(listener::onPersistActivationSucceeded);
                 return null;
             }
-            // So far, so good, execute the request.
-            return mClient.post(request, new INetworkResponseListener<>() {
+            // So far, so good, execute the task.
+            return mClient.post(task, new INetworkResponseListener<>() {
                 @Override
                 public void onNetworkResponse(@Nullable Object o) {
                     saveSerializedState();

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/CoreHttpClient.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/CoreHttpClient.java
@@ -160,6 +160,7 @@ public class CoreHttpClient {
             // multiple tasks including an actual request execution.
             final CompositeCancelableTask compositeTask = new CompositeCancelableTask(true);
             compositeTask.setCancelCallback(() -> {
+                setCoreRequestFinished(request, null);
                 callbackDispatcher.dispatchCallback(listener::onCancel);
             });
             // Now determine what type of task should be executed before an actual task.
@@ -175,7 +176,7 @@ public class CoreHttpClient {
 
                     @Override
                     public void onCreateKeyFailed(@NonNull Throwable throwable) {
-                        setCoreRequestFinished(request, true);
+                        setCoreRequestFinished(request, throwable);
                         if (compositeTask.setCompleted()) {
                             listener.onNetworkError(throwable);
                         }
@@ -195,7 +196,7 @@ public class CoreHttpClient {
 
                     @Override
                     public void onTimeSynchronizationFailed(@NonNull Throwable t) {
-                        setCoreRequestFinished(request, true);
+                        setCoreRequestFinished(request, t);
                         if (compositeTask.setCompleted()) {
                             listener.onNetworkError(t);
                         }
@@ -215,13 +216,13 @@ public class CoreHttpClient {
     /**
      * Set instance of {@link CoreRequest} as unexpectedly finished.
      * @param request Request to set.
-     * @param isFailed If true, request is set as failed, otherwise canceled.
+     * @param failure Reason of failure. If null, then reason for completion is cancel.
      * @param <TResponse> Type of response.
      */
-    private <TResponse> void setCoreRequestFinished(CoreRequest<TResponse> request, boolean isFailed) {
-        if (request != null && !request.isDone()) {
-            if (isFailed) {
-                request.setFailed();
+    private <TResponse> void setCoreRequestFinished(@NonNull CoreRequest<TResponse> request, Throwable failure) {
+        if (!request.isDone()) {
+            if (failure != null) {
+                request.setFailed(failure);
             } else {
                 request.cancel();
             }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/CoreHttpRequest.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/CoreHttpRequest.java
@@ -330,7 +330,7 @@ public class CoreHttpRequest<TResult> implements ICancelable {
      */
     private void setFailed(@NonNull Throwable t) {
         // Mark core request as failed
-        coreRequest.setFailed();
+        coreRequest.setFailed(t);
         // Report completion
         reportCompletion(null, t);
     }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/CoreHttpTask.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/CoreHttpTask.java
@@ -36,6 +36,7 @@ public class CoreHttpTask<TResponse> extends CompositeCancelableTask {
     private final CoreTask<TResponse> task;
     private final CoreHttpClient httpClient;
     private final INetworkResponseListener<TResponse> listener;
+    private final INetworkResponseListener<TResponse> requestListener;
 
     /**
      * Construct task with required parameters.
@@ -50,6 +51,24 @@ public class CoreHttpTask<TResponse> extends CompositeCancelableTask {
         this.task = task;
         this.httpClient = httpClient;
         this.listener = listener;
+        this.requestListener = new INetworkResponseListener<>() {
+            @Override
+            public void onNetworkResponse(@Nullable Object o) {
+                processNext();
+            }
+
+            @Override
+            public void onNetworkError(@NonNull Throwable throwable) {
+                processNext();
+            }
+
+            @Override
+            public void onCancel() {
+                if (setCompleted()) {
+                    listener.onCancel();
+                }
+            }
+        };
     }
 
     /**
@@ -65,7 +84,7 @@ public class CoreHttpTask<TResponse> extends CompositeCancelableTask {
      */
     private void processNext() {
         try {
-            final CoreRequest<Object> request = task.getNextRequest();
+            final CoreRequest<TResponse> request = task.getNextRequest();
             if (request == null) {
                 if (task.isDone()) {
                     setFinished();
@@ -73,24 +92,7 @@ public class CoreHttpTask<TResponse> extends CompositeCancelableTask {
                     setFinished(new PowerAuthErrorException(PowerAuthErrorCodes.OPERATION_CANCELED, "Task did not create next request"));
                 }
             } else {
-                addCancelable(httpClient.post(request, new INetworkResponseListener<>() {
-                    @Override
-                    public void onNetworkResponse(@Nullable Object o) {
-                        processNext();
-                    }
-
-                    @Override
-                    public void onNetworkError(@NonNull Throwable throwable) {
-                        setFinished(throwable);
-                    }
-
-                    @Override
-                    public void onCancel() {
-                        if (setCompleted()) {
-                            listener.onCancel();
-                        }
-                    }
-                }));
+                addCancelable(httpClient.post(request, requestListener));
             }
         } catch (CoreException exception) {
             setFinished(PowerAuthErrorException.wrapException(PowerAuthErrorCodes.NETWORK_ERROR, exception));

--- a/proj-xcode/PowerAuth2/PowerAuthSDK.m
+++ b/proj-xcode/PowerAuth2/PowerAuthSDK.m
@@ -719,15 +719,15 @@ static PowerAuthSDK * s_inst;
                                                           callback:(void(^)(NSError * error))callback
 {
     NSError * localError = nil;
-    PowerAuthCoreRequest * request = [self persistActivationInSession:authentication error:&localError];
-    if (!request) {
+    PowerAuthCoreTask * task = [self persistActivationInSession:authentication error:&localError];
+    if (!task) {
         // If activation is V3, then it's OK to exit immediately, because there's no additional asynchronous
         // operation required. So, we can end here for both, successful and failure scenarios.
         callback(localError);
         return nil;
     }
     // Otherwise execute the core request
-    return [_client postCoreRequest:request completion:^(PowerAuthCoreRequest* request, id response, NSError* error) {
+    return [_client postCoreTask:task completion:^(PowerAuthCoreTask* request, id response, NSError* error) {
         // TODO: recovery from failure
         callback(error);
     }];
@@ -770,14 +770,14 @@ static PowerAuthSDK * s_inst;
                                        error:(NSError**)error
 {
     NSError * localError = nil;
-    PowerAuthCoreRequest * request = [self persistActivationInSession:authentication error:&localError];
+    PowerAuthCoreTask * task = [self persistActivationInSession:authentication error:&localError];
     if (localError) {
         if (error) *error = localError;
         return NO;
     }
-    if (request) {
+    if (task) {
         // Persist is asynchronous and this deprecated function is synchronous. Cancel the request and report error.
-        [request cancel];
+        [task cancel];
         PA2SetError(error, PowerAuthErrorCode_WrongParameter, @"Synchronous persist is not supported at this protocol version");
         return NO;
     }
@@ -797,12 +797,12 @@ static PowerAuthSDK * s_inst;
 }
 
 
-- (PowerAuthCoreRequest*) persistActivationInSession:(PowerAuthAuthentication*)authentication error:(NSError**)error
+- (PowerAuthCoreTask*) persistActivationInSession:(PowerAuthAuthentication*)authentication error:(NSError**)error
 {
     // Validate authentication object usage
     [authentication validateUsage:YES];
     
-    return [_sessionInterface writeTaskWithSession:^PowerAuthCoreRequest* (PowerAuthCoreSession * session, NSError** error) {
+    return [_sessionInterface writeTaskWithSession:^PowerAuthCoreTask* (PowerAuthCoreSession * session, NSError** error) {
         
         NSError * localError = nil;
         
@@ -815,7 +815,7 @@ static PowerAuthSDK * s_inst;
                 return nil;
             }
         }
-        PowerAuthCoreRequest * request = [session confirmActivationWithPassword:password withBiometryKek:biometryKek error:&localError];
+        PowerAuthCoreTask * task = [session confirmActivationWithPassword:password withBiometryKek:biometryKek error:&localError];
         if (localError) {
             if (error) *error = localError;
             return nil;
@@ -828,7 +828,7 @@ static PowerAuthSDK * s_inst;
         }
         // Clear TokenStore
         [_tokenStore removeAllLocalTokens];
-        return request;
+        return task;
         
     } error:error];
 }

--- a/proj-xcode/PowerAuth2/private/PA2CoreHttpClient.m
+++ b/proj-xcode/PowerAuth2/private/PA2CoreHttpClient.m
@@ -124,7 +124,7 @@ static NSOperationQueue * _GetSharedConcurrentQueue(void)
         // Endpoint require encryption key or time is not synchronized yet. We have to create a composite task that handle multiple
         // requests before an actual request is executed.
         PA2CompositeTask * compositeTask = [[PA2CompositeTask alloc] initWithCancelBlock:^{
-            [self setCoreRequestFinished:request isFailed:NO urlTask:nil];
+            [self setCoreRequestFinished:request failure:nil urlTask:nil];
         }];
         // Prepare common completion block with the composite task.
         void (^compositeCompletion)(PowerAuthCoreRequest *, id, NSError *) = ^(PowerAuthCoreRequest * request, id response, NSError *error) {
@@ -132,7 +132,7 @@ static NSOperationQueue * _GetSharedConcurrentQueue(void)
             dispatch_async(_completionQueue, ^{
                 // Make sure the core request is set as failed
                 if (error) {
-                    [self setCoreRequestFinished:request isFailed:YES urlTask:nil];
+                    [self setCoreRequestFinished:request failure:error urlTask:nil];
                 }
                 // Set composite operation as completed. The message returns YES if composite task was not completed or canceled before.
                 // If so, then simply call the completion block.
@@ -227,7 +227,7 @@ static NSOperationQueue * _GetSharedConcurrentQueue(void)
                 object = [self buildResponse:request responseData:data response:(NSHTTPURLResponse*)urlResponse error:&error];
             } else {
                 // Network, or other error. Report this immediately to C++ layer.
-                [self setCoreRequestFinished:request isFailed:YES urlTask:nil];
+                [self setCoreRequestFinished:request failure:error urlTask:nil];
                 object = nil;
             }
             // Log response
@@ -244,13 +244,13 @@ static NSOperationQueue * _GetSharedConcurrentQueue(void)
         NSError * error = op.operationError;
         // Make sure the core request is set as failed before we call the completion.
         if (error) {
-            [self setCoreRequestFinished:request isFailed:YES urlTask:nil];
+            [self setCoreRequestFinished:request failure:error urlTask:nil];
         }
         completion(request, object, error);
     };
     // Setup cancellation block
     op.cancelBlock = ^(PA2AsyncOperation *op, id task) {
-        [self setCoreRequestFinished:request isFailed:NO urlTask:PA2ObjectAs(task, NSURLSessionDataTask)];
+        [self setCoreRequestFinished:request failure:nil urlTask:PA2ObjectAs(task, NSURLSessionDataTask)];
     };
     // Finally, add operation to the right queue
     if (request.isRequireSerialQueue) {
@@ -285,7 +285,7 @@ static NSOperationQueue * _GetSharedConcurrentQueue(void)
         if (!processed) {
             // We never entered to the request preparation block. In this case, we have to try to cancel the core request
             // to notify core layer about this failure.
-            [self setCoreRequestFinished:coreRequest isFailed:YES urlTask:nil];
+            [self setCoreRequestFinished:coreRequest failure:localError urlTask:nil];
         }
         PA2WrapError(localError, error);
         return nil;
@@ -336,17 +336,17 @@ static NSOperationQueue * _GetSharedConcurrentQueue(void)
             if (!processed) {
                 // We never entered to the response processing. In this case, we have to try to
                 // set the core request as failed to notify core layer about this.
-                [self setCoreRequestFinished:coreRequest isFailed:YES urlTask:nil];
+                [self setCoreRequestFinished:coreRequest failure:*error urlTask:nil];
             }
             return nil;
         }
         // success, note that response object may be nil
         return coreRequest.responseObject;
     }
-    // Notify C++ layer about this failure.
-    [self setCoreRequestFinished:coreRequest isFailed:YES urlTask:nil];
     // build error
     *error = [self buildErrorForData:responseData httpResponse:httpResponse];
+    // Notify C++ layer about this failure.
+    [self setCoreRequestFinished:coreRequest failure:*error urlTask:nil];
     return nil;
 }
 
@@ -382,15 +382,15 @@ static NSOperationQueue * _GetSharedConcurrentQueue(void)
 }
 
 - (void) setCoreRequestFinished:(PowerAuthCoreRequest*)request
-                       isFailed:(BOOL)isFailed
+                        failure:(NSError*)failure
                         urlTask:(NSURLSessionDataTask*)task
 {
     [task cancel];
     if (request && !request.isDone) {
         // acquire write task in case the cancel cause internal state change
         [_sessionInterface writeBoolTaskWithSession:^BOOL(PowerAuthCoreSession * _Nonnull session, NSError * _Nonnull __autoreleasing * _Nullable error) {
-            if (isFailed) {
-                [request setFailed];
+            if (failure) {
+                [request setFailedWithError:failure];
             } else {
                 [request cancel];
             }

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKBaseTests.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKBaseTests.m
@@ -84,6 +84,97 @@
     XCTAssertTrue(activation.success);
 }
 
+/// Helper function that creates activation and expects failure at persist step.
+/// - Parameters:
+///   - shouldPass: If YES, then persist step should work.
+- (void) createActivationAndExpectPersistFailure:(BOOL)shouldPass
+{
+    PATSInitActivationResponse * response = [_helper prepareActivation:NO activationOtp:nil];
+    if (!response) {
+        XCTFail(@"Prepare failed");
+        return;
+    }
+    NSError * error = nil;
+    PowerAuthActivation * activation = [PowerAuthActivation activationWithActivationCode:response.activationCode error:&error];
+    if (!activation) {
+        XCTFail(@"activationWithActivationCode failed");
+        return;
+    }
+    PowerAuthActivationResult * activationResult = [AsyncHelper synchronizeAsynchronousBlock:^(AsyncHelper *waiting) {
+        [_sdk createActivation:activation callback:^(PowerAuthActivationResult * _Nullable result, NSError * _Nullable error) {
+            [waiting reportCompletion:result];
+        }];
+    }];
+    if (!activationResult) {
+        XCTFail(@"createActivation failed");
+        return;
+    }
+    PowerAuthAuthentication * initialAuthentication = [_helper createPersistAuthenticationWithFlags:0];
+    error = [AsyncHelper synchronizeAsynchronousBlock:^(AsyncHelper *waiting) {
+        [_sdk persistActivationWithAuthentication:initialAuthentication callback:^(NSError * _Nullable error) {
+            [waiting reportCompletion:error];
+        }];
+    }];
+    if (error) {
+        NSLog(@"Confirm error: %@", [error description]);
+    }
+    if (shouldPass) {
+        XCTAssertNil(error);
+    } else {
+        XCTAssertNotNil(error);
+    }
+    if (!shouldPass && error) {
+        // retry the operation. It should work
+        [self clearAllSimulateFailures];
+        error = [AsyncHelper synchronizeAsynchronousBlock:^(AsyncHelper *waiting) {
+            [_sdk persistActivationWithAuthentication:initialAuthentication callback:^(NSError * _Nullable error) {
+                [waiting reportCompletion:error];
+            }];
+        }];
+        XCTAssertNil(error);
+    }
+    [_helper assignCustomActivationData:response activationResult:activationResult credentials:initialAuthentication];
+    [_helper cleanup];
+    [self clearAllSimulateFailures];
+}
+
+- (void) testPersistActivationFailRecovery
+{
+    CHECK_TEST_CONFIG();
+    if (self.powerAuthAlgorithm == PowerAuthAlgorithm_LEGACY_P256) {
+        NSLog(@"Test not available for LEGACY_P256");
+        return;
+    }
+    NSString * confirmEndpoint = @"/activation/confirm";
+    NSString * statusEndpoint = @"/activation/status";
+    NSString * keystoreEndpoint = @"/keystore/create";
+    
+    // one failure at confirm send, no failure at status
+    [self simulateNetworkErrorOnSend:confirmEndpoint repeatCount:1];
+    [self createActivationAndExpectPersistFailure:YES];
+    
+    // one failure at confirm send, one failure at /keystore/create (prerequisite for status)
+    [self simulateNetworkErrorOnSend:confirmEndpoint repeatCount:1];
+    [self simulateNetworkErrorOnSend:keystoreEndpoint repeatCount:1];
+    [self createActivationAndExpectPersistFailure:NO];
+    
+    // 2 failures at confirm send, no failure at status. We should recovery from this.
+    [self simulateNetworkErrorOnSend:confirmEndpoint repeatCount:2];
+    [self createActivationAndExpectPersistFailure:YES];
+    
+    // 3 failures at confirm send, no failure at status. Out of recovery attempts
+    [self simulateNetworkErrorOnSend:confirmEndpoint repeatCount:3];
+    [self createActivationAndExpectPersistFailure:NO];
+    
+    // one failure at confirm, one failure at status. Cannot recovery here
+    [self simulateNetworkErrorOnSend:confirmEndpoint repeatCount:1];
+    [self simulateNetworkErrorOnSend:statusEndpoint repeatCount:1];
+    [self createActivationAndExpectPersistFailure:NO];
+
+    // failure at confirm receive, so the server processed the confirmation
+    [self simulateNetworkErrorOnReceive:confirmEndpoint];
+    [self createActivationAndExpectPersistFailure:YES];
+}
 
 - (void) testRemoveActivation
 {

--- a/proj-xcode/PowerAuthCore.xcodeproj/project.pbxproj
+++ b/proj-xcode/PowerAuthCore.xcodeproj/project.pbxproj
@@ -56,6 +56,8 @@
 		BF0825D72E01630D00B89A68 /* EciesEncryptorFactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BF0825D52E01630D00B89A68 /* EciesEncryptorFactory.cpp */; };
 		BF0825E82E0308AA00B89A68 /* SecretKeysPool.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BF0825E72E0308AA00B89A68 /* SecretKeysPool.cpp */; };
 		BF0825E92E0308AA00B89A68 /* SecretKeysPool.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BF0825E72E0308AA00B89A68 /* SecretKeysPool.cpp */; };
+		BF112EDC2F3DD51B00D578F0 /* ConfirmActivationTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BF112EDB2F3DD51B00D578F0 /* ConfirmActivationTask.cpp */; };
+		BF112EDD2F3DD51B00D578F0 /* ConfirmActivationTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BF112EDB2F3DD51B00D578F0 /* ConfirmActivationTask.cpp */; };
 		BF1150412E18434E008601DE /* PowerAuthCoreTimeService.mm in Sources */ = {isa = PBXBuildFile; fileRef = BF1150402E18434E008601DE /* PowerAuthCoreTimeService.mm */; };
 		BF1150422E18434E008601DE /* PowerAuthCoreTimeService.mm in Sources */ = {isa = PBXBuildFile; fileRef = BF1150402E18434E008601DE /* PowerAuthCoreTimeService.mm */; };
 		BF14D4572DD1C9A400BA7F51 /* SharedSecret.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BF14D4562DD1C9A400BA7F51 /* SharedSecret.cpp */; };
@@ -522,6 +524,8 @@
 		BF0825D52E01630D00B89A68 /* EciesEncryptorFactory.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = EciesEncryptorFactory.cpp; sourceTree = "<group>"; };
 		BF0825E62E0308AA00B89A68 /* SecretKeysPool.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SecretKeysPool.h; sourceTree = "<group>"; };
 		BF0825E72E0308AA00B89A68 /* SecretKeysPool.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SecretKeysPool.cpp; sourceTree = "<group>"; };
+		BF112EDA2F3DD51B00D578F0 /* ConfirmActivationTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ConfirmActivationTask.h; sourceTree = "<group>"; };
+		BF112EDB2F3DD51B00D578F0 /* ConfirmActivationTask.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ConfirmActivationTask.cpp; sourceTree = "<group>"; };
 		BF1150402E18434E008601DE /* PowerAuthCoreTimeService.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PowerAuthCoreTimeService.mm; sourceTree = "<group>"; };
 		BF14D4552DD1C99000BA7F51 /* SharedSecret.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SharedSecret.h; sourceTree = "<group>"; };
 		BF14D4562DD1C9A400BA7F51 /* SharedSecret.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SharedSecret.cpp; sourceTree = "<group>"; };
@@ -808,6 +812,8 @@
 				8F0006652E82AF6700C57A29 /* ProtocolUpgradeTask.cpp */,
 				BF062BDC2E6B08FA001436AD /* GetActivationStatusTask.h */,
 				BF062BDD2E6B08FA001436AD /* GetActivationStatusTask.cpp */,
+				BF112EDA2F3DD51B00D578F0 /* ConfirmActivationTask.h */,
+				BF112EDB2F3DD51B00D578F0 /* ConfirmActivationTask.cpp */,
 			);
 			path = task;
 			sourceTree = "<group>";
@@ -1707,6 +1713,7 @@
 				BF062BD92E6AE2DD001436AD /* Task.cpp in Sources */,
 				BFAAC9992E3E6B0600062165 /* ActivationResult.cpp in Sources */,
 				BF75F9BF2E05463A00D1E4F0 /* HybridKeyPair.cpp in Sources */,
+				BF112EDD2F3DD51B00D578F0 /* ConfirmActivationTask.cpp in Sources */,
 				BF4D854E2DE476CD00D32F55 /* Context.cpp in Sources */,
 				BF4D86332DF0629300D32F55 /* RegistrationData.cpp in Sources */,
 			);
@@ -1837,6 +1844,7 @@
 				BF062BDA2E6AE2DD001436AD /* Task.cpp in Sources */,
 				BFAAC9982E3E6B0600062165 /* ActivationResult.cpp in Sources */,
 				BF75F9BB2E05463A00D1E4F0 /* HybridKeyPair.cpp in Sources */,
+				BF112EDC2F3DD51B00D578F0 /* ConfirmActivationTask.cpp in Sources */,
 				BF4D854D2DE476CD00D32F55 /* Context.cpp in Sources */,
 				BF4D86322DF0629300D32F55 /* RegistrationData.cpp in Sources */,
 			);

--- a/proj-xcode/PowerAuthCore/PowerAuthCoreRequest.h
+++ b/proj-xcode/PowerAuthCore/PowerAuthCoreRequest.h
@@ -82,7 +82,7 @@ typedef void(^PowerAuthCoreRequestCallback)(id _Nullable response, NSError * _Nu
 
 /// Set request as failed. You have to call this method when the HTTP request ends with
 /// external failure, such as non-200 status code is received.
-- (void) setFailed;
+- (void) setFailedWithError:(nullable NSError*)error;
 
 /// Prepare request body and headers. It's recommended to call this method on background
 /// execution queue to avoid main thread disruptions.

--- a/proj-xcode/PowerAuthCore/PowerAuthCoreRequest.mm
+++ b/proj-xcode/PowerAuthCore/PowerAuthCoreRequest.mm
@@ -132,9 +132,29 @@
     _request->cancel();
 }
 
-- (void) setFailed
+- (void) setFailedWithError:(NSError *)error
 {
-    _request->setFailed(nullptr);
+    if (error) {
+        // Keep failure if it's not set yet
+        if (!_failure) {
+            _failure = error;
+        }
+        // Convert NSError to Exception. This will keep at least original message
+        PowerAuthCoreError errorCode = error.powerAuthCoreErrorCode;
+        NSString * message = error.localizedDescription;
+        if (errorCode == PowerAuthCoreError_NA) {
+            errorCode = PowerAuthCoreError_Other;
+        }
+        try {
+            auto ec = static_cast<powerAuth::ErrorCode>(errorCode);
+            throw powerAuth::Exception(ec, message.UTF8String);
+        } catch (...) {
+            _request->setFailed(std::current_exception());
+        }
+    } else {
+        // No reason provided
+        _request->setFailed(nullptr);
+    }
 }
 
 - (BOOL) prepareRequest:(NSError *__autoreleasing *)error

--- a/proj-xcode/PowerAuthCore/PowerAuthCoreSession.h
+++ b/proj-xcode/PowerAuthCore/PowerAuthCoreSession.h
@@ -248,10 +248,10 @@
 ///   - password: User's password.
 ///   - biometryKek: Optional biometric factor KEK. If `nil` then this session will not have biometry configured.
 ///   - error: Pointer where error is stored in case of failure.
-/// - Returns: Core request object containing all required information for activation confirmation.
-- (nullable PowerAuthCoreRequest*) confirmActivationWithPassword:(nonnull PowerAuthCorePassword*)password
-                                                 withBiometryKek:(nullable PowerAuthCoreData*)biometryKek
-                                                           error:(NSError*_Nullable*_Nullable)error;
+/// - Returns: Core task for activation confirmation.
+- (nullable PowerAuthCoreTask*) confirmActivationWithPassword:(nonnull PowerAuthCorePassword*)password
+                                              withBiometryKek:(nullable PowerAuthCoreData*)biometryKek
+                                                        error:(NSError*_Nullable*_Nullable)error;
 
 /// Remove activation from the server.
 ///

--- a/proj-xcode/PowerAuthCore/PowerAuthCoreSession.mm
+++ b/proj-xcode/PowerAuthCore/PowerAuthCoreSession.mm
@@ -292,17 +292,9 @@ static void _ReportError(PowerAuthCoreError code, NSString * message, NSError **
     }
 }
 
-- (nullable PowerAuthCoreRequest*) confirmActivationWithPassword:(nonnull PowerAuthCorePassword*)password
-                                                           error:(NSError*_Nullable*_Nullable)error
-{
-    return [self confirmActivationWithPassword:password
-                               withBiometryKek:nil
-                                         error:error];
-}
-
-- (nullable PowerAuthCoreRequest*) confirmActivationWithPassword:(nonnull PowerAuthCorePassword*)password
-                                                 withBiometryKek:(nullable PowerAuthCoreData*)biometryKek
-                                                           error:(NSError*_Nullable*_Nullable)error
+- (nullable PowerAuthCoreTask*) confirmActivationWithPassword:(nonnull PowerAuthCorePassword*)password
+                                              withBiometryKek:(nullable PowerAuthCoreData*)biometryKek
+                                                        error:(NSError*_Nullable*_Nullable)error
 {
     if (![self requireWriteAccess:error]) {
         return nil;
@@ -310,9 +302,9 @@ static void _ReportError(PowerAuthCoreError code, NSString * message, NSError **
     try {
         auto biometry = biometryKek ? biometryKek.byteArrayRef : ByteRange();
         auto credentials = InitialCredentials::credentials(password.passObjRef->passwordData(), biometry);
-        auto request = _session->confirmActivation(credentials);
-        if (request) {
-            return [[PowerAuthCoreRequest alloc] initWithRequest:request];
+        auto task = _session->confirmActivation(credentials);
+        if (task) {
+            return [[PowerAuthCoreTask alloc] initWithTask:task];
         }
     } catch (...) {
         if (error) {

--- a/src/Android.mk
+++ b/src/Android.mk
@@ -82,6 +82,7 @@ LOCAL_SRC_FILES += \
 # Multiplatform sources - PowerAuth/task
 LOCAL_SRC_FILES += \
 	PowerAuth/task/ProtocolUpgradeTask.cpp \
+	PowerAuth/task/ConfirmActivationTask.cpp \
 	PowerAuth/task/GetActivationStatusTask.cpp
 
 # Multiplatform sources - PowerAuth/model

--- a/src/PowerAuth/ActivationStatus.cpp
+++ b/src/PowerAuth/ActivationStatus.cpp
@@ -41,8 +41,9 @@ ActivationStatus::ActivationStatus(ProtocolVersion version,
     _fail_count(data.failCount),
     _max_fail_count(data.maxFailCount),
     _upgrade_version(data.upgradeVersion),
-    _is_protocol_upgrade_available(data.currentVersion < data.upgradeVersion),
     _is_pending_activation_confirm(data.statusFlags & STATUS_FLAG_ACTIVATION_CONFIRM),
+    _is_unsupported_algorithm(data.statusFlags & STATUS_FLAG_UNSUPPORTED_ALGORITHM),
+    _is_protocol_upgrade_available(data.currentVersion < data.upgradeVersion),
     _is_pending_upgrade_confirm(data.statusFlags & STATUS_FLAG_UPGRADE_CONFIRM),
     _custom_object(custom_object)
 {
@@ -69,6 +70,16 @@ ActivationState ActivationStatus::activationState() const noexcept
 ActivationStatus::ServerState ActivationStatus::serverState() const noexcept
 {
     return _server_state;
+}
+
+bool ActivationStatus::isPendingActivationConfirm() const noexcept
+{
+    return _is_pending_activation_confirm;
+}
+
+bool ActivationStatus::isUnsupportedAlgorithm() const noexcept
+{
+    return _is_unsupported_algorithm;
 }
 
 bool ActivationStatus::isProtocolUpgradeAvailable() const noexcept

--- a/src/PowerAuth/Context.cpp
+++ b/src/PowerAuth/Context.cpp
@@ -268,6 +268,13 @@ std::shared_ptr<Context> Context::createTargetAlgorithmContext()
     return _target_context;
 }
 
+void Context::resetState() noexcept
+{
+    _activation_service->resetState();
+    _key_provider->clearActivationKeys();
+    _encryptor_factory->resetActivationData();
+}
+
 void Context::destroyTargetAlgorithmContext()
 {
     if (!_target_context) {

--- a/src/PowerAuth/Context.h
+++ b/src/PowerAuth/Context.h
@@ -61,6 +61,9 @@ public:
     /// Returns the new context for the target algorithm.
     std::shared_ptr<Context> createTargetAlgorithmContext();
     
+    /// Reset context state. This is identical to remove activation locally.
+    void resetState() noexcept;
+    
     void destroyTargetAlgorithmContext();
     
     /// Returns the target algorithm context if exists.

--- a/src/PowerAuth/Session.cpp
+++ b/src/PowerAuth/Session.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <PowerAuth/Session.h>
+#include "task/ConfirmActivationTask.h"
 #include "task/GetActivationStatusTask.h"
 #include "task/ProtocolUpgradeTask.h"
 
@@ -122,7 +123,7 @@ RequestPtr Session::createActivation(const cc7::json::JsonValue& L1_data, const 
     return _context->activationService().createActivation(L1_data, L2_data);
 }
 
-RequestPtr Session::confirmActivation(InitialCredentialsPtr credentials)
+TaskPtr Session::confirmActivation(const InitialCredentialsPtr& credentials)
 {
     LOCK_GUARD();
     // Validate credentials in advance. This is typically done also in key provider,
@@ -136,7 +137,13 @@ RequestPtr Session::confirmActivation(InitialCredentialsPtr credentials)
     if (rd.getActivationId().empty()) {
         throw Exception(EC_WrongActivationState, "Cannot confirm activation. Key-exchange is not completed yet");
     }
-    return _context->activationService().confirmActivation(credentials);
+    if (_context->protocolVersion() < Version_V4) {
+        // V3 doesn't require HTTP communication for activation confirm
+        _context->activationService().confirmActivation(credentials);
+        return nullptr;
+    }
+    // V4+ uses ConfirmActivationTask
+    return std::make_shared<ConfirmActivationTask>(_context, credentials);
 }
 
 bool Session::hasValidActivationData() const noexcept

--- a/src/PowerAuth/Session.cpp
+++ b/src/PowerAuth/Session.cpp
@@ -94,7 +94,7 @@ cc7::ByteArray Session::saveState()
 void Session::resetState()
 {
     LOCK_GUARD();
-    _context->activationService().resetState();
+    _context->resetState();
 }
 
 

--- a/src/PowerAuth/Task.cpp
+++ b/src/PowerAuth/Task.cpp
@@ -119,7 +119,7 @@ void Task::setFailed(std::exception_ptr exception) noexcept
     captureExceptionAndComplete(exception);
 }
 
-void Task::setCompleted() noexcept
+void Task::setCompleted(bool clear_failure) noexcept
 {
     LOCK_GUARD();
     try {
@@ -133,6 +133,9 @@ void Task::setCompleted() noexcept
         }
         if (!_completion_processed) {
             _completion_processed = true;
+            if (clear_failure) {
+                _failure = nullptr;
+            }
             onTaskEnd();
         }
     } catch (...) {
@@ -176,6 +179,9 @@ RequestPtr Task::getNextRequest()
 void Task::setNextRequest(const RequestPtr &request, int tag, int flags)
 {
     LOCK_GUARD();
+    if (!request) {
+        throw Exception(EC_InternalError, "Next request is null");
+    }
     if (_next_request) {
         throw Exception(EC_InternalError, "Next request is already set");
     }

--- a/src/PowerAuth/model/RegistrationData.h
+++ b/src/PowerAuth/model/RegistrationData.h
@@ -41,6 +41,7 @@ public:
         SharedSecretContextPtr sharedSecretContext;
         cc7::ByteArray calculatedSharedSecret;
         cc7::byte authCodeCounterByte = 0;
+        bool lastConfirmFailed = false;
     };
     
     struct V3

--- a/src/PowerAuth/task/ConfirmActivationTask.cpp
+++ b/src/PowerAuth/task/ConfirmActivationTask.cpp
@@ -67,6 +67,7 @@ void ConfirmActivationTask::onRequestFailure(const Request &request)
     // lock already acquired
     switch (request.getParentTaskTag()) {
         case CONFIRM_ACTIVATION:
+            _session_data->registrationData().v4().lastConfirmFailed = true;
             fetchActivationStatus();
             break;
         case FETCH_STATUS:

--- a/src/PowerAuth/task/ConfirmActivationTask.cpp
+++ b/src/PowerAuth/task/ConfirmActivationTask.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ConfirmActivationTask.h"
+
+namespace powerAuth {
+
+#define LOCK_GUARD() std::lock_guard<std::recursive_mutex> _lock_guard(*_mutex)
+
+ConfirmActivationTask::ConfirmActivationTask(const ContextPtr& context, const InitialCredentialsPtr& credentials) :
+    Task("ConfirmActivation", context),
+    _credentials(credentials),
+    _session_data(context->getSessionDataPtr()),
+    _activation_service(context->getActivationServicePtr()),
+    _retry_count(2)
+{
+}
+
+void ConfirmActivationTask::onTaskStart()
+{
+    LOCK_GUARD();
+    if (_session_data->getCurrentProtocolVersion() < Version_V4) {
+        throw Exception(EC_InternalError, "Confirm task is not supported in V3");
+    }
+    if (!_session_data->hasRegistrationData()) {
+        throw Exception(EC_InternalError, "There's no pending registration to confirm");
+    }
+    if (_session_data->registrationData().v4().lastConfirmFailed) {
+        // If previous confirm failed, then we have to start with status fetch
+        fetchActivationStatus();
+    } else {
+        // Otherwise start with regular confirm
+        confirmActivation(false);
+    }
+}
+
+void ConfirmActivationTask::onRequestSuccess(const Request &request)
+{
+    // lock already acquired
+    switch (request.getParentTaskTag()) {
+        case CONFIRM_ACTIVATION:
+            setCompleted(true);
+            break;
+        case FETCH_STATUS:
+            processActivationStatus(*request.getTypedResponseObject<ActivationStatus>());
+            break;
+        default:
+            throw Exception(EC_InternalError, "Unknown request tag");
+    }
+}
+
+void ConfirmActivationTask::onRequestFailure(const Request &request)
+{
+    // lock already acquired
+    switch (request.getParentTaskTag()) {
+        case CONFIRM_ACTIVATION:
+            fetchActivationStatus();
+            break;
+        case FETCH_STATUS:
+            setCompleted();
+            break;
+        default:
+            throw Exception(EC_InternalError, "Unknown request tag");
+    }
+}
+
+// Private
+
+void ConfirmActivationTask::processActivationStatus(const ActivationStatus &status)
+{
+    // lock must be guaranteed
+    auto state = status.activationState();
+    if ((state != ActivationState::Active && state != ActivationState::PendingCommit)) {
+        // Activation is in a complete wrong state. Only "ACTIVE" and "PENDING_COMMIT" states
+        // are accepted at this point.
+        throw Exception(EC_WrongActivationState, "Activation on the server is in wrong state");
+    }
+    if (status.isPendingActivationConfirm()) {
+        // seems that confirm request did not reach the server, try to retry.
+        confirmActivation(true);
+    } else {
+        // There's no longer pending confirm, so set the task as successfully completed.
+        setCompleted(true);
+    }
+}
+
+void ConfirmActivationTask::confirmActivation(bool retry)
+{
+    // lock must be acquired
+    if (retry) {
+        if (_retry_count-- == 0) {
+            throw Exception(EC_Other, "Failed to confirm activation after several attempts");
+        }
+    }
+    setNextRequest(_activation_service->confirmActivation(_credentials),
+                   CONFIRM_ACTIVATION,
+                   RF_PRIMARY | RF_IGNORE_FAILURE);
+}
+
+void ConfirmActivationTask::fetchActivationStatus()
+{
+    // lock must be acquired
+    setNextRequest(_activation_service->fetchActivationStatus(),
+                   FETCH_STATUS,
+                   RF_NONE);
+}
+
+} // namespace powerAuth

--- a/src/PowerAuth/task/ConfirmActivationTask.h
+++ b/src/PowerAuth/task/ConfirmActivationTask.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <PowerAuth/Task.h>
+#include "../Context.h"
+
+namespace powerAuth {
+
+class ConfirmActivationTask : public Task {
+public:
+    ConfirmActivationTask(const ContextPtr& context, const InitialCredentialsPtr& credentials);
+    
+protected:
+    void onTaskStart() override;
+    void onRequestSuccess(const Request &request) override;
+    void onRequestFailure(const Request &request) override;
+    
+    enum RequestId
+    {
+        FETCH_STATUS = 1,
+        CONFIRM_ACTIVATION,
+    };
+    
+private:
+    
+    void fetchActivationStatus();
+    void confirmActivation(bool retry);
+    void recoverFromFailure();
+    void processActivationStatus(const ActivationStatus &status);
+    
+    InitialCredentialsPtr _credentials;
+    SessionDataPtr _session_data;
+    IActivationServicePtr _activation_service;
+    int _retry_count;
+};
+
+} // namespace powerAuth

--- a/src/PowerAuth/v3/ActivationServiceV3.cpp
+++ b/src/PowerAuth/v3/ActivationServiceV3.cpp
@@ -149,7 +149,7 @@ std::string ActivationServiceV3::calculateActivationFingerprint(Context& context
     return common::CalculateHumanReadableCodeFromHash(hash, v3::ACTIVATION_FINGERPRINT_SIZE);
 }
 
-RequestPtr ActivationServiceV3::confirmActivation(InitialCredentialsPtr credentials)
+RequestPtr ActivationServiceV3::confirmActivation(const InitialCredentialsPtr& credentials)
 {
     LOCK_GUARD();
     auto context = lockContext();
@@ -336,7 +336,7 @@ int ActivationServiceV3::calculateHashCounterDistance(cc7::ByteArray& local_ctr_
 
 // MARK: - Remove
 
-RequestPtr ActivationServiceV3::removeActivation(CredentialsPtr credentials)
+RequestPtr ActivationServiceV3::removeActivation(const CredentialsPtr& credentials)
 {
     LOCK_GUARD();
     auto context = lockContext();
@@ -353,7 +353,7 @@ RequestPtr ActivationServiceV3::removeActivation(CredentialsPtr credentials)
 
 // MARK: - Factors
 
-RequestPtr ActivationServiceV3::changePassword(PasswordPtr old_password, PasswordPtr new_password)
+RequestPtr ActivationServiceV3::changePassword(const PasswordPtr& old_password, const PasswordPtr& new_password)
 {
     LOCK_GUARD();
     auto context = lockContext();
@@ -369,7 +369,7 @@ RequestPtr ActivationServiceV3::changePassword(PasswordPtr old_password, Passwor
     return nullptr;
 }
 
-RequestPtr ActivationServiceV3::addBiometricFactor(PasswordPtr password, const cc7::ByteRange& new_biometry_kek)
+RequestPtr ActivationServiceV3::addBiometricFactor(const PasswordPtr& password, const cc7::ByteRange& new_biometry_kek)
 {
     LOCK_GUARD();
     cc7::ByteArray new_kek = new_biometry_kek;

--- a/src/PowerAuth/v3/ActivationServiceV3.h
+++ b/src/PowerAuth/v3/ActivationServiceV3.h
@@ -33,15 +33,15 @@ public:
     ProtocolVersion protocolVersion() const noexcept override;
     IServicePtr asService() override;
     RequestPtr createActivation(cc7::json::JsonValue L1_data, cc7::json::JsonValue L2_data) override;
-    RequestPtr confirmActivation(InitialCredentialsPtr credentials) override;
+    RequestPtr confirmActivation(const InitialCredentialsPtr& credentials) override;
     std::string calculateActivationFingerprint() override;
     
     void resetState() override;
     RequestPtr fetchActivationStatus() override;
-    RequestPtr removeActivation(CredentialsPtr credentials) override;
+    RequestPtr removeActivation(const CredentialsPtr& credentials) override;
     
-    RequestPtr changePassword(PasswordPtr old_password, PasswordPtr new_password) override;
-    RequestPtr addBiometricFactor(PasswordPtr password, const cc7::ByteRange& new_biometry_kek) override;
+    RequestPtr changePassword(const PasswordPtr& old_password, const PasswordPtr& new_password) override;
+    RequestPtr addBiometricFactor(const PasswordPtr& password, const cc7::ByteRange& new_biometry_kek) override;
     RequestPtr removeBiometricFactor() override;
     
     RequestPtr fetchUserInfo() override;

--- a/src/PowerAuth/v3/EciesEncryptorFactory.cpp
+++ b/src/PowerAuth/v3/EciesEncryptorFactory.cpp
@@ -143,7 +143,7 @@ IClientEncryptorPtr EciesEncryptorFactory::getClientEncryptor(EncryptorId encryp
                                                           _configuration->applicationKey(),
                                                           _configuration->applicationSecret(),
                                                           ki.keyIdentifier,
-                                                          activationId());
+                                                          activationId(spec->scope));
 
     ByteArray transport_key;
     if (spec->isActivationScoped()) {
@@ -167,7 +167,7 @@ cc7::json::JsonValue EciesEncryptorFactory::createTemporaryKeyRequest(EncryptorS
         throw Exception(EC_NotAllowed, "There's already pending request for temporary key");
     }
 
-    auto activation_id = activationId();
+    auto activation_id = activationId(scope);
     if (act_scope && activation_id.empty()) {
         throw Exception(EC_MissingActivation, "Activation is required for activation scoped temporary key");
     }
@@ -246,7 +246,7 @@ void EciesEncryptorFactory::completeTemporaryKeyRequest(EncryptorScope scope, co
             ki.clear();
             throw Exception(EC_Cryptography, "Request and Response data doesn't match");
         }
-        if (act_scope && activationId() != response.activationId) {
+        if (act_scope && activationId(scope) != response.activationId) {
             ki.clear();
             throw Exception(EC_InternalError, "ActivationID from response is no longer valid");
         }
@@ -307,9 +307,9 @@ EciesEncryptorFactory::GetTemporaryKeyResponse EciesEncryptorFactory::GetTempora
 
 // MARK: - Private functions
 
-std::string EciesEncryptorFactory::activationId() const noexcept
+std::string EciesEncryptorFactory::activationId(EncryptorScope scope) const noexcept
 {
-    if (_session_data->hasPersistentData() && _session_data->getCurrentProtocolVersion() == Version_V3) {
+    if (scope == EncryptorScope::ACTIVATION && _session_data->hasPersistentData(Version_V3)) {
         return _session_data->persistentData().v3().activationId;
     }
     return std::string();

--- a/src/PowerAuth/v3/EciesEncryptorFactory.h
+++ b/src/PowerAuth/v3/EciesEncryptorFactory.h
@@ -113,7 +113,7 @@ private:
     cc7::json::JsonValue createTemporaryKeyRequest(EncryptorScope scope);
     void completeTemporaryKeyRequest(EncryptorScope scope, const cc7::json::JsonValue& response);
     void cancelPendingTemporaryKeyRequest(EncryptorScope scope);
-    std::string activationId() const noexcept;
+    std::string activationId(EncryptorScope scope) const noexcept;
     
     const ContextWeakPtr _context;
     const ConfigurationPtr _configuration;

--- a/src/PowerAuth/v4/ActivationServiceV4.cpp
+++ b/src/PowerAuth/v4/ActivationServiceV4.cpp
@@ -125,7 +125,7 @@ ResponseObjectPtr ActivationServiceV4::processResponseActivationData(Context& co
     return std::make_shared<ActivationResult>(calculateActivationFingerprint(), L1_data);
 }
 
-RequestPtr ActivationServiceV4::confirmActivation(InitialCredentialsPtr credentials)
+RequestPtr ActivationServiceV4::confirmActivation(const InitialCredentialsPtr& credentials)
 {
     LOCK_GUARD();
     auto context = lockContext();
@@ -366,7 +366,7 @@ ActivationStatus::CounterState ActivationServiceV4::trySynchronizeCounter(const 
     return ActivationStatus::CounterState_Invalid;
 }
 
-RequestPtr ActivationServiceV4::removeActivation(CredentialsPtr credentials)
+RequestPtr ActivationServiceV4::removeActivation(const CredentialsPtr& credentials)
 {
     LOCK_GUARD();
     auto context = lockContext();
@@ -382,7 +382,7 @@ RequestPtr ActivationServiceV4::removeActivation(CredentialsPtr credentials)
 
 // MARK: - Factors
 
-RequestPtr ActivationServiceV4::changePassword(PasswordPtr old_password, PasswordPtr new_password)
+RequestPtr ActivationServiceV4::changePassword(const PasswordPtr& old_password, const PasswordPtr& new_password)
 {
     LOCK_GUARD();
     auto context = lockContext();
@@ -419,7 +419,7 @@ ResponseObjectPtr ActivationServiceV4::processResponseChangePassword(Context &co
     return nullptr;
 }
 
-RequestPtr ActivationServiceV4::addBiometricFactor(PasswordPtr password, const cc7::ByteRange& new_biometry_kek)
+RequestPtr ActivationServiceV4::addBiometricFactor(const PasswordPtr& password, const cc7::ByteRange& new_biometry_kek)
 {
     LOCK_GUARD();
     auto context = lockContext();

--- a/src/PowerAuth/v4/ActivationServiceV4.h
+++ b/src/PowerAuth/v4/ActivationServiceV4.h
@@ -33,15 +33,15 @@ public:
     ProtocolVersion protocolVersion() const noexcept override;
     IServicePtr asService() override;
     RequestPtr createActivation(cc7::json::JsonValue L1_data, cc7::json::JsonValue L2_data) override;
-    RequestPtr confirmActivation(InitialCredentialsPtr credentials) override;
+    RequestPtr confirmActivation(const InitialCredentialsPtr& credentials) override;
     std::string calculateActivationFingerprint() override;
     
     void resetState() override;
     RequestPtr fetchActivationStatus() override;
-    RequestPtr removeActivation(CredentialsPtr credentials) override;
+    RequestPtr removeActivation(const CredentialsPtr& credentials) override;
     
-    RequestPtr changePassword(PasswordPtr old_password, PasswordPtr new_password) override;
-    RequestPtr addBiometricFactor(PasswordPtr password, const cc7::ByteRange& new_biometry_kek) override;
+    RequestPtr changePassword(const PasswordPtr& old_password, const PasswordPtr& new_password) override;
+    RequestPtr addBiometricFactor(const PasswordPtr& password, const cc7::ByteRange& new_biometry_kek) override;
     RequestPtr removeBiometricFactor() override;
     
     RequestPtr fetchUserInfo() override;

--- a/src/PowerAuth/v4/AeadEncryptorFactory.cpp
+++ b/src/PowerAuth/v4/AeadEncryptorFactory.cpp
@@ -326,8 +326,8 @@ AeadEncryptorFactory::GetTemporaryKeyResponse AeadEncryptorFactory::GetTemporary
 
 std::string AeadEncryptorFactory::activationId() const noexcept
 {
-    if (_session_data->hasPersistentData() && _session_data->getCurrentProtocolVersion() == Version_V4) {
-        return _session_data->persistentData().v4().activationId;
+    if (_session_data->hasActivationId()) {
+        return _session_data->getActivationId();
     }
     return std::string();
 }
@@ -357,7 +357,7 @@ AeadEncryptorFactory::TemporaryKeyData& AeadEncryptorFactory::validKeyInfo(Encry
         ki.clear();
         throw Exception(EC_NotAllowed, "Temporary key is not valid or is expired");
     }
-    if (ki.keyScope == EncryptorScope::ACTIVATION && !_session_data->hasPersistentData()) {
+    if (ki.keyScope == EncryptorScope::ACTIVATION && !_session_data->hasActivationId()) {
         ki.clear();
         throw Exception(EC_MissingActivation, "Temporary key cannot be accessed due to missing activation");
     }

--- a/src/PowerAuth/v4/AeadEncryptorFactory.cpp
+++ b/src/PowerAuth/v4/AeadEncryptorFactory.cpp
@@ -123,7 +123,7 @@ IClientEncryptorPtr AeadEncryptorFactory::getClientEncryptor(EncryptorId encrypt
                                                           _configuration->applicationKey(),
                                                           _configuration->applicationSecret(),
                                                           ki.keyIdentifier,
-                                                          activationId());
+                                                          activationId(spec->scope));
     ByteArray e2ee_shared_info2_key;
     if (spec->isActivationScoped()) {
         e2ee_shared_info2_key = _key_provider->unlockSecretKeys()->keyE2EESharedInfo2();
@@ -176,7 +176,7 @@ cc7::json::JsonValue AeadEncryptorFactory::createTemporaryKeyRequest(EncryptorSc
     if (ki.hasPendingRequest()) {
         throw Exception(EC_NotAllowed, "There's already pending request for temporary key");
     }
-    auto activation_id = activationId();
+    auto activation_id = activationId(scope);
     if (act_scope && activation_id.empty()) {
         throw Exception(EC_MissingActivation, "Activation is required for activation scoped temporary key");
     }
@@ -265,9 +265,9 @@ void AeadEncryptorFactory::completeTemporaryKeyRequest(EncryptorScope scope, con
             ki.clear();
             throw Exception(EC_Cryptography, "Request and Response data doesn't match");
         }
-        if (act_scope && activationId() != response.activationId) {
+        if (act_scope && (activationId(scope) != response.activationId)) {
             ki.clear();
-            // This makes no sense, but it seems that
+            // This makes no sense, but it seems that activation ID changed between request and response.
             throw Exception(EC_InternalError, "ActivationID from response is no longer valid");
         }
         
@@ -324,9 +324,9 @@ AeadEncryptorFactory::GetTemporaryKeyResponse AeadEncryptorFactory::GetTemporary
 
 // MARK: - Private functions
 
-std::string AeadEncryptorFactory::activationId() const noexcept
+std::string AeadEncryptorFactory::activationId(EncryptorScope scope) const noexcept
 {
-    if (_session_data->hasActivationId()) {
+    if (scope == EncryptorScope::ACTIVATION && _session_data->hasActivationId()) {
         return _session_data->getActivationId();
     }
     return std::string();

--- a/src/PowerAuth/v4/AeadEncryptorFactory.h
+++ b/src/PowerAuth/v4/AeadEncryptorFactory.h
@@ -117,7 +117,7 @@ private:
     cc7::json::JsonValue createTemporaryKeyRequest(EncryptorScope scope);
     void completeTemporaryKeyRequest(EncryptorScope scope, const cc7::json::JsonValue & response);
     void cancelPendingTemporaryKeyRequest(EncryptorScope scope);
-    std::string activationId() const noexcept;
+    std::string activationId(EncryptorScope scope) const noexcept;
     
     const ContextWeakPtr _context;
     const ConfigurationPtr _configuration;

--- a/src/PowerAuthJni/CoreRequestJNI.cpp
+++ b/src/PowerAuthJni/CoreRequestJNI.cpp
@@ -222,7 +222,7 @@ CC7_JNI_METHOD(void, cancel)
     NH_CATCH_RT_ONLY()
 }
 
-CC7_JNI_METHOD(void, setFailed)
+CC7_JNI_METHOD_PARAMS(void, setFailed, jint errorCode, jstring message)
 {
     NH_TRY
     {
@@ -230,7 +230,13 @@ CC7_JNI_METHOD(void, setFailed)
         auto this_wrapped = jni.fromJava(thiz, specs.coreRequest.native.classRef);
         auto this_obj = jni.fromHandle<Request>(this_wrapped.getLong(specs.coreRequest.native.handle));
         // set failed
-        this_obj->setFailed(nullptr);
+        auto cpp_ec = jni.fromJava<ErrorCode>(specs.coreErrorCode, errorCode);
+        auto cpp_message = jni.fromJava(message);
+        try {
+            throw Exception(cpp_ec, cpp_message);
+        } catch (...) {
+            this_obj->setFailed(std::current_exception());
+        }
         // cleanup builder
         jni::ClearResponseBuilderClosure(jni, specs, this_wrapped);
     }

--- a/src/PowerAuthJni/CoreSessionJNI.cpp
+++ b/src/PowerAuthJni/CoreSessionJNI.cpp
@@ -268,12 +268,12 @@ CC7_JNI_METHOD_PARAMS(jobject, confirmActivation, jobject password, jobject biom
         auto cpp_password = jni.fromJava<Password>(specs.password, password);
         auto cpp_biometry = CopyFromSecureData(jni, biometryKek);
         auto credentials = InitialCredentials::credentials(cpp_password->passwordData(), cpp_biometry);
-        auto request = THIS_OBJ()->confirmActivation(credentials);
-        if (!request) {
+        auto task = THIS_OBJ()->confirmActivation(credentials);
+        if (!task) {
             // This is valid for V3 activations
             return nullptr;
         }
-        return BuildCoreRequest(jni, request);
+        return BuildCoreTask(jni, task);
     }
     NH_CATCH(nullptr)
 }


### PR DESCRIPTION
This PR adds ability to recover from failed activation confirmation in protocol 4.0.

Other changes:

- Fixed C++ `Context` cleanup after local activation remove
- `AeadEncryptorFactory` now provides activation scoped key also when activation is not persisted yet. This is required because we need to fetch activation status in confirm activation recovery task.
- Minor improvements in `IActivationService`. Interface now uses references instead of smart pointer copy.
- Added missing getters to status flags in `ActivationStatus`
- Improved error reported from `CoreTask` or `PowerAuthCoreTask`. Previously, most of the errors were "Request failed with no exact reason"