### PR TITLE
Fix #838: Handle session state serialization after upgrade confirm in the ActivationStatusTask

### DIFF
--- a/include/PowerAuth/Task.h
+++ b/include/PowerAuth/Task.h
@@ -89,6 +89,9 @@ public:
     /// - Throws: `Exception` with `EC_NotAllowed` if task is not finished yet.
     const cc7::json::JsonValue& getResponseJson() const;
     
+    // Returns true if session state serialization is recommended after this task completes.
+    bool isSessionStateSerializationRecommended() const noexcept;
+    
 protected:
     enum RequestFlags
     {
@@ -150,6 +153,9 @@ protected:
     /// Contains shared mutex.
     const SharedMutexPtr& _mutex;
     
+    /// Sets the information about session state serialization recommendation.
+    void setSessionStateSerializationRecommended(bool is_recommended = true);
+    
 private:
     friend class Request;
     
@@ -203,6 +209,9 @@ private:
     cc7::json::JsonValue _response_json;
     /// Captured reason of failure.
     std::exception_ptr _failure;
+    
+    /// Indicates that session state serialization is recommended.
+    bool _session_state_serialization_recommended;
 };
 
 CC7_SHARED_PTR(Task)

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreTask.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreTask.java
@@ -169,4 +169,9 @@ public class CoreTask<TResponse> extends NativeObject {
      */
     @Nullable
     private native CoreRequest<TResponse> getNextRequestImpl() throws CoreException;
+
+    /**
+     * @return {@code true} if session's state should be serialized after the task finishes.
+     */
+    public native boolean isSessionStateSerializationNeeded();
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -1212,18 +1212,10 @@ public class PowerAuthSDK {
                 task = mGetActivationStatusTask.createChildTask(completion);
             }
             if (task == null) {
-                mGetActivationStatusTask = new GetActivationStatusTask(mClient, mSession, mLock, mCallbackDispatcher, this::saveSerializedState, new GetActivationStatusTask.ICompletionListener() {
-                    @Override
-                    public void onSessionStateChange() {
-                        saveSerializedState();
-                    }
-
-                    @Override
-                    public void onTaskCompletion(@NonNull GetActivationStatusTask task, @Nullable PowerAuthActivationStatus status) {
-                        // The mLock is already locked, because GetActivationStatusTask uses shared lock.
-                        if (task == mGetActivationStatusTask) {
-                            mGetActivationStatusTask = null;
-                        }
+                mGetActivationStatusTask = new GetActivationStatusTask(mClient, mSession, mLock, mCallbackDispatcher, this::saveSerializedState, getActivationStatusTask -> {
+                    // The mLock is already locked, because GetActivationStatusTask uses shared lock.
+                    if (getActivationStatusTask == mGetActivationStatusTask) {
+                        mGetActivationStatusTask = null;
                     }
                 });
                 task = mGetActivationStatusTask.createChildTask(completion);

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/GetActivationStatusTask.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/GetActivationStatusTask.java
@@ -93,6 +93,8 @@ public class GetActivationStatusTask extends GroupedTask<PowerAuthActivationStat
                     final CoreActivationStatus coreStatus = Objects.requireNonNull(status);
                     if (coreStatus.isSessionSerializationNeeded()) {
                         saveStateCallback.run();
+                    } else if (coreTask.isSessionStateSerializationNeeded()) {
+                        completionListener.onSessionStateChange();
                     }
                     complete(new PowerAuthActivationStatus(coreStatus));
                 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/GetActivationStatusTask.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/impl/GetActivationStatusTask.java
@@ -23,7 +23,6 @@ import java.util.Objects;
 import java.util.concurrent.locks.ReentrantLock;
 
 import io.getlime.security.powerauth.core.CoreException;
-import io.getlime.security.powerauth.core.CoreRequest;
 import io.getlime.security.powerauth.core.CoreSession;
 import io.getlime.security.powerauth.core.CoreTask;
 import io.getlime.security.powerauth.core.response.CoreActivationStatus;
@@ -40,11 +39,6 @@ import io.getlime.security.powerauth.sdk.PowerAuthActivationStatus;
  */
 public class GetActivationStatusTask extends GroupedTask<PowerAuthActivationStatus> {
 
-    public interface ICompletionListener {
-        void onSessionStateChange();
-        void onTaskCompletion(@NonNull GetActivationStatusTask task, @Nullable PowerAuthActivationStatus status);
-    }
-
     @NonNull
     private final CoreHttpClient httpClient;
     @NonNull
@@ -52,7 +46,7 @@ public class GetActivationStatusTask extends GroupedTask<PowerAuthActivationStat
     @NonNull
     private final Runnable saveStateCallback;
     @NonNull
-    private final ICompletionListener completionListener;
+    private final IConsumer<GetActivationStatusTask> onCompleteConsumer;
 
     /**
      * Create task for getting activation status.
@@ -62,7 +56,7 @@ public class GetActivationStatusTask extends GroupedTask<PowerAuthActivationStat
      * @param sharedLock Shared lock.
      * @param saveStateCallback Callback called when save of session state is required.
      * @param callbackDispatcher callback dispatcher from parent SDK object
-     * @param completionListener final completion listener.
+     * @param onCompleteConsumer consumer to be applied once the task is completed
      */
     public GetActivationStatusTask(
             @NonNull CoreHttpClient httpClient,
@@ -70,12 +64,12 @@ public class GetActivationStatusTask extends GroupedTask<PowerAuthActivationStat
             @NonNull ReentrantLock sharedLock,
             @NonNull ICallbackDispatcher callbackDispatcher,
             @NonNull Runnable saveStateCallback,
-            @NonNull ICompletionListener completionListener) {
+            @NonNull IConsumer<GetActivationStatusTask> onCompleteConsumer) {
         super("GetActivationStatus", sharedLock, callbackDispatcher);
         this.httpClient = httpClient;
         this.session = session;
         this.saveStateCallback = saveStateCallback;
-        this.completionListener = completionListener;
+        this.onCompleteConsumer = onCompleteConsumer;
     }
 
     //
@@ -91,10 +85,8 @@ public class GetActivationStatusTask extends GroupedTask<PowerAuthActivationStat
                 @Override
                 public void onNetworkResponse(@Nullable CoreActivationStatus status) {
                     final CoreActivationStatus coreStatus = Objects.requireNonNull(status);
-                    if (coreStatus.isSessionSerializationNeeded()) {
+                    if (coreStatus.isSessionSerializationNeeded() || coreTask.isSessionStateSerializationNeeded()) {
                         saveStateCallback.run();
-                    } else if (coreTask.isSessionStateSerializationNeeded()) {
-                        completionListener.onSessionStateChange();
                     }
                     complete(new PowerAuthActivationStatus(coreStatus));
                 }
@@ -117,6 +109,6 @@ public class GetActivationStatusTask extends GroupedTask<PowerAuthActivationStat
     @Override
     public void onGroupedTaskComplete(@Nullable PowerAuthActivationStatus activationStatus, @Nullable Throwable failure) {
         super.onGroupedTaskComplete(activationStatus, failure);
-        completionListener.onTaskCompletion(this, activationStatus);
+        onCompleteConsumer.accept(this);
     }
 }

--- a/src/PowerAuth/Task.cpp
+++ b/src/PowerAuth/Task.cpp
@@ -27,7 +27,8 @@ Task::Task(const std::string& name, const ContextPtr& context) :
     _context(context),
     _state(State::CREATED),
     _processed_requests(0),
-    _completion_processed(false)
+    _completion_processed(false),
+    _session_state_serialization_recommended(false)
 {
     //log("Task allocated");
 }
@@ -310,6 +311,16 @@ void Task::onRequestFailure(const Request& request)
 void Task::onRequestCancel(const Request& request)
 {
     // empty
+}
+
+bool Task::isSessionStateSerializationRecommended() const noexcept
+{
+    return _session_state_serialization_recommended;
+}
+
+void Task::setSessionStateSerializationRecommended(bool is_recommended)
+{
+    _session_state_serialization_recommended = is_recommended;
 }
 
 

--- a/src/PowerAuth/task/GetActivationStatusTask.cpp
+++ b/src/PowerAuth/task/GetActivationStatusTask.cpp
@@ -42,6 +42,7 @@ void GetActivationStatusTask::onRequestSuccess(const Request &request)
             break;
         case PROTOCOL_UPGRADE_CONFIRM:
             lockContext()->sessionData().persistentData().v4().flags.pendingProtocolUpgrade = 0;
+            setSessionStateSerializationRecommended();
             break;
         case SYNC_COUNTER:
             setCompleted();
@@ -73,6 +74,7 @@ void GetActivationStatusTask::processActivationStatus(const ActivationStatus &st
         if (context->hasProtocolUpgradePending()) {
             // Protocol upgrade confirmed, but locally the flag is still set.
             context->sessionData().persistentData().v4().flags.pendingProtocolUpgrade = 0;
+            setSessionStateSerializationRecommended();
         }
     }
     

--- a/src/PowerAuthJni/CoreTaskJNI.cpp
+++ b/src/PowerAuthJni/CoreTaskJNI.cpp
@@ -197,4 +197,13 @@ CC7_JNI_METHOD(jobject, getNextRequestImpl)
     NH_CATCH(nullptr)
 }
 
+CC7_JNI_METHOD(jboolean, isSessionStateSerializationNeeded)
+{
+    NH_TRY
+    {
+        return THIS_OBJ()->isSessionStateSerializationRecommended();
+    }
+    NH_CATCH(true)
+}
+
 CC7_JNI_MODULE_CLASS_END()


### PR DESCRIPTION
It may happen that the protocol upgrade is confirmed during activation status fetching, in which case the `pendingProtocolUpgrade` flag in persistent data is modified. That should lead to saving the session state.

As the session state save must be done explicitly on Android, we need to propagate the session state save requirement to Java from the Task framework.