### PR TITLE
Fix #833: IService update allowing unified cleanup on activation reset

### DIFF
--- a/include/PowerAuth/Service.h
+++ b/include/PowerAuth/Service.h
@@ -43,6 +43,11 @@ public:
     ///
     /// The method is typically called when application is going to foreground.
     virtual void restoreSensitiveData() = 0;
+    
+    /// The service's implementation must erase all data related to activation.
+    ///
+    /// The method is typically called when the session is resetting its state.
+    virtual void clearActivationData() = 0;
 };
 
 CC7_SHARED_PTR(IService)
@@ -67,6 +72,7 @@ public:
     void destroyService() override;
     void clearSensitiveData() override;
     void restoreSensitiveData() override;
+    void clearActivationData() override;
     bool isServiceDestroyed() const noexcept override;
     
 protected:

--- a/src/PowerAuth/Context.cpp
+++ b/src/PowerAuth/Context.cpp
@@ -270,9 +270,9 @@ std::shared_ptr<Context> Context::createTargetAlgorithmContext()
 
 void Context::resetState() noexcept
 {
-    _activation_service->resetState();
-    _key_provider->clearActivationKeys();
-    _encryptor_factory->resetActivationData();
+    for (const auto& service : _services) {
+        service->clearActivationData();
+    }
 }
 
 void Context::destroyTargetAlgorithmContext()

--- a/src/PowerAuth/Service.cpp
+++ b/src/PowerAuth/Service.cpp
@@ -80,6 +80,12 @@ void Service::restoreSensitiveData()
     CC7_LOG("%s: sensitive data restore", _service_name.c_str());
 }
 
+void Service::clearActivationData()
+{
+    checkNotDestroyed();
+    CC7_LOG("%s: activation data clear", _service_name.c_str());
+}
+
 // MARK: - Service with context
 
 ServiceWithContext::ServiceWithContext(const std::string& service_name,

--- a/src/PowerAuth/v3/ActivationServiceV3.cpp
+++ b/src/PowerAuth/v3/ActivationServiceV3.cpp
@@ -44,6 +44,14 @@ IServicePtr ActivationServiceV3::asService()
     return shared_from_this();
 }
 
+// MARK: - IService
+
+void ActivationServiceV3::clearActivationData()
+{
+    Service::clearActivationData();
+    resetState();
+}
+
 // MARK: - Activation creation
 
 RequestPtr ActivationServiceV3::createActivation(cc7::json::JsonValue L1_data, cc7::json::JsonValue L2_data)

--- a/src/PowerAuth/v3/ActivationServiceV3.h
+++ b/src/PowerAuth/v3/ActivationServiceV3.h
@@ -46,6 +46,9 @@ public:
     
     RequestPtr fetchUserInfo() override;
     
+    // IService
+    void clearActivationData() override;
+    
 private:
     
     // Activation create

--- a/src/PowerAuth/v3/EciesEncryptorFactory.cpp
+++ b/src/PowerAuth/v3/EciesEncryptorFactory.cpp
@@ -56,6 +56,12 @@ void EciesEncryptorFactory::doServiceDestroy()
     resetAllData();
 }
 
+void EciesEncryptorFactory::clearActivationData()
+{
+    Service::clearActivationData();
+    resetActivationData();
+}
+
 // MARK: - Public functions
 
 IServicePtr EciesEncryptorFactory::asService()

--- a/src/PowerAuth/v3/EciesEncryptorFactory.h
+++ b/src/PowerAuth/v3/EciesEncryptorFactory.h
@@ -31,6 +31,9 @@ public:
     
     EciesEncryptorFactory(const ContextPtr & context);
 
+    // IService
+    void clearActivationData() override;
+    
     // IEncryptorFactory
     IServicePtr asService() override;
 

--- a/src/PowerAuth/v3/KeyProviderV3.cpp
+++ b/src/PowerAuth/v3/KeyProviderV3.cpp
@@ -37,21 +37,27 @@ IServicePtr KeyProviderV3::asService()
 
 void KeyProviderV3::doServiceDestroy()
 {
-    clearSensitiveData();
+    Service::doServiceDestroy();
+    doClearSensitiveData();
 }
 
 void KeyProviderV3::clearSensitiveData()
 {
     Service::clearSensitiveData();
-    
+    doClearSensitiveData();
+}
+
+void KeyProviderV3::clearActivationData()
+{
+    Service::clearActivationData();
+    doClearSensitiveData();
+}
+
+void KeyProviderV3::doClearSensitiveData()
+{
     _device_public_key = nullptr;
     _server_public_key = nullptr;
 }
-
-//void KeyProviderV3::restoreSensitiveData()
-//{
-//    Service::restoreSensitiveData();
-//}
 
 ProtocolVersion KeyProviderV3::protocolVersion() const noexcept
 {

--- a/src/PowerAuth/v3/KeyProviderV3.h
+++ b/src/PowerAuth/v3/KeyProviderV3.h
@@ -53,7 +53,7 @@ public:
     
     // IService
     void clearSensitiveData() override;
-    //void restoreSensitiveData() override;
+    void clearActivationData() override;
     
     // Custom methods
 
@@ -64,6 +64,7 @@ public:
     
 protected:
     void doServiceDestroy() override;
+    void doClearSensitiveData();
     
 private:
 

--- a/src/PowerAuth/v3/TokenServiceV3.cpp
+++ b/src/PowerAuth/v3/TokenServiceV3.cpp
@@ -36,6 +36,13 @@ IServicePtr TokenServiceV3::asService()
     return shared_from_this();
 }
 
+void TokenServiceV3::clearActivationData()
+{
+    Service::clearActivationData();
+    LOCK_GUARD();
+    _nonce_generator->resetSavedState();
+}
+
 HttpHeader TokenServiceV3::calculateTokenHeader(const TokenAuthenticationData &token_data)
 {
     LOCK_GUARD();

--- a/src/PowerAuth/v3/TokenServiceV3.h
+++ b/src/PowerAuth/v3/TokenServiceV3.h
@@ -38,6 +38,9 @@ public:
     RequestPtr createAccessToken(const CredentialsPtr &credentials) override;
     RequestPtr removeAccessToken(const std::string_view &token_identifier) override;
     
+    // IService
+    void clearActivationData() override;
+    
 private:
     ResponseObjectPtr processCreateAccessTokenResponse(AuthFactors factors, const cc7::json::JsonValue& response);
 

--- a/src/PowerAuth/v4/ActivationServiceV4.cpp
+++ b/src/PowerAuth/v4/ActivationServiceV4.cpp
@@ -42,6 +42,14 @@ IServicePtr ActivationServiceV4::asService()
     return shared_from_this();
 }
 
+// MARK: - IService
+
+void ActivationServiceV4::clearActivationData()
+{
+    Service::clearActivationData();
+    resetState();
+}
+
 // MARK: - Activation creation
 
 RequestPtr ActivationServiceV4::createActivation(cc7::json::JsonValue L1_data, cc7::json::JsonValue L2_data)

--- a/src/PowerAuth/v4/ActivationServiceV4.h
+++ b/src/PowerAuth/v4/ActivationServiceV4.h
@@ -46,6 +46,9 @@ public:
     
     RequestPtr fetchUserInfo() override;
     
+    // IService
+    void clearActivationData() override;
+    
 private:
     
     // Activation create

--- a/src/PowerAuth/v4/AeadEncryptorFactory.cpp
+++ b/src/PowerAuth/v4/AeadEncryptorFactory.cpp
@@ -62,6 +62,12 @@ void AeadEncryptorFactory::doServiceDestroy()
     resetAllData();
 }
 
+void AeadEncryptorFactory::clearActivationData()
+{
+    Service::clearActivationData();
+    resetActivationData();
+}
+
 
 // MARK: - Public functions
 

--- a/src/PowerAuth/v4/AeadEncryptorFactory.h
+++ b/src/PowerAuth/v4/AeadEncryptorFactory.h
@@ -31,6 +31,9 @@ public:
     
     AeadEncryptorFactory(const ContextPtr& context);
     
+    // IService
+    void clearActivationData() override;
+    
     // IEncryptorFactory
     IServicePtr asService() override;
     

--- a/src/PowerAuth/v4/KeyProviderV4.cpp
+++ b/src/PowerAuth/v4/KeyProviderV4.cpp
@@ -43,16 +43,14 @@ IServicePtr KeyProviderV4::asService()
 
 void KeyProviderV4::doServiceDestroy()
 {
-    clearSensitiveData();
+    Service::doServiceDestroy();
+    doClearSensitiveData();
 }
 
 void KeyProviderV4::clearSensitiveData()
 {
     Service::clearSensitiveData();
-    
-    _device_public_key = nullptr;
-    _server_public_key = nullptr;
-    _local_data_key.secureClear();
+    doClearSensitiveData();
 }
 
 void KeyProviderV4::restoreSensitiveData()
@@ -61,6 +59,19 @@ void KeyProviderV4::restoreSensitiveData()
     if (_session_data->hasPersistentData(Version_V4)) {
         updateKeyLocalData(nullptr);
     }
+}
+
+void KeyProviderV4::clearActivationData()
+{
+    Service::clearActivationData();
+    doClearSensitiveData();
+}
+
+void KeyProviderV4::doClearSensitiveData()
+{
+    _device_public_key = nullptr;
+    _server_public_key = nullptr;
+    _local_data_key.secureClear();
 }
 
 ProtocolVersion KeyProviderV4::protocolVersion() const noexcept

--- a/src/PowerAuth/v4/KeyProviderV4.h
+++ b/src/PowerAuth/v4/KeyProviderV4.h
@@ -53,6 +53,7 @@ public:
     // IService
     void clearSensitiveData() override;
     void restoreSensitiveData() override;
+    void clearActivationData() override;
     
     // Custom methods
 
@@ -63,6 +64,7 @@ public:
     
 protected:
     void doServiceDestroy() override;
+    void doClearSensitiveData();
     
 private:
 

--- a/src/PowerAuth/v4/TokenServiceV4.cpp
+++ b/src/PowerAuth/v4/TokenServiceV4.cpp
@@ -37,6 +37,13 @@ IServicePtr TokenServiceV4::asService()
     return shared_from_this();
 }
 
+void TokenServiceV4::clearActivationData()
+{
+    Service::clearActivationData();
+    LOCK_GUARD();
+    _nonce_generator->resetSavedState();
+}
+
 HttpHeader TokenServiceV4::calculateTokenHeader(const TokenAuthenticationData &token_data)
 {
     LOCK_GUARD();

--- a/src/PowerAuth/v4/TokenServiceV4.h
+++ b/src/PowerAuth/v4/TokenServiceV4.h
@@ -39,6 +39,9 @@ public:
     RequestPtr createAccessToken(const CredentialsPtr &credentials) override;
     RequestPtr removeAccessToken(const std::string_view &token_identifier) override;
     
+    // IService
+    void clearActivationData() override;
+    
 private:
     ResponseObjectPtr processCreateAccessTokenResponse(AuthFactors factors, const cc7::json::JsonValue& response);
     


### PR DESCRIPTION
This PR unifies cleanup of activation data in internal C++ services.