### PR TITLE
Fix #809: Deprecate custom possession key

### DIFF
--- a/docs/Migration-from-1.9-to-2.0.md
+++ b/docs/Migration-from-1.9-to-2.0.md
@@ -11,6 +11,7 @@ PowerAuth Mobile SDK in version `2.0.0` provides the following improvements:
 - PowerAuth Mobile SDK now ensures sensitive keys are not retained in memory.
 - Activation using a recovery code is no longer supported.
 - External encryption key feature is discontinued and will be removed in the next SDK release.
+- Custom possession factor key provided in `PowerAuthAuthentication` is no longer supported.
 
 ### Compatibility with PowerAuth Server
 
@@ -54,6 +55,11 @@ Notable changes on Android:
     - `offlineSignatureComponentLength()` - use `offlineAuthenticationCodeComponentLength()` instead.
     - `disableAutomaticProtocolUpgrade()` - has no effect.
     - `build()` - method now throws `PowerAuthErrorException` if wrong configuration is provided.
+
+  - `PowerAuthAuthentication` class:
+    - `PowerAuthSDK` now validates the purpose of the authentication object. If you use an object created for authentication to persist activation (and vice versa), an exception is reported. 
+    - `getOverriddenPossessionKey()` method is now deprecated with no replacement.
+    - All construction methods that take a custom possession key are now deprecated. If you use such a method and provide a custom possession key, the created object will not pass validation when used in `PowerAuthSDK`. Please contact our support team for more details if this is important to you.
 
   - `IPersistActivationListener` callback interface:
     - `onPersistActivationFailed()` method now receives `Throwable` instead of `PowerAuthErrorException`. You can also expect `FailedApiException` and similar exceptions if communication with the server failed.
@@ -108,7 +114,7 @@ Notable changes on Android:
   - `PowerAuthSDK.persistActivationWithPassword()`
   - `PowerAuthSDK.addBiometryFactor()`
   - `PowerAuthAuthentication.getBiometryFactorRelatedKey()`
-  - `PowerAuthAuthentication.getOverriddenPossessionKey()`
+  - `PowerAuthAuthentication.getOverriddenPossessionKey()` and the method is deprecated with no replacement.
   - All static functions in `PowerAuthAuthentication` that takes custom possession or biometry key in parameter.
   - `IFetchEncryptionKeyListener.onFetchEncryptionKeySucceed()`
   - `CryptoUtils.ecdhComputeSharedSecret()`
@@ -179,6 +185,10 @@ Notable changes on iOS:
     - `disableAutomaticProtocolUpgrade` property is deprecated and has no effect in SDK.
   - `PowerAuthTokenStore` protocol:
     - `generateAuthorizationHeader(withName:completion:)` is replaced with `generateAuthenticationHeader(withName:completion:)`
+  - `PowerAuthAuthentication` class:
+    - `PowerAuthSDK` now validates the purpose of the authentication object. If you use an object created for authentication to persist activation (and vice versa), an error is reported. 
+    - `overridenPossessionKey` property is now deprecated with no replacement.
+    - All construction methods that take a custom possession key are now deprecated. If you use such a method and provide a custom possession key, the created object will not pass validation when used in `PowerAuthSDK`. Please contact our support team for more details if this is important to you.
   - `PowerAuthAuthorizationHttpHeader` is deprecated and replaced with `PowerAuthHttpHeader`
 
 - All static methods for accessing a various shared instances are now deprecated:
@@ -203,8 +213,8 @@ Notable changes on iOS:
 
 - The following functions or properties now takes or returns `PowerAuthCoreData` instead of `Data`:
   - `PowerAuthSDK.fetchEncryptionKey()`
-  - All static functions in `PowerAuthAuthentication` that takes custom possession or biometry key in parameter.
-  - `PowerAuthAuthentication.overridenPossessionKey` property is now `customPossessionKey`
+  - All static functions in `PowerAuthAuthentication` that takes custom biometry key in parameter.
+  - `PowerAuthAuthentication.overridenPossessionKey` and the method is deprecated with no replacement.
   - `PowerAuthAuthentication.overridenBiometryKey` property is now `customBiometryKey`
   - `PowerAuthCoreCryptoUtils.ecdhComputeSharedSecret()`
 

--- a/proj-android/PowerAuthLibrary/build.gradle
+++ b/proj-android/PowerAuthLibrary/build.gradle
@@ -156,6 +156,11 @@ tasks.register('verifyDebugSymbolsForRelease', Exec) {
     commandLine 'bash', '../../scripts/android-validate-build.sh', '--aar', "${buildDir}/outputs/aar/PowerAuthLibrary-release.aar"
 }
 
+// Uncomment to show usage of deprecated APIs
+//tasks.withType(JavaCompile).configureEach {
+//    options.compilerArgs += ["-Xlint:deprecation"]
+//}
+
 afterEvaluate {
     externalNativeBuildCleanDebug.dependsOn prepareOpenSSL
     externalNativeBuildCleanRelease.dependsOn prepareOpenSSL

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/PowerAuthTestHelper.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/PowerAuthTestHelper.java
@@ -114,8 +114,6 @@ public class PowerAuthTestHelper {
         private ApplicationDetail sharedApplication;
         private ApplicationVersion sharedApplicationVersion;
 
-        private boolean authenticationUsageStrictMode = true;
-
         private @PowerAuthAlgorithm int powerAuthAlgorithm = PowerAuthAlgorithm.DEFAULT;
 
         /**
@@ -207,17 +205,6 @@ public class PowerAuthTestHelper {
             return this;
         }
 
-        /**
-         * Enable or disable strict mode for PowerAuthAuthentication usage. The default value is that
-         * strict mode is enabled. See {@link io.getlime.security.powerauth.sdk.PowerAuthAuthenticationHelper#setStrictModeForUsageValidation(boolean)}.
-         * @param strictMode Enable or disable strict mode.
-         * @return Instance of this builder.
-         */
-        public @NonNull Builder powerAuthAuthenticationUsageValidationMode(boolean strictMode) {
-            this.authenticationUsageStrictMode = strictMode;
-            return this;
-        }
-
         public @NonNull Builder testFragmentActivity(@NonNull FragmentActivity activity) {
             this.testFragmentActivity = activity;
             return this;
@@ -249,8 +236,6 @@ public class PowerAuthTestHelper {
             // Prepare logger
             PowerAuthLog.setEnabled(true);
             PowerAuthLog.setVerbose(true);
-            // Prepare authentication validation mode
-            PowerAuthAuthenticationHelper.setStrictModeForUsageValidation(authenticationUsageStrictMode);
             // Prepare PowerAuthSDK configurations.
             final PowerAuthConfiguration configuration = prepareConfiguration();
             final PowerAuthBiometricConfiguration biometricConfiguration = prepareBiometricConfiguration();

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/sdk/PowerAuthAuthenticationHelper.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/sdk/PowerAuthAuthenticationHelper.java
@@ -27,15 +27,6 @@ import io.getlime.security.powerauth.core.Password;
  */
 public class PowerAuthAuthenticationHelper {
     /**
-     * Enable or disable strict mode for PowerAuthAuthentication usage validation. See
-     * {@link PowerAuthAuthentication#setStrictValidateAuthenticationUsage(boolean)} for more details.
-     * @param strictMode Enable or disable strict mode.
-     */
-    public static void setStrictModeForUsageValidation(boolean strictMode) {
-        PowerAuthAuthentication.setStrictValidateAuthenticationUsage(strictMode);
-    }
-
-    /**
      * Extract plaintext password from PowerAuthAuthentication's password.
      * @param authentication Authentication that should contain password.
      * @return Extracted password.

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/sdk/PowerAuthAuthenticationTests.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/sdk/PowerAuthAuthenticationTests.java
@@ -23,6 +23,8 @@ import org.junit.runner.RunWith;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.getlime.security.powerauth.core.Password;
+import io.getlime.security.powerauth.exception.PowerAuthErrorCodes;
+import io.getlime.security.powerauth.exception.PowerAuthErrorException;
 import io.getlime.security.powerauth.integration.support.RandomGenerator;
 import io.getlime.security.powerauth.system.PowerAuthLog;
 
@@ -47,106 +49,84 @@ public class PowerAuthAuthenticationTests {
         PowerAuthLog.setEnabled(true);
     }
 
-    @Before
-    public void setUp() throws Exception {
-        // disable strict validation mode, we would like to return failures instead of throwing an exception.
-        PowerAuthAuthenticationHelper.setStrictModeForUsageValidation(false);
-    }
-
     @Test
     public void testPersistWithPassword() throws Exception {
         PowerAuthAuthentication authentication = PowerAuthAuthentication.persistWithPassword(password);
-        assertTrue(authentication.validateAuthenticationUsage(true));
+        authentication.validateAuthenticationUsage(true);
         assertEquals(password, authentication.getPassword());
-
-        authentication = PowerAuthAuthentication.persistWithPassword(password, customPossessionKey);
-        assertTrue(authentication.validateAuthenticationUsage(true));
-        assertEquals(password, authentication.getPassword());
-        assertEquals(customPossessionKey, authentication.getOverriddenPossessionKey());
 
         authentication = PowerAuthAuthentication.persistWithPassword(stringPassword);
-        assertTrue(authentication.validateAuthenticationUsage(true));
+        authentication.validateAuthenticationUsage(true);
         assertEquals(password, authentication.getPassword());
-
-        authentication = PowerAuthAuthentication.persistWithPassword(stringPassword, customPossessionKey);
-        assertTrue(authentication.validateAuthenticationUsage(true));
-        assertEquals(password, authentication.getPassword());
-        assertEquals(customPossessionKey, authentication.getOverriddenPossessionKey());
     }
 
     @Test
     public void testPersisWithPasswordAndBiometry() throws Exception {
         PowerAuthAuthentication authentication = PowerAuthAuthentication.persistWithPasswordAndBiometry(password, biometryKey);
-        assertTrue(authentication.validateAuthenticationUsage(true));
+        authentication.validateAuthenticationUsage(true);
         assertEquals(password, authentication.getPassword());
         assertEquals(biometryKey, authentication.getBiometryFactorRelatedKey());
-
-        authentication = PowerAuthAuthentication.persistWithPasswordAndBiometry(password, biometryKey, customPossessionKey);
-        assertTrue(authentication.validateAuthenticationUsage(true));
-        assertEquals(password, authentication.getPassword());
-        assertEquals(biometryKey, authentication.getBiometryFactorRelatedKey());
-        assertEquals(customPossessionKey, authentication.getOverriddenPossessionKey());
 
         authentication = PowerAuthAuthentication.persistWithPasswordAndBiometry(stringPassword, biometryKey);
-        assertTrue(authentication.validateAuthenticationUsage(true));
+        authentication.validateAuthenticationUsage(true);
         assertEquals(password, authentication.getPassword());
         assertEquals(biometryKey, authentication.getBiometryFactorRelatedKey());
-
-        authentication = PowerAuthAuthentication.persistWithPasswordAndBiometry(stringPassword, biometryKey, customPossessionKey);
-        assertTrue(authentication.validateAuthenticationUsage(true));
-        assertEquals(password, authentication.getPassword());
-        assertEquals(biometryKey, authentication.getBiometryFactorRelatedKey());
-        assertEquals(customPossessionKey, authentication.getOverriddenPossessionKey());
     }
 
     @Test
     public void testPossessionOnly() throws Exception {
         PowerAuthAuthentication authentication = PowerAuthAuthentication.possession();
-        assertTrue(authentication.validateAuthenticationUsage(false));
-        assertEquals(1, authentication.getAuthenticationCodeFactorsMask());
-        
-        authentication = PowerAuthAuthentication.possession(customPossessionKey);
-        assertTrue(authentication.validateAuthenticationUsage(false));
-        assertEquals(customPossessionKey, authentication.getOverriddenPossessionKey());
+        authentication.validateAuthenticationUsage(false);
         assertEquals(1, authentication.getAuthenticationCodeFactorsMask());
     }
 
     @Test
     public void testPossessionWithPassword() throws Exception {
         PowerAuthAuthentication authentication = PowerAuthAuthentication.possessionWithPassword(password);
-        assertTrue(authentication.validateAuthenticationUsage(false));
+        authentication.validateAuthenticationUsage(false);
         assertEquals(password, authentication.getPassword());
-        assertEquals(1 + 2, authentication.getAuthenticationCodeFactorsMask());
-
-        authentication = PowerAuthAuthentication.possessionWithPassword(password, customPossessionKey);
-        assertTrue(authentication.validateAuthenticationUsage(false));
-        assertEquals(password, authentication.getPassword());
-        assertEquals(customPossessionKey, authentication.getOverriddenPossessionKey());
         assertEquals(1 + 2, authentication.getAuthenticationCodeFactorsMask());
 
         authentication = PowerAuthAuthentication.possessionWithPassword(stringPassword);
-        assertTrue(authentication.validateAuthenticationUsage(false));
+        authentication.validateAuthenticationUsage(false);
         assertEquals(password, authentication.getPassword());
-        assertEquals(1 + 2, authentication.getAuthenticationCodeFactorsMask());
-
-        authentication = PowerAuthAuthentication.possessionWithPassword(stringPassword, customPossessionKey);
-        assertTrue(authentication.validateAuthenticationUsage(false));
-        assertEquals(password, authentication.getPassword());
-        assertEquals(customPossessionKey, authentication.getOverriddenPossessionKey());
         assertEquals(1 + 2, authentication.getAuthenticationCodeFactorsMask());
     }
 
     @Test
     public void testPossessionWithBiometry() throws Exception {
         PowerAuthAuthentication authentication = PowerAuthAuthentication.possessionWithBiometry(biometryKey);
-        assertTrue(authentication.validateAuthenticationUsage(false));
+        authentication.validateAuthenticationUsage(false);
         assertEquals(biometryKey, authentication.getBiometryFactorRelatedKey());
         assertEquals(1 + 4, authentication.getAuthenticationCodeFactorsMask());
+    }
 
-        authentication = PowerAuthAuthentication.possessionWithBiometry(biometryKey, customPossessionKey);
-        assertTrue(authentication.validateAuthenticationUsage(false));
-        assertEquals(biometryKey, authentication.getBiometryFactorRelatedKey());
-        assertEquals(customPossessionKey, authentication.getOverriddenPossessionKey());
-        assertEquals(1 + 4, authentication.getAuthenticationCodeFactorsMask());
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testWrongUsage() {
+        PowerAuthErrorException exception;
+        // wrong usage
+        exception = assertThrows(PowerAuthErrorException.class, () -> PowerAuthAuthentication.persistWithPassword(password).validateAuthenticationUsage(false));
+        assertEquals(PowerAuthErrorCodes.WRONG_PARAMETER, exception.getPowerAuthErrorCode());
+        exception = assertThrows(PowerAuthErrorException.class, () -> PowerAuthAuthentication.possessionWithPassword(password).validateAuthenticationUsage(true));
+        assertEquals(PowerAuthErrorCodes.WRONG_PARAMETER, exception.getPowerAuthErrorCode());
+
+        // deprecated API
+        exception = assertThrows(PowerAuthErrorException.class, () -> PowerAuthAuthentication.persistWithPassword(password, customPossessionKey).validateAuthenticationUsage(true));
+        assertEquals(PowerAuthErrorCodes.WRONG_PARAMETER, exception.getPowerAuthErrorCode());
+        exception = assertThrows(PowerAuthErrorException.class, () -> PowerAuthAuthentication.persistWithPassword(stringPassword, customPossessionKey).validateAuthenticationUsage(true));
+        assertEquals(PowerAuthErrorCodes.WRONG_PARAMETER, exception.getPowerAuthErrorCode());
+        exception = assertThrows(PowerAuthErrorException.class, () -> PowerAuthAuthentication.persistWithPasswordAndBiometry(password, biometryKey, customPossessionKey).validateAuthenticationUsage(true));
+        assertEquals(PowerAuthErrorCodes.WRONG_PARAMETER, exception.getPowerAuthErrorCode());
+        exception = assertThrows(PowerAuthErrorException.class, () -> PowerAuthAuthentication.persistWithPasswordAndBiometry(stringPassword, biometryKey, customPossessionKey).validateAuthenticationUsage(true));
+        assertEquals(PowerAuthErrorCodes.WRONG_PARAMETER, exception.getPowerAuthErrorCode());
+        exception = assertThrows(PowerAuthErrorException.class, () -> PowerAuthAuthentication.possession(customPossessionKey).validateAuthenticationUsage(false));
+        assertEquals(PowerAuthErrorCodes.WRONG_PARAMETER, exception.getPowerAuthErrorCode());
+        exception = assertThrows(PowerAuthErrorException.class, () -> PowerAuthAuthentication.possessionWithPassword(password, customPossessionKey).validateAuthenticationUsage(false));
+        assertEquals(PowerAuthErrorCodes.WRONG_PARAMETER, exception.getPowerAuthErrorCode());
+        exception = assertThrows(PowerAuthErrorException.class, () -> PowerAuthAuthentication.possessionWithPassword(stringPassword, customPossessionKey).validateAuthenticationUsage(false));
+        assertEquals(PowerAuthErrorCodes.WRONG_PARAMETER, exception.getPowerAuthErrorCode());
+        exception = assertThrows(PowerAuthErrorException.class, () -> PowerAuthAuthentication.possessionWithBiometry(biometryKey, customPossessionKey).validateAuthenticationUsage(false));
+        assertEquals(PowerAuthErrorCodes.WRONG_PARAMETER, exception.getPowerAuthErrorCode());
     }
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthAuthentication.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthAuthentication.java
@@ -20,6 +20,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import io.getlime.security.powerauth.core.Password;
 import io.getlime.security.powerauth.core.SecureData;
+import io.getlime.security.powerauth.exception.PowerAuthErrorCodes;
+import io.getlime.security.powerauth.exception.PowerAuthErrorException;
 import io.getlime.security.powerauth.system.PowerAuthLog;
 
 import java.util.Arrays;
@@ -50,7 +52,7 @@ public class PowerAuthAuthentication {
      * if object is for authentication code calculation or {@code null} if this is a legacy object with no usage
      * specified.
      */
-    private final Boolean persistActivation;
+    private final boolean persistActivation;
 
     /**
      * Construct object with desired combination of factors. Such authentication object can be used
@@ -70,7 +72,7 @@ public class PowerAuthAuthentication {
      * @param overriddenPossessionKey Custom possession factor related key.
      */
     PowerAuthAuthentication(
-            Boolean persistActivation,
+            boolean persistActivation,
             @Nullable Password password,
             @Nullable PowerAuthBiometricPrompt biometricPrompt,
             @Nullable SecureData biometryFactorRelatedKey,
@@ -134,7 +136,9 @@ public class PowerAuthAuthentication {
      * @param password Password to set for new activation.
      * @param overriddenPossessionKey Custom possession key to set for new activation.
      * @return Authentication object constructed to persist activation with password, with using custom key for the possession factor.
+     * @deprecated The custom possession key is no longer supported.
      */
+    @Deprecated(since = "2.0.0")
     public static PowerAuthAuthentication persistWithPassword(@NonNull String password, @NonNull SecureData overriddenPossessionKey) {
         return new PowerAuthAuthentication(true, new Password(password), null, null, overriddenPossessionKey);
     }
@@ -165,7 +169,9 @@ public class PowerAuthAuthentication {
      * @param biometryFactorRelatedKey Biometry factor related key to set for new activation.
      * @param overriddenPossessionKey Custom possession key to set for new activation.
      * @return Authentication object constructed to persist activation with password, with using custom key for the possession factor.
+     * @deprecated The custom possession key is no longer supported.
      */
+    @Deprecated(since = "2.0.0")
     public static PowerAuthAuthentication persistWithPasswordAndBiometry(@NonNull String password, @NonNull SecureData biometryFactorRelatedKey, @NonNull SecureData overriddenPossessionKey) {
         return new PowerAuthAuthentication(true, new Password(password), null, biometryFactorRelatedKey, overriddenPossessionKey);
     }
@@ -186,7 +192,9 @@ public class PowerAuthAuthentication {
      * @param password Password to set for new activation.
      * @param overriddenPossessionKey Custom possession key to set for new activation.
      * @return Authentication object constructed to persist activation and password, with using custom key for the possession factor.
+     * @deprecated The custom possession key is no longer supported.
      */
+    @Deprecated(since = "2.0.0")
     public static PowerAuthAuthentication persistWithPassword(@NonNull Password password, @NonNull SecureData overriddenPossessionKey) {
         return new PowerAuthAuthentication(true, password, null, null, overriddenPossessionKey);
     }
@@ -217,7 +225,9 @@ public class PowerAuthAuthentication {
      * @param biometryFactorRelatedKey Biometry factor related key to set for new activation.
      * @param overriddenPossessionKey Custom possession key to set for new activation.
      * @return Authentication object constructed to persist activation with password, with using custom key for the possession factor.
+     * @deprecated The custom possession key is no longer supported.
      */
+    @Deprecated(since = "2.0.0")
     public static PowerAuthAuthentication persistWithPasswordAndBiometry(@NonNull Password password, @NonNull SecureData biometryFactorRelatedKey, @NonNull SecureData overriddenPossessionKey) {
         return new PowerAuthAuthentication(true, password, null, biometryFactorRelatedKey, overriddenPossessionKey);
     }
@@ -236,7 +246,9 @@ public class PowerAuthAuthentication {
      * Construct authentication object for authentication code calculation purposes. The authentication code is calculated with possession factor only, with using custom possession key.
      * @param overriddenPossessionKey Custom possession key to use for the authentication code calculation.
      * @return Authentication object constructed to calculate authentication code with possession factor with custom possession key.
+     * @deprecated The custom possession key is no longer supported.
      */
+    @Deprecated(since = "2.0.0")
     public static PowerAuthAuthentication possession(@NonNull SecureData overriddenPossessionKey) {
         return new PowerAuthAuthentication(false, null, null, null, overriddenPossessionKey);
     }
@@ -255,7 +267,9 @@ public class PowerAuthAuthentication {
      * @param password Password to use for the authentication code calculation.
      * @param overriddenPossessionKey Custom possession key to use for the authentication code calculation.
      * @return Authentication object constructed to calculate authentication code with possession and knowledge factors, with using custom possession key.
+     * @deprecated The custom possession key is no longer supported.
      */
+    @Deprecated(since = "2.0.0")
     public static PowerAuthAuthentication possessionWithPassword(@NonNull String password, @NonNull SecureData overriddenPossessionKey) {
         return new PowerAuthAuthentication(false, new Password(password), null, null, overriddenPossessionKey);
     }
@@ -283,7 +297,9 @@ public class PowerAuthAuthentication {
      * @param biometryFactorRelatedKey Biometry key data to use for the authentication code calculation.
      * @param overriddenPossessionKey Custom possession key to use for the authentication code calculation.
      * @return Authentication object constructed to calculate authentication code with possession and biometry factors, with using custom possession key.
+     * @deprecated The custom possession key is no longer supported.
      */
+    @Deprecated(since = "2.0.0")
     public static PowerAuthAuthentication possessionWithBiometry(@NonNull SecureData biometryFactorRelatedKey, @NonNull SecureData overriddenPossessionKey) {
         return new PowerAuthAuthentication(false, null, null, biometryFactorRelatedKey, overriddenPossessionKey);
     }
@@ -304,7 +320,9 @@ public class PowerAuthAuthentication {
      * @param password Password to use for the authentication code calculation.
      * @param overriddenPossessionKey Custom possession key to use for the authentication code calculation.
      * @return Authentication object constructed to calculate authentication code with possession and knowledge factors, with using custom possession key.
+     * @deprecated The custom possession key is no longer supported.
      */
+    @Deprecated(since = "2.0.0")
     public static PowerAuthAuthentication possessionWithPassword(@NonNull Password password, @NonNull SecureData overriddenPossessionKey) {
         return new PowerAuthAuthentication(false, password, null, null, overriddenPossessionKey);
     }
@@ -347,6 +365,7 @@ public class PowerAuthAuthentication {
     /**
      * @return If non-null, then custom key is specified for the possession factor.
      */
+    @Deprecated(since = "2.0.0")
     @Nullable
     public SecureData getOverriddenPossessionKey() {
         return overriddenPossessionKey;
@@ -378,55 +397,18 @@ public class PowerAuthAuthentication {
     }
 
     /**
-     * Validate usage of PowerAuthAuthentication object. If something doesn't match, then function
-     * print warning to the debug console.
+     * Validate usage of PowerAuthAuthentication object.
      * @param forPersist If true, then activation persist is expected.
-     * @return false if object is created for the different purpose or is legacy constructed.
+     * @throws PowerAuthErrorException if authentication object is not valid.
      */
-    boolean validateAuthenticationUsage(boolean forPersist) {
-        boolean result = validateAuthenticationUsageImpl(forPersist);
-        if (!result && strictAuthenticationUsageValidation) {
-            throw new IllegalArgumentException("Invalid PowerAuthAuthentication object provided");
+    void validateAuthenticationUsage(boolean forPersist) throws PowerAuthErrorException {
+        if (persistActivation != forPersist) {
+            throw new PowerAuthErrorException(PowerAuthErrorCodes.WRONG_PARAMETER,
+                    forPersist ? "Using PowerAuthAuthentication object for a different purpose. The object to persist activation is expected."
+                            : "Using PowerAuthAuthentication object for a different purpose. The object for authentication code calculation is expected.");
+        } else if (overriddenPossessionKey != null) {
+            throw new PowerAuthErrorException(PowerAuthErrorCodes.WRONG_PARAMETER,
+                    "Using PowerAuthAuthentication with a custom possession key is no longer supported.");
         }
-        return result;
-    }
-
-    /**
-     * If set to true, then validateAuthenticationUsage() throws IllegalArgumentException().
-     */
-    private static boolean strictAuthenticationUsageValidation = false;
-
-    /**
-     * Enable or disable strict mode for {@link #validateAuthenticationUsage(boolean)} method.
-     * If strict mode is enabled, then validation throws an error in case that validation fails.
-     * This is useful only for PowerAuth SDK unit and integration testing.
-     *
-     * @param strict Enable or disable strict mode.
-     */
-    static void setStrictValidateAuthenticationUsage(boolean strict) {
-        strictAuthenticationUsageValidation = strict;
-    }
-
-    /**
-     * Validate usage of PowerAuthAuthentication object. If something doesn't match, then function
-     * print warning to the debug console.
-     * @param forPersist If true, then activation persist is expected.
-     * @return false if object is created for the different purpose or is legacy constructed.
-     */
-    private boolean validateAuthenticationUsageImpl(boolean forPersist) {
-        if (persistActivation == null) {
-            PowerAuthLog.w("Using PowerAuthAuthentication object created with legacy constructor.");
-            return false;
-        } else {
-            if (persistActivation != forPersist) {
-                if (forPersist) {
-                    PowerAuthLog.w("Using PowerAuthAuthentication object for a different purpose. The object to persist activation is expected.");
-                } else {
-                    PowerAuthLog.w("Using PowerAuthAuthentication object for a different purpose. The object for authentication code calculation is expected.");
-                }
-                return false;
-            }
-        }
-        return true;
     }
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthAuthentication.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthAuthentication.java
@@ -22,7 +22,6 @@ import io.getlime.security.powerauth.core.Password;
 import io.getlime.security.powerauth.core.SecureData;
 import io.getlime.security.powerauth.exception.PowerAuthErrorCodes;
 import io.getlime.security.powerauth.exception.PowerAuthErrorException;
-import io.getlime.security.powerauth.system.PowerAuthLog;
 
 import java.util.Arrays;
 
@@ -48,9 +47,8 @@ public class PowerAuthAuthentication {
     private final @Nullable SecureData overriddenPossessionKey;
 
     /**
-     * Contains {@code true} if authentication object should be used to persist activation, {@code false}
-     * if object is for authentication code calculation or {@code null} if this is a legacy object with no usage
-     * specified.
+     * Contains {@code true} if authentication object should be used to persist activation,
+     * {@code false} if object is for authentication code calculation.
      */
     private final boolean persistActivation;
 

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthAuthorizationHttpHeader.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthAuthorizationHttpHeader.java
@@ -72,6 +72,7 @@ public class PowerAuthAuthorizationHttpHeader {
      * @deprecated The new methods for calculating authentication headers throws an exception in case of failure, and
      *             therefore the returned header is always valid.
      */
+    @Deprecated
     public boolean isValid() {
         return powerAuthErrorCode == PowerAuthErrorCodes.SUCCEED &&
                 key != null &&

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -214,9 +214,6 @@ public class PowerAuthSDK {
             // Prepare state listener
             final ISavePowerAuthStateListener stateListener = mStateListener != null ? mStateListener : new DefaultSavePowerAuthStateListener(statusKeychain);
 
-            // Prepare possession factor encryption key provider
-            final IDeviceSpecificDataProvider possessionEncryptionKeyProvider = new DefaultDeviceSpecificDataProvider();
-
             // Prepare time synchronization service and connect it with HTTP client.
             final TimeSynchronizationService timeSynchronizationService = new TimeSynchronizationService(sharedLock, session.getTimeService(), httpClient, mCallbackDispatcher);
             httpClient.setTimeSynchronizationService(timeSynchronizationService);

--- a/proj-xcode/PowerAuth2/PowerAuthAuthentication.h
+++ b/proj-xcode/PowerAuth2/PowerAuthAuthentication.h
@@ -259,7 +259,7 @@
 ///
 /// @param password PowerAuthCorePassword used for the knowledge factor.
 /// @param customBiometryKey Custom key used for biometry factor.
-/// @return Instance of authentication object configured to persist activation with password and biometry, allowing to usecustom keys for possession and biometry factors.
+/// @return Instance of authentication object configured to persist activation with password and biometry, allowing to use custom keys for possession and biometry factors.
 + (nonnull PowerAuthAuthentication*) persistWithCorePasswordAndBiometry:(nonnull PowerAuthCorePassword*)password
                                                       customBiometryKey:(nullable PowerAuthCoreData*)customBiometryKey
                             NS_SWIFT_NAME(persistWithPasswordAndBiometry(password:customBiometryKey:));
@@ -272,7 +272,7 @@
 /// @param password PowerAuthCorePassword used for the knowledge factor.
 /// @param customBiometryKey Custom key used for biometry factor.
 /// @param customPossessionKey Custom key used for possession factor.
-/// @return Instance of authentication object configured to persist activation with password and biometry, allowing to usecustom keys for possession and biometry factors.
+/// @return Instance of authentication object configured to persist activation with password and biometry, allowing to use custom keys for possession and biometry factors.
 /// @deprecated The custom possession key is no longer supported.
 + (nonnull PowerAuthAuthentication*) persistWithCorePasswordAndBiometry:(nonnull PowerAuthCorePassword*)password
                                                       customBiometryKey:(nullable PowerAuthCoreData*)customBiometryKey

--- a/proj-xcode/PowerAuth2/PowerAuthAuthentication.h
+++ b/proj-xcode/PowerAuth2/PowerAuthAuthentication.h
@@ -100,7 +100,7 @@
 ///
 /// @param password Password used for the knowledge factor.
 /// @param customBiometryKey Custom key used for biometry factor.
-/// @return Instance of authentication object configured to persist activation with password and biometry, allowing to use custom keys for possession and biometry factors.
+/// @return Instance of authentication object configured to persist activation with password and biometry, allowing to use custom key for the biometry factor.
 + (nonnull PowerAuthAuthentication*) persistWithPasswordAndBiometry:(nonnull NSString*)password
                                                   customBiometryKey:(nullable PowerAuthCoreData*)customBiometryKey;
 

--- a/proj-xcode/PowerAuth2/PowerAuthAuthentication.h
+++ b/proj-xcode/PowerAuth2/PowerAuthAuthentication.h
@@ -48,7 +48,8 @@
 @property (nonatomic, strong, nullable, readonly) LAContext *biometryContext API_UNAVAILABLE(watchos, tvos);
 
 /// If 'usePossession' is set to YES, this value may specify possession key data. If no custom data is specified, default possession key is used.
-@property (nonatomic, strong, nullable, readonly) PowerAuthCoreData *customPossessionKey;
+/// @deprecated The custom possession key is no longer supported.
+@property (nonatomic, strong, nullable, readonly) PowerAuthCoreData *overridenPossessionKey PA2_DEPRECATED(2.0.0);
 
 /// If 'useBiometry' is set to YES, this value may specify biometry key data. If no custom data is specified, default biometry key is used for the PowerAuthSDK instance, based on the keychain configuration and SDK instance configuration.
 @property (nonatomic, strong, nullable, readonly) PowerAuthCoreData *customBiometryKey;
@@ -75,9 +76,11 @@
 /// @param password Password used for the knowledge factor.
 /// @param customPossessionKey Custom key used for possession factor.
 /// @return Instance of authentication object configured for to persist activation with password and custom possession key.
+/// @deprecated The custom possession key is no longer supported.
 + (nonnull PowerAuthAuthentication*) persistWithPassword:(nonnull NSString*)password
                                      customPossessionKey:(nonnull PowerAuthCoreData*)customPossessionKey
-                        NS_SWIFT_NAME(persistWithPassword(password:customPossessionKey:));
+                        NS_SWIFT_NAME(persistWithPassword(password:customPossessionKey:))
+                        PA2_DEPRECATED(2.0.0);
 
 // Persist, Possession + Knowledge + Biometry
 
@@ -91,6 +94,17 @@
                         NS_SWIFT_NAME(persistWithPasswordAndBiometry(password:));
 
 /// Create a new instance of authentication object configured to persist activation with password and with biometry.
+/// This variant of function allows you to use custom keys for biometry.
+///
+/// Function is not available for App extensions and on watchOS.
+///
+/// @param password Password used for the knowledge factor.
+/// @param customBiometryKey Custom key used for biometry factor.
+/// @return Instance of authentication object configured to persist activation with password and biometry, allowing to use custom keys for possession and biometry factors.
++ (nonnull PowerAuthAuthentication*) persistWithPasswordAndBiometry:(nonnull NSString*)password
+                                                  customBiometryKey:(nullable PowerAuthCoreData*)customBiometryKey;
+
+/// Create a new instance of authentication object configured to persist activation with password and with biometry.
 /// This variant of function allows you to use custom keys for biometry and possession factors.
 ///
 /// Function is not available for App extensions and on watchOS.
@@ -99,10 +113,12 @@
 /// @param customBiometryKey Custom key used for biometry factor.
 /// @param customPossessionKey Custom key used for possession factor.
 /// @return Instance of authentication object configured to persist activation with password and biometry, allowing to use custom keys for possession and biometry factors.
+/// @deprecated The custom possession key is no longer supported.
 + (nonnull PowerAuthAuthentication*) persistWithPasswordAndBiometry:(nonnull NSString*)password
                                                   customBiometryKey:(nullable PowerAuthCoreData*)customBiometryKey
                                                 customPossessionKey:(nullable PowerAuthCoreData*)customPossessionKey
-                        NS_SWIFT_NAME(persistWithPasswordAndBiometry(password:customBiometryKey:customPossessionKey:));
+                        NS_SWIFT_NAME(persistWithPasswordAndBiometry(password:customBiometryKey:customPossessionKey:))
+                        PA2_DEPRECATED(2.0.0);
 
 // Signing, Possession only
 
@@ -113,10 +129,12 @@
 /// Create a new instance of authentication object preconfigured for signing with a possession factor, with using custom possession key.
 /// @param customPossessionKey Custom key used for possession factor.
 /// @return Instance of PowerAuthAuthentication configured for signing with a possession factor with using custom possession key.
+/// @deprecated The custom possession key is no longer supported.
 + (nonnull PowerAuthAuthentication *) possessionWithCustomPossessionKey:(nonnull PowerAuthCoreData*)customPossessionKey
-                        NS_SWIFT_NAME(possession(customPossessionKey:));
+                        NS_SWIFT_NAME(possession(customPossessionKey:))
+                        PA2_DEPRECATED(2.0.0);
 
-// Signing, Possession + Biometry
+// Authentication, Possession + Biometry
 
 /// Create a new instance of authentication object preconfigured for signing with a possession and biometry factors.
 /// @return Instance of PowerAuthAuthentication configured for signing with a possession and biometry factors.
@@ -125,11 +143,19 @@
 
 /// Returns a new instance of authentication object preconfigured for a combination of possession and biometry factors.
 /// @param customBiometryKey Custom key used for biometry factor.
-/// @param customPossessionKey Custom key used for possession factor.
 /// @return New instance of authentication object configured for signing with a possession and biometry factors, with custom biometry and possession keys.
 + (nonnull PowerAuthAuthentication *) possessionWithBiometryWithCustomBiometryKey:(nullable PowerAuthCoreData*)customBiometryKey
+                        NS_SWIFT_NAME(possessionWithBiometry(customBiometryKey:));
+
+/// Returns a new instance of authentication object preconfigured for a combination of possession and biometry factors.
+/// @param customBiometryKey Custom key used for biometry factor.
+/// @param customPossessionKey Custom key used for possession factor.
+/// @return New instance of authentication object configured for signing with a possession and biometry factors, with custom biometry and possession keys.
+/// @deprecated The custom possession key is no longer supported.
++ (nonnull PowerAuthAuthentication *) possessionWithBiometryWithCustomBiometryKey:(nullable PowerAuthCoreData*)customBiometryKey
                                                               customPossessionKey:(nullable PowerAuthCoreData*)customPossessionKey
-                        NS_SWIFT_NAME(possessionWithBiometry(customBiometryKey:customPossessionKey:));
+                        NS_SWIFT_NAME(possessionWithBiometry(customBiometryKey:customPossessionKey:))
+                        PA2_DEPRECATED(2.0.0);
 
 /// Create a new instance of authentication object preconfigured for signign with combination of possession and biometry factors and with prompt,
 /// displayed in the system biometric authentication dialog.
@@ -142,9 +168,11 @@
 /// displayed in the system biometric authentication dialog. This variant of function allows you also use the custom possession key for the possession factor.
 /// @param biometryPrompt Prompt displayed in the system biometric authentication dialog.
 /// @return New instance of authentication object configured for signing with a custom possession key and biometry factors, with custom prompt displayed in the system biometric authentication dialog.
+/// @deprecated The custom possession key is no longer supported.
 + (nonnull PowerAuthAuthentication *) possessionWithBiometryPrompt:(nonnull NSString*)biometryPrompt
                                                customPossessionKey:(nonnull PowerAuthCoreData*)customPossessionKey
-                        NS_SWIFT_NAME(possessionWithBiometry(prompt:customPossessionKey:));
+                        NS_SWIFT_NAME(possessionWithBiometry(prompt:customPossessionKey:))
+                        PA2_DEPRECATED(2.0.0);
 
 /// Create a new instance of authentication object preconfigured for signing with combination of possession and biometry factors and with local
 /// authentication context. The context allows you to better customize the system biometric authentication dialog.
@@ -159,10 +187,12 @@
 /// you also use the custom possession key for the possession factor.
 /// @param context LAContext for the system biometric authentication dialog.
 /// @return New instance of authentication object configured for signing with a custom possession key and biometry factor, with local authentication context.
+/// @deprecated The custom possession key is no longer supported.
 + (nonnull PowerAuthAuthentication *) possessionWithBiometryContext:(nonnull LAContext*)context
                                                 customPossessionKey:(nonnull PowerAuthCoreData*)customPossessionKey
                         NS_SWIFT_NAME(possessionWithBiometry(context:customPossessionKey:))
-                        API_UNAVAILABLE(watchos, tvos);
+                        API_UNAVAILABLE(watchos, tvos)
+                        PA2_DEPRECATED(2.0.0);
 
 
 // Signing, Possession + Knowledge
@@ -176,10 +206,12 @@
 /// Create a new instance of authentication object preconfigured for combination of possesion and knowledge factors, with using custom possession key.
 /// @param password Password used for the knowledge factor.
 /// @param customPossessionKey Custom key used for possession factor.
-/// @return New instnace of authentication object configured for signing with custom possession key and knowledge factor.
+/// @return New instance of authentication object configured for signing with custom possession key and knowledge factor.
+/// @deprecated The custom possession key is no longer supported.
 + (nonnull PowerAuthAuthentication *) possessionWithPassword:(nonnull NSString*)password
                                          customPossessionKey:(nonnull PowerAuthCoreData*)customPossessionKey
-                        NS_SWIFT_NAME(possessionWithPassword(password:customPossessionKey:));
+                        NS_SWIFT_NAME(possessionWithPassword(password:customPossessionKey:))
+                        PA2_DEPRECATED(2.0.0);
 
 @end
 
@@ -203,9 +235,11 @@
 /// @param password PowerAuthCorePassword used for the knowledge factor.
 /// @param customPossessionKey Custom key used for possession factor.
 /// @return Instance of authentication object configured to persist activation with password and custom possession key.
+/// @deprecated The custom possession key is no longer supported.
 + (nonnull PowerAuthAuthentication*) persistWithCorePassword:(nonnull PowerAuthCorePassword*)password
                                          customPossessionKey:(nonnull PowerAuthCoreData*)customPossessionKey
-                            NS_SWIFT_NAME(persistWithPassword(password:customPossessionKey:));
+                            NS_SWIFT_NAME(persistWithPassword(password:customPossessionKey:))
+                            PA2_DEPRECATED(2.0.0);
 
 // Persist, Possession + Knowledge + Biometry
 
@@ -225,12 +259,26 @@
 ///
 /// @param password PowerAuthCorePassword used for the knowledge factor.
 /// @param customBiometryKey Custom key used for biometry factor.
-/// @param customPossessionKey Custom key used for possession factor.
 /// @return Instance of authentication object configured to persist activation with password and biometry, allowing to usecustom keys for possession and biometry factors.
 + (nonnull PowerAuthAuthentication*) persistWithCorePasswordAndBiometry:(nonnull PowerAuthCorePassword*)password
                                                       customBiometryKey:(nullable PowerAuthCoreData*)customBiometryKey
+                            NS_SWIFT_NAME(persistWithPasswordAndBiometry(password:customBiometryKey:));
+
+/// Create a new instance of authentication object configured to persist activation with password and with biometry.
+/// This variant of function allows you to use custom keys for biometry and possession factors.
+///
+/// Function is not available for App extensions and on watchOS.
+///
+/// @param password PowerAuthCorePassword used for the knowledge factor.
+/// @param customBiometryKey Custom key used for biometry factor.
+/// @param customPossessionKey Custom key used for possession factor.
+/// @return Instance of authentication object configured to persist activation with password and biometry, allowing to usecustom keys for possession and biometry factors.
+/// @deprecated The custom possession key is no longer supported.
++ (nonnull PowerAuthAuthentication*) persistWithCorePasswordAndBiometry:(nonnull PowerAuthCorePassword*)password
+                                                      customBiometryKey:(nullable PowerAuthCoreData*)customBiometryKey
                                                     customPossessionKey:(nullable PowerAuthCoreData*)customPossessionKey
-                            NS_SWIFT_NAME(persistWithPasswordAndBiometry(password:customBiometryKey:customPossessionKey:));
+                            NS_SWIFT_NAME(persistWithPasswordAndBiometry(password:customBiometryKey:customPossessionKey:))
+                            PA2_DEPRECATED(2.0.0);
 
 // Signing, Possession + Knowledge
 
@@ -243,9 +291,11 @@
 /// Create a new instance of authentication object preconfigured for combination of possesion and knowledge factors, with using custom possession key.
 /// @param password PowerAuthCorePassword used for the knowledge factor.
 /// @param customPossessionKey Custom key used for possession factor.
-/// @return New instnace of authentication object configured for signing with custom possession key and knowledge factor.
+/// @return New instance of authentication object configured for signing with custom possession key and knowledge factor.
+/// @deprecated The custom possession key is no longer supported.
 + (nonnull PowerAuthAuthentication *) possessionWithCorePassword:(nonnull PowerAuthCorePassword*)password
                                          customPossessionKey:(nonnull PowerAuthCoreData*)customPossessionKey
-                            NS_SWIFT_NAME(possessionWithPassword(password:customPossessionKey:));
+                            NS_SWIFT_NAME(possessionWithPassword(password:customPossessionKey:))
+                            PA2_DEPRECATED(2.0.0);
 
 @end

--- a/proj-xcode/PowerAuth2/PowerAuthAuthentication.m
+++ b/proj-xcode/PowerAuth2/PowerAuthAuthentication.m
@@ -18,6 +18,7 @@
 #import <PowerAuth2/PowerAuthKeychainAuthentication.h>
 #import <PowerAuth2/PowerAuthLog.h>
 #import "PowerAuthAuthentication+Private.h"
+#import "PA2PrivateMacros.h"
 
 @import PowerAuthCore;
 
@@ -45,7 +46,7 @@
         _useBiometry = biometry;
         _biometryPrompt = biometryPrompt;
         _biometryContext = biometryContext;
-        _customPossessionKey = customPossessionKey;
+        _overridenPossessionKey = customPossessionKey;
         _customBiometryKey = customBiometryKey;
     }
     return self;
@@ -60,7 +61,7 @@
         copy->_useBiometry = _useBiometry;
         copy->_password = _password;
         copy->_biometryPrompt = _biometryPrompt;
-        copy->_customPossessionKey = _customPossessionKey;
+        copy->_overridenPossessionKey = _overridenPossessionKey;
         copy->_customBiometryKey = _customBiometryKey;
 #if PA2_HAS_LACONTEXT == 1
         copy->_biometryContext = _biometryContext;
@@ -114,7 +115,7 @@
     if (_customBiometryKey) {
         [info addObject:@"+extBK"];
     }
-    if (_customPossessionKey) {
+    if (_overridenPossessionKey) {
         [info addObject:@"+extPK"];
     }
     NSString * info_str = info.count == 0 ? @"" : [@", " stringByAppendingString:[info componentsJoinedByString:@" "]];
@@ -134,6 +135,7 @@
     return [self persistWithCorePassword:[PowerAuthCorePassword passwordWithString:password]];
 }
 
+// PA2_DEPRECATED(2.0.0)
 + (PowerAuthAuthentication*) persistWithPassword:(NSString*)password
                              customPossessionKey:(PowerAuthCoreData*)customPossessionKey
 {
@@ -150,29 +152,20 @@
 
 + (PowerAuthAuthentication*) persistWithPasswordAndBiometry:(NSString*)password
                                           customBiometryKey:(PowerAuthCoreData*)customBiometryKey
+{
+    return [self persistWithCorePasswordAndBiometry:[PowerAuthCorePassword passwordWithString:password]
+                                  customBiometryKey:customBiometryKey];
+}
+
+// PA2_DEPRECATED(2.0.0)
++ (PowerAuthAuthentication*) persistWithPasswordAndBiometry:(NSString*)password
+                                          customBiometryKey:(PowerAuthCoreData*)customBiometryKey
                                         customPossessionKey:(PowerAuthCoreData*)customPossessionKey
 {
     return [self persistWithCorePasswordAndBiometry:[PowerAuthCorePassword passwordWithString:password]
                                   customBiometryKey:customBiometryKey
                                 customPossessionKey:customPossessionKey];
 }
-
-// MARK: Commit, Possession + Knowledge + Biometry
-
-+ (PowerAuthAuthentication*) commitWithPasswordAndBiometry:(NSString*)password
-{
-    return [self persistWithPasswordAndBiometry:password];
-}
-
-+ (PowerAuthAuthentication*) commitWithPasswordAndBiometry:(NSString*)password
-                                         customBiometryKey:(PowerAuthCoreData*)customBiometryKey
-                                       customPossessionKey:(PowerAuthCoreData*)customPossessionKey
-{
-    return [self persistWithPasswordAndBiometry:password
-                              customBiometryKey:customBiometryKey
-                            customPossessionKey:customPossessionKey];
-}
-
 
 
 // MARK: - Signing, Possession only
@@ -188,6 +181,7 @@
                                               customBiometryKey:nil];
 }
 
+// PA2_DEPRECATED(2.0.0)
 + (PowerAuthAuthentication *) possessionWithCustomPossessionKey:(PowerAuthCoreData*)customPossessionKey
 {
     return [[PowerAuthAuthentication alloc] initWithObjectUsage:AUTH_FOR_SIGN
@@ -223,6 +217,7 @@
                                               customBiometryKey:nil];
 }
 
+// PA2_DEPRECATED(2.0.0)
 + (PowerAuthAuthentication *) possessionWithBiometryPrompt:(NSString*)biometryPrompt
                                        customPossessionKey:(PowerAuthCoreData*)customPossessionKey
 {
@@ -235,6 +230,18 @@
                                               customBiometryKey:nil];
 }
 
++ (PowerAuthAuthentication *) possessionWithBiometryWithCustomBiometryKey:(PowerAuthCoreData*)customBiometryKey
+{
+    return [[PowerAuthAuthentication alloc] initWithObjectUsage:AUTH_FOR_SIGN
+                                                       password:nil
+                                                       biometry:YES
+                                                 biometryPrompt:nil
+                                                biometryContext:nil
+                                            customPossessionKey:nil
+                                              customBiometryKey:customBiometryKey];
+}
+
+// PA2_DEPRECATED(2.0.0)
 + (PowerAuthAuthentication *) possessionWithBiometryWithCustomBiometryKey:(PowerAuthCoreData*)customBiometryKey
                                                       customPossessionKey:(PowerAuthCoreData*)customPossessionKey
 {
@@ -258,6 +265,8 @@
                                             customPossessionKey:nil
                                               customBiometryKey:nil];
 }
+
+// PA2_DEPRECATED(2.0.0)
 + (PowerAuthAuthentication *) possessionWithBiometryContext:(LAContext*)context
                                         customPossessionKey:(PowerAuthCoreData*)customPossessionKey
 {
@@ -278,6 +287,7 @@
     return [self possessionWithCorePassword:[PowerAuthCorePassword passwordWithString:password]];
 }
 
+// PA2_DEPRECATED(2.0.0)
 + (PowerAuthAuthentication *) possessionWithPassword:(NSString*)password
                                  customPossessionKey:(PowerAuthCoreData*)customPossessionKey
 {
@@ -302,6 +312,7 @@
                                               customBiometryKey:nil];
 }
 
+// PA2_DEPRECATED(2.0.0)
 + (PowerAuthAuthentication*) persistWithCorePassword:(PowerAuthCorePassword*)password
                                  customPossessionKey:(PowerAuthCoreData*)customPossessionKey
 {
@@ -327,6 +338,19 @@
 
 + (PowerAuthAuthentication*) persistWithCorePasswordAndBiometry:(PowerAuthCorePassword*)password
                                               customBiometryKey:(PowerAuthCoreData*)customBiometryKey
+{
+    return [[PowerAuthAuthentication alloc] initWithObjectUsage:AUTH_FOR_PERSIST
+                                                       password:password
+                                                       biometry:YES
+                                                 biometryPrompt:nil
+                                                biometryContext:nil
+                                            customPossessionKey:nil
+                                              customBiometryKey:customBiometryKey];
+}
+
+// PA2_DEPRECATED(2.0.0)
++ (PowerAuthAuthentication*) persistWithCorePasswordAndBiometry:(PowerAuthCorePassword*)password
+                                              customBiometryKey:(PowerAuthCoreData*)customBiometryKey
                                             customPossessionKey:(PowerAuthCoreData*)customPossessionKey
 {
     return [[PowerAuthAuthentication alloc] initWithObjectUsage:AUTH_FOR_PERSIST
@@ -349,6 +373,7 @@
                                               customBiometryKey:nil];
 }
 
+// PA2_DEPRECATED(2.0.0)
 + (PowerAuthAuthentication *) possessionWithCorePassword:(PowerAuthCorePassword*)password
                                      customPossessionKey:(PowerAuthCoreData*)customPossessionKey
 {
@@ -377,17 +402,22 @@
     return result;
 }
 
-- (BOOL) validateUsage:(BOOL)forPersist
+- (NSError*) validateUsage:(BOOL)forPersist
 {
+    NSString * errorMessage;
     if (forPersist != (_objectUsage == AUTH_FOR_PERSIST)) {
-        if (forPersist) {
-            PowerAuthLog(@"WARNING: Using PowerAuthAuthentication object for a different purpose. The object for activation persist is expected.");
-        } else {
-            PowerAuthLog(@"WARNING: Using PowerAuthAuthentication object for a different purpose. The object for authentication code calculation is expected.");
-        }
-        return NO;
+        errorMessage = forPersist
+            ? @"Using PowerAuthAuthentication object for a different purpose. The object for activation persist is expected."
+            : @"Using PowerAuthAuthentication object for a different purpose. The object for authentication code calculation is expected.";
+    } else if (_overridenPossessionKey) {
+        errorMessage = @"Using PowerAuthAuthentication with a custom possession key is no longer supported.";
+    } else {
+        errorMessage = nil;
     }
-    return YES;
+    if (errorMessage) {
+        return PA2MakeError(PowerAuthErrorCode_WrongParameter, errorMessage);
+    }
+    return nil;
 }
 
 @end

--- a/proj-xcode/PowerAuth2/PowerAuthSDK.m
+++ b/proj-xcode/PowerAuth2/PowerAuthSDK.m
@@ -418,7 +418,7 @@ static NSData * _BuildDeviceSpecificData(void)
         }
         // If localError variable is set, then we need to report an error.
         if (localError) {
-            if (error) { *error = localError; }
+            PA2SetExistingError(error, localError);
             return nil;
         }
         // No error generated, so create a fake biometry key to fail on the server.
@@ -453,7 +453,11 @@ static NSData * _BuildDeviceSpecificData(void)
                                                              error:(NSError **)error
 {
     // Validate authentication object usage
-    [authentication validateUsage:NO];
+    NSError * localError = [authentication validateUsage:NO];
+    if (localError) {
+        PA2SetExistingError(error, localError);
+        return nil;
+    }
     
     if (authentication.password) {
         // possession + knowledge
@@ -772,7 +776,7 @@ static PowerAuthSDK * s_inst;
     NSError * localError = nil;
     PowerAuthCoreTask * task = [self persistActivationInSession:authentication error:&localError];
     if (localError) {
-        if (error) *error = localError;
+        PA2SetExistingError(error, localError);
         return NO;
     }
     if (task) {
@@ -800,7 +804,11 @@ static PowerAuthSDK * s_inst;
 - (PowerAuthCoreTask*) persistActivationInSession:(PowerAuthAuthentication*)authentication error:(NSError**)error
 {
     // Validate authentication object usage
-    [authentication validateUsage:YES];
+    NSError * localError = [authentication validateUsage:YES];
+    if (localError) {
+        PA2SetExistingError(error, localError);
+        return nil;
+    }
     
     return [_sessionInterface writeTaskWithSession:^PowerAuthCoreTask* (PowerAuthCoreSession * session, NSError** error) {
         
@@ -811,13 +819,13 @@ static PowerAuthSDK * s_inst;
         PowerAuthCoreData *biometryKek = authentication.customBiometryKey;
         if (authentication.useBiometry && !biometryKek) {
             if (!(biometryKek = [session generateFactorKek:&localError])) {
-                if (error) *error = localError;
+                PA2SetExistingError(error, localError);
                 return nil;
             }
         }
         PowerAuthCoreTask * task = [session confirmActivationWithPassword:password withBiometryKek:biometryKek error:&localError];
         if (localError) {
-            if (error) *error = localError;
+            PA2SetExistingError(error, localError);
             return nil;
         }
         
@@ -1521,8 +1529,7 @@ static PowerAuthSDK * s_inst;
             if (biometryKey) {
                 // The biometry key is available, so create a new PowerAuthAuthentication object preconfigured
                 // with possession+biometry factors.
-                authentication = [PowerAuthAuthentication possessionWithBiometryWithCustomBiometryKey:biometryKey
-                                                                                  customPossessionKey:nil];
+                authentication = [PowerAuthAuthentication possessionWithBiometryWithCustomBiometryKey:biometryKey];
                 error = nil;
             } else {
                 // Otherwise report an error depending on whether the operation was canceled by the user.
@@ -1538,8 +1545,7 @@ static PowerAuthSDK * s_inst;
                     case LAErrorAuthenticationFailed:   // User failed to provide valid credentials.
                     case LAErrorBiometryLockout:        // Too many failed attempts, biometry is now locked out.
                         // Authentication failed, now it's time to generate the fake key
-                        authentication = [PowerAuthAuthentication possessionWithBiometryWithCustomBiometryKey:[self generateInvalidBiometricKey]
-                                                                                          customPossessionKey:nil];
+                        authentication = [PowerAuthAuthentication possessionWithBiometryWithCustomBiometryKey:[self generateInvalidBiometricKey]];
                         error = nil;
                         break;
                         

--- a/proj-xcode/PowerAuth2/private/PA2PrivateMacros.h
+++ b/proj-xcode/PowerAuth2/private/PA2PrivateMacros.h
@@ -70,10 +70,16 @@ PA2_EXTERN_C NSString * PA2MakeDefaultErrorDescription(PowerAuthErrorCode errorC
 /// Safe set nullable value to mutable dictionary.
 PA2_EXTERN_C void PA2DictionarySafeSet(NSMutableDictionary * dict, NSString * key, id value);
 
-/// Create NSError with using PA2MakeError function and set it to optional errorPtr.
+/// Create NSError with using PA2MakeError function and set it to optional errorPtr, which is type of `NSError**`.
 #define PA2SetError(errorPtr, errorCode, message)       \
     if (errorPtr) {                                     \
         *errorPtr = PA2MakeError(errorCode, message);   \
+    }
+
+/// Set existing NSError into optional errorPtr, which is type of `NSError**`.
+#define PA2SetExistingError(errorPtr, localError)       \
+    if (errorPtr) {                                     \
+        *errorPtr = localError;                         \
     }
 
 #if DEBUG

--- a/proj-xcode/PowerAuth2/private/PowerAuthAuthentication+Private.h
+++ b/proj-xcode/PowerAuth2/private/PowerAuthAuthentication+Private.h
@@ -30,9 +30,9 @@
  */
 @property (nonatomic, readonly) PowerAuthKeychainAuthentication * keychainAuthentication;
 
-/// Function validates whether PowerAuthAuthentication.
+/// Validates whether this `PowerAuthAuthentication` instance can be used for the requested operation.
 /// @param forPersist Specifies whether persist or authenticate operation is required.
-/// @return Error object if authentication object cannot be used.
+/// @return `nil` if the authentication object can be used; an `NSError` describing the problem otherwise.
 - (NSError*) validateUsage:(BOOL)forPersist;
 
 @end

--- a/proj-xcode/PowerAuth2/private/PowerAuthAuthentication+Private.h
+++ b/proj-xcode/PowerAuth2/private/PowerAuthAuthentication+Private.h
@@ -30,9 +30,9 @@
  */
 @property (nonatomic, readonly) PowerAuthKeychainAuthentication * keychainAuthentication;
 
-/// Function validates whether PowerAuthAuthentication was created for the right object usage.
-/// @param forPersist Specifies whether persist or sign operation is required.
-/// @return YES if object is correct for the specified usage.
-- (BOOL) validateUsage:(BOOL)forPersist;
+/// Function validates whether PowerAuthAuthentication.
+/// @param forPersist Specifies whether persist or authenticate operation is required.
+/// @return Error object if authentication object cannot be used.
+- (NSError*) validateUsage:(BOOL)forPersist;
 
 @end

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKBaseTests.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKBaseTests.m
@@ -1210,7 +1210,7 @@
     }
     XCTAssertFalse([_sdk hasBiometryFactor]);
     PowerAuthCoreData * newBiometryKek = [PowerAuthCoreCryptoUtils randomCoreData:_sdk.currentAlgorithm == PowerAuthAlgorithm_LEGACY_P256 ? 16 : 32];
-    PowerAuthAuthentication * newBiometryAuth = [PowerAuthAuthentication possessionWithBiometryWithCustomBiometryKey:newBiometryKek customPossessionKey:nil];
+    PowerAuthAuthentication * newBiometryAuth = [PowerAuthAuthentication possessionWithBiometryWithCustomBiometryKey:newBiometryKek];
     NSData * randomData = [[[PowerAuthCoreCryptoUtils randomBytes:63] base64EncodedStringWithOptions:0] dataUsingEncoding:NSASCIIStringEncoding];
     [AsyncHelper synchronizeAsynchronousBlock:^(AsyncHelper *waiting) {
         [_sdk addBiometryFactorWithCorePassword:activation.credentials.password customBiometryKek:newBiometryKek callback:^(NSError * _Nullable error) {
@@ -1248,7 +1248,7 @@
     XCTAssertFalse(result);
 
     newBiometryKek = [PowerAuthCoreCryptoUtils randomCoreData:_sdk.currentAlgorithm == PowerAuthAlgorithm_LEGACY_P256 ? 16 : 32];
-    newBiometryAuth = [PowerAuthAuthentication possessionWithBiometryWithCustomBiometryKey:newBiometryKek customPossessionKey:nil];
+    newBiometryAuth = [PowerAuthAuthentication possessionWithBiometryWithCustomBiometryKey:newBiometryKek];
     randomData = [[[PowerAuthCoreCryptoUtils randomBytes:63] base64EncodedStringWithOptions:0] dataUsingEncoding:NSASCIIStringEncoding];
     [AsyncHelper synchronizeAsynchronousBlock:^(AsyncHelper *waiting) {
         [_sdk addBiometryFactorWithPassword:activation.credentials.password.extractedPassword customBiometryKek:newBiometryKek callback:^(NSError * _Nullable error) {
@@ -2710,7 +2710,7 @@
     if (self.powerAuthAlgorithm > PowerAuthAlgorithm_LEGACY_P256) {
         XCTAssertFalse(result.activationStatusFetchRequired);
         XCTAssertNotNil(result.activationFingerprint);
-        biometryAuth = [PowerAuthAuthentication possessionWithBiometryWithCustomBiometryKey:newBiometryKek customPossessionKey:nil];
+        biometryAuth = [PowerAuthAuthentication possessionWithBiometryWithCustomBiometryKey:newBiometryKek];
     } else {
         biometryAuth = _helper.currentActivation.biometryCredentials;
     }
@@ -2904,7 +2904,7 @@
     _sdk = [_helper reCreateSdkInstance];
     
     // Check biometry factor not possible during upgrade.
-    PowerAuthAuthentication * newBiometryAuth = [PowerAuthAuthentication possessionWithBiometryWithCustomBiometryKey:newBiometryKek customPossessionKey:nil];
+    PowerAuthAuthentication * newBiometryAuth = [PowerAuthAuthentication possessionWithBiometryWithCustomBiometryKey:newBiometryKek];
     NSData * randomData = [[[PowerAuthCoreCryptoUtils randomBytes:42] base64EncodedStringWithOptions:0] dataUsingEncoding:NSASCIIStringEncoding];
     
     // Authentication header calculation not allowed when protocol upgrade pending.
@@ -3030,7 +3030,7 @@
     
     // Check biometry factor not set.
     XCTAssertFalse(_sdk.hasBiometryFactor);
-    PowerAuthAuthentication * newBiometryAuth = [PowerAuthAuthentication possessionWithBiometryWithCustomBiometryKey:newBiometryKek customPossessionKey:nil];
+    PowerAuthAuthentication * newBiometryAuth = [PowerAuthAuthentication possessionWithBiometryWithCustomBiometryKey:newBiometryKek];
     NSData * randomData = [[[PowerAuthCoreCryptoUtils randomBytes:42] base64EncodedStringWithOptions:0] dataUsingEncoding:NSASCIIStringEncoding];
     BOOL authenticationValid = [_helper validateAuthentication:newBiometryAuth
                                                           data:randomData

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSdkTestHelper.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSdkTestHelper.m
@@ -645,7 +645,7 @@ static NSString * PA_Ver_Current = @"4.0";
         PowerAuthCoreData* biometryKek = [_sdk.sessionProvider readTaskWithSession:^PowerAuthCoreData* _Nullable(PowerAuthCoreSession * _Nonnull session, NSError * _Nonnull __autoreleasing * _Nullable error) {
             return [session generateFactorKek:error];
         } error:nil];
-        return [PowerAuthAuthentication persistWithPasswordAndBiometry:newPassword customBiometryKey:biometryKek customPossessionKey:nil];
+        return [PowerAuthAuthentication persistWithPasswordAndBiometry:newPassword customBiometryKey:biometryKek];
     }
     return [PowerAuthAuthentication persistWithPassword:newPassword];
 }
@@ -934,7 +934,7 @@ static NSString * PA_Ver_Current = @"4.0";
 - (PowerAuthAuthentication*) copyBiometryForSigning
 {
     if (self.customBiometryKey) {
-        return [PowerAuthAuthentication possessionWithBiometryWithCustomBiometryKey:self.customBiometryKey customPossessionKey:nil];
+        return [PowerAuthAuthentication possessionWithBiometryWithCustomBiometryKey:self.customBiometryKey];
     }
     if (self.useBiometry) {
         return [PowerAuthAuthentication possessionWithBiometryPrompt:@"Please authenticate with biometry"];

--- a/proj-xcode/PowerAuth2Tests/PowerAuthAuthenticationTests.m
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthAuthenticationTests.m
@@ -55,19 +55,8 @@
     XCTAssertNil(auth.biometryPrompt);
     XCTAssertContextNil(auth.biometryContext);
     XCTAssertNil(auth.customBiometryKey);
-    XCTAssertNil(auth.customPossessionKey);
-    XCTAssertTrue([auth validateUsage:YES]);
-    
-    auth = [PowerAuthAuthentication persistWithPassword:@"4321" customPossessionKey:_customPossessionKey];
-    XCTAssertTrue(auth.usePossession);
-    XCTAssertFalse(auth.useBiometry);
-    XCTAssertEqualObjects(@"4321", auth.password.extractedPassword);
-    XCTAssertNil(auth.biometryPrompt);
-    XCTAssertContextNil(auth.biometryContext);
-    XCTAssertNil(auth.customBiometryKey);
-    XCTAssertEqualObjects(self.customPossessionKey, auth.customPossessionKey);
-    XCTAssertTrue([auth validateUsage:YES]);
-    
+    XCTAssertNil([auth validateUsage:YES]);
+        
     // core password variants
     
     auth = [PowerAuthAuthentication persistWithCorePassword:[PowerAuthCorePassword passwordWithString:@"1234"]];
@@ -77,18 +66,7 @@
     XCTAssertNil(auth.biometryPrompt);
     XCTAssertContextNil(auth.biometryContext);
     XCTAssertNil(auth.customBiometryKey);
-    XCTAssertNil(auth.customPossessionKey);
-    XCTAssertTrue([auth validateUsage:YES]);
-
-    auth = [PowerAuthAuthentication persistWithCorePassword:[PowerAuthCorePassword passwordWithString:@"4321"] customPossessionKey:_customPossessionKey];
-    XCTAssertTrue(auth.usePossession);
-    XCTAssertFalse(auth.useBiometry);
-    XCTAssertEqualObjects(@"4321", auth.password.extractedPassword);
-    XCTAssertNil(auth.biometryPrompt);
-    XCTAssertContextNil(auth.biometryContext);
-    XCTAssertNil(auth.customBiometryKey);
-    XCTAssertEqualObjects(self.customPossessionKey, auth.customPossessionKey);
-    XCTAssertTrue([auth validateUsage:YES]);
+    XCTAssertNil([auth validateUsage:YES]);
 }
 
 - (void) testPersistWithPasswordAndBiometry
@@ -100,18 +78,16 @@
     XCTAssertNil(auth.biometryPrompt);
     XCTAssertContextNil(auth.biometryContext);
     XCTAssertNil(auth.customBiometryKey);
-    XCTAssertNil(auth.customPossessionKey);
-    XCTAssertTrue([auth validateUsage:YES]);
+    XCTAssertNil([auth validateUsage:YES]);
     
-    auth = [PowerAuthAuthentication persistWithPasswordAndBiometry:@"4321" customBiometryKey:_customBiometryKey customPossessionKey:_customPossessionKey];
+    auth = [PowerAuthAuthentication persistWithPasswordAndBiometry:@"4321" customBiometryKey:_customBiometryKey];
     XCTAssertTrue(auth.usePossession);
     XCTAssertTrue(auth.useBiometry);
     XCTAssertEqualObjects(@"4321", auth.password.extractedPassword);
     XCTAssertNil(auth.biometryPrompt);
     XCTAssertContextNil(auth.biometryContext);
     XCTAssertEqualObjects(self.customBiometryKey, auth.customBiometryKey);
-    XCTAssertEqualObjects(self.customPossessionKey, auth.customPossessionKey);
-    XCTAssertTrue([auth validateUsage:YES]);
+    XCTAssertNil([auth validateUsage:YES]);
     
     // core password variants
     
@@ -122,18 +98,16 @@
     XCTAssertNil(auth.biometryPrompt);
     XCTAssertContextNil(auth.biometryContext);
     XCTAssertNil(auth.customBiometryKey);
-    XCTAssertNil(auth.customPossessionKey);
-    XCTAssertTrue([auth validateUsage:YES]);
+    XCTAssertNil([auth validateUsage:YES]);
     
-    auth = [PowerAuthAuthentication persistWithCorePasswordAndBiometry:[PowerAuthCorePassword passwordWithString:@"4321"] customBiometryKey:_customBiometryKey customPossessionKey:_customPossessionKey];
+    auth = [PowerAuthAuthentication persistWithCorePasswordAndBiometry:[PowerAuthCorePassword passwordWithString:@"4321"] customBiometryKey:_customBiometryKey];
     XCTAssertTrue(auth.usePossession);
     XCTAssertTrue(auth.useBiometry);
     XCTAssertEqualObjects(@"4321", auth.password.extractedPassword);
     XCTAssertNil(auth.biometryPrompt);
     XCTAssertContextNil(auth.biometryContext);
     XCTAssertEqualObjects(self.customBiometryKey, auth.customBiometryKey);
-    XCTAssertEqualObjects(self.customPossessionKey, auth.customPossessionKey);
-    XCTAssertTrue([auth validateUsage:YES]);
+    XCTAssertNil([auth validateUsage:YES]);
 }
 
 - (void) testSignPossessionOnly
@@ -145,8 +119,7 @@
     XCTAssertNil(auth.biometryPrompt);
     XCTAssertContextNil(auth.biometryContext);
     XCTAssertNil(auth.customBiometryKey);
-    XCTAssertNil(auth.customPossessionKey);
-    XCTAssertTrue([auth validateUsage:NO]);
+    XCTAssertNil([auth validateUsage:NO]);
 }
 
 - (void) testSignPossessionWithPassword
@@ -158,19 +131,8 @@
     XCTAssertNil(auth.biometryPrompt);
     XCTAssertContextNil(auth.biometryContext);
     XCTAssertNil(auth.customBiometryKey);
-    XCTAssertNil(auth.customPossessionKey);
-    XCTAssertTrue([auth validateUsage:NO]);
-    
-    auth = [PowerAuthAuthentication possessionWithPassword:@"4321" customPossessionKey:_customPossessionKey];
-    XCTAssertTrue(auth.usePossession);
-    XCTAssertFalse(auth.useBiometry);
-    XCTAssertEqualObjects(@"4321", auth.password.extractedPassword);
-    XCTAssertNil(auth.biometryPrompt);
-    XCTAssertContextNil(auth.biometryContext);
-    XCTAssertNil(auth.customBiometryKey);
-    XCTAssertEqualObjects(self.customPossessionKey, auth.customPossessionKey);
-    XCTAssertTrue([auth validateUsage:NO]);
-    
+    XCTAssertNil([auth validateUsage:NO]);
+        
     // core password variants
     
     auth = [PowerAuthAuthentication possessionWithCorePassword:[PowerAuthCorePassword passwordWithString:@"1234"]];
@@ -180,18 +142,7 @@
     XCTAssertNil(auth.biometryPrompt);
     XCTAssertContextNil(auth.biometryContext);
     XCTAssertNil(auth.customBiometryKey);
-    XCTAssertNil(auth.customPossessionKey);
-    XCTAssertTrue([auth validateUsage:NO]);
-    
-    auth = [PowerAuthAuthentication possessionWithCorePassword:[PowerAuthCorePassword passwordWithString:@"4321"] customPossessionKey:_customPossessionKey];
-    XCTAssertTrue(auth.usePossession);
-    XCTAssertFalse(auth.useBiometry);
-    XCTAssertEqualObjects(@"4321", auth.password.extractedPassword);
-    XCTAssertNil(auth.biometryPrompt);
-    XCTAssertContextNil(auth.biometryContext);
-    XCTAssertNil(auth.customBiometryKey);
-    XCTAssertEqualObjects(self.customPossessionKey, auth.customPossessionKey);
-    XCTAssertTrue([auth validateUsage:NO]);
+    XCTAssertNil([auth validateUsage:NO]);
 }
 
 - (void) testSignPossessionWithBiometry
@@ -203,18 +154,16 @@
     XCTAssertNil(auth.biometryPrompt);
     XCTAssertContextNil(auth.biometryContext);
     XCTAssertNil(auth.customBiometryKey);
-    XCTAssertNil(auth.customPossessionKey);
-    XCTAssertTrue([auth validateUsage:NO]);
+    XCTAssertNil([auth validateUsage:NO]);
 
-    auth = [PowerAuthAuthentication possessionWithBiometryWithCustomBiometryKey:_customBiometryKey customPossessionKey:_customPossessionKey];
+    auth = [PowerAuthAuthentication possessionWithBiometryWithCustomBiometryKey:_customBiometryKey];
     XCTAssertTrue(auth.usePossession);
     XCTAssertTrue(auth.useBiometry);
     XCTAssertNil(auth.password);
     XCTAssertNil(auth.biometryPrompt);
     XCTAssertContextNil(auth.biometryContext);
     XCTAssertEqualObjects(self.customBiometryKey, auth.customBiometryKey);
-    XCTAssertEqualObjects(self.customPossessionKey, auth.customPossessionKey);
-    XCTAssertTrue([auth validateUsage:NO]);
+    XCTAssertNil([auth validateUsage:NO]);
     
     auth = [PowerAuthAuthentication possessionWithBiometryPrompt:_biometryPrompt];
     XCTAssertTrue(auth.usePossession);
@@ -223,18 +172,16 @@
     XCTAssertEqualObjects(_biometryPrompt, auth.biometryPrompt);
     XCTAssertContextNil(auth.biometryContext);
     XCTAssertNil(auth.customBiometryKey);
-    XCTAssertNil(auth.customPossessionKey);
-    XCTAssertTrue([auth validateUsage:NO]);
+    XCTAssertNil([auth validateUsage:NO]);
     
-    auth = [PowerAuthAuthentication possessionWithBiometryPrompt:_biometryPrompt customPossessionKey:_customPossessionKey];
+    auth = [PowerAuthAuthentication possessionWithBiometryPrompt:_biometryPrompt];
     XCTAssertTrue(auth.usePossession);
     XCTAssertTrue(auth.useBiometry);
     XCTAssertNil(auth.password);
     XCTAssertEqualObjects(_biometryPrompt, auth.biometryPrompt);
     XCTAssertContextNil(auth.biometryContext);
     XCTAssertNil(auth.customBiometryKey);
-    XCTAssertEqualObjects(self.customPossessionKey, auth.customPossessionKey);
-    XCTAssertTrue([auth validateUsage:NO]);
+    XCTAssertNil([auth validateUsage:NO]);
     
 #if PA2_HAS_LACONTEXT
     auth = [PowerAuthAuthentication possessionWithBiometryContext:_biometryContext];
@@ -244,29 +191,66 @@
     XCTAssertNil(auth.biometryPrompt);
     XCTAssertEqualObjects(self.biometryContext, auth.biometryContext);
     XCTAssertNil(auth.customBiometryKey);
-    XCTAssertNil(auth.customPossessionKey);
-    XCTAssertTrue([auth validateUsage:NO]);
+    XCTAssertNil([auth validateUsage:NO]);
     
-    auth = [PowerAuthAuthentication possessionWithBiometryContext:_biometryContext customPossessionKey:_customPossessionKey];
+    auth = [PowerAuthAuthentication possessionWithBiometryContext:_biometryContext];
     XCTAssertTrue(auth.usePossession);
     XCTAssertTrue(auth.useBiometry);
     XCTAssertNil(auth.password);
     XCTAssertNil(auth.biometryPrompt);
     XCTAssertEqualObjects(self.biometryContext, auth.biometryContext);
     XCTAssertNil(auth.customBiometryKey);
-    XCTAssertEqualObjects(self.customPossessionKey, auth.customPossessionKey);
-    XCTAssertTrue([auth validateUsage:NO]);
+    XCTAssertNil([auth validateUsage:NO]);
 #endif // PA2_HAS_LACONTEXT
 }
 
 - (void) testWrongUsage
 {
     PowerAuthAuthentication * auth = [PowerAuthAuthentication possession];
-    XCTAssertFalse([auth validateUsage:YES]);
+    NSError * error;
+    error = [auth validateUsage:YES];
+    XCTAssertEqual(PowerAuthErrorCode_WrongParameter, error.powerAuthErrorCode);
     auth = [PowerAuthAuthentication persistWithPassword:@"Hello"];
-    XCTAssertFalse([auth validateUsage:NO]);
+    error = [auth validateUsage:NO];
+    XCTAssertEqual(PowerAuthErrorCode_WrongParameter, error.powerAuthErrorCode);
     auth = [PowerAuthAuthentication persistWithCorePassword:[PowerAuthCorePassword passwordWithString:@"Hello"]];
-    XCTAssertFalse([auth validateUsage:NO]);
+    error = [auth validateUsage:NO];
+    XCTAssertEqual(PowerAuthErrorCode_WrongParameter, error.powerAuthErrorCode);
+    
+#pragma clang diagnostic push   // PA2_DEPRECATED(2.0.0)
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    // custom possession key
+    auth = [PowerAuthAuthentication persistWithPassword:@"4321" customPossessionKey:_customPossessionKey];
+    error = [auth validateUsage:YES];
+    XCTAssertEqual(PowerAuthErrorCode_WrongParameter, error.powerAuthErrorCode);
+    auth = [PowerAuthAuthentication persistWithCorePassword:[PowerAuthCorePassword passwordWithString:@"4321"] customPossessionKey:_customPossessionKey];
+    error = [auth validateUsage:YES];
+    XCTAssertEqual(PowerAuthErrorCode_WrongParameter, error.powerAuthErrorCode);
+    auth = [PowerAuthAuthentication persistWithPasswordAndBiometry:@"4321" customBiometryKey:_customBiometryKey customPossessionKey:_customPossessionKey];
+    error = [auth validateUsage:YES];
+    XCTAssertEqual(PowerAuthErrorCode_WrongParameter, error.powerAuthErrorCode);
+    auth = [PowerAuthAuthentication persistWithCorePasswordAndBiometry:[PowerAuthCorePassword passwordWithString:@"4321"] customBiometryKey:_customBiometryKey customPossessionKey:_customPossessionKey];
+    error = [auth validateUsage:YES];
+    XCTAssertEqual(PowerAuthErrorCode_WrongParameter, error.powerAuthErrorCode);
+    
+    auth = [PowerAuthAuthentication possessionWithPassword:@"4321" customPossessionKey:_customPossessionKey];
+    error = [auth validateUsage:NO];
+    XCTAssertEqual(PowerAuthErrorCode_WrongParameter, error.powerAuthErrorCode);
+    auth = [PowerAuthAuthentication possessionWithCorePassword:[PowerAuthCorePassword passwordWithString:@"4321"] customPossessionKey:_customPossessionKey];
+    error = [auth validateUsage:NO];
+    XCTAssertEqual(PowerAuthErrorCode_WrongParameter, error.powerAuthErrorCode);
+    auth = [PowerAuthAuthentication possessionWithBiometryWithCustomBiometryKey:_customBiometryKey customPossessionKey:_customPossessionKey];
+    error = [auth validateUsage:NO];
+    XCTAssertEqual(PowerAuthErrorCode_WrongParameter, error.powerAuthErrorCode);
+    auth = [PowerAuthAuthentication possessionWithBiometryPrompt:_biometryPrompt customPossessionKey:_customPossessionKey];
+    error = [auth validateUsage:NO];
+#if PA2_HAS_LACONTEXT
+    XCTAssertEqual(PowerAuthErrorCode_WrongParameter, error.powerAuthErrorCode);
+    auth = [PowerAuthAuthentication possessionWithBiometryContext:_biometryContext customPossessionKey:_customPossessionKey];
+    error = [auth validateUsage:NO];
+    XCTAssertEqual(PowerAuthErrorCode_WrongParameter, error.powerAuthErrorCode);
+#endif // PA2_HAS_LACONTEXT
+#pragma clang diagnostic pop
 }
 
 @end

--- a/proj-xcode/PowerAuth2Tests/PowerAuthAuthenticationTests.m
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthAuthenticationTests.m
@@ -173,16 +173,7 @@
     XCTAssertContextNil(auth.biometryContext);
     XCTAssertNil(auth.customBiometryKey);
     XCTAssertNil([auth validateUsage:NO]);
-    
-    auth = [PowerAuthAuthentication possessionWithBiometryPrompt:_biometryPrompt];
-    XCTAssertTrue(auth.usePossession);
-    XCTAssertTrue(auth.useBiometry);
-    XCTAssertNil(auth.password);
-    XCTAssertEqualObjects(_biometryPrompt, auth.biometryPrompt);
-    XCTAssertContextNil(auth.biometryContext);
-    XCTAssertNil(auth.customBiometryKey);
-    XCTAssertNil([auth validateUsage:NO]);
-    
+        
 #if PA2_HAS_LACONTEXT
     auth = [PowerAuthAuthentication possessionWithBiometryContext:_biometryContext];
     XCTAssertTrue(auth.usePossession);
@@ -244,8 +235,8 @@
     XCTAssertEqual(PowerAuthErrorCode_WrongParameter, error.powerAuthErrorCode);
     auth = [PowerAuthAuthentication possessionWithBiometryPrompt:_biometryPrompt customPossessionKey:_customPossessionKey];
     error = [auth validateUsage:NO];
-#if PA2_HAS_LACONTEXT
     XCTAssertEqual(PowerAuthErrorCode_WrongParameter, error.powerAuthErrorCode);
+#if PA2_HAS_LACONTEXT
     auth = [PowerAuthAuthentication possessionWithBiometryContext:_biometryContext customPossessionKey:_customPossessionKey];
     error = [auth validateUsage:NO];
     XCTAssertEqual(PowerAuthErrorCode_WrongParameter, error.powerAuthErrorCode);


### PR DESCRIPTION
- Validate purpose of authentication object