### PR TITLE
Fix #836: Add Context to new 2.0 APIs

### DIFF
--- a/docs/PowerAuth-SDK-for-Android.md
+++ b/docs/PowerAuth-SDK-for-Android.md
@@ -845,7 +845,7 @@ val signingKey = PowerAuthSignatureKeyId.DEVICE_ML_DSA
 // Data to sign
 val data = "hello".getBytes()
 // Calculate signature
-powerAuthSDK.calculateDigitalSignature(authentication, data, signingKey, object: IDigitalSignatureListener {
+powerAuthSDK.calculateDigitalSignature(context, authentication, data, signingKey, object: IDigitalSignatureListener {
     override fun onDigitalSignatureSucceed(signature: ByteArray) {
         // Use data signature...
     }
@@ -876,7 +876,7 @@ val data = "hello".getBytes()
 // - The dataType parameter is added to the JWS Protected Header under the "typ" key.
 //   A null parameter means that no "typ" value is included in the header.
 // - The compact parameter determines whether the output is a JWS (compact = false) or JWT (compact = true).
-powerAuthSDK.calculateJwsSignature(authentication, data, null, false, signingKey, object: IJwsSignatureListener {
+powerAuthSDK.calculateJwsSignature(context, authentication, data, null, false, signingKey, object: IJwsSignatureListener {
     override fun onJwsSignatureSucceed(signedData: String, compactForm: Boolean) {
         // Use signed data
     }
@@ -904,7 +904,7 @@ val authentication = PowerAuthAuthentication.possessionWithPassword("1234")
 // and therefore an ML-DSA signature will be produced.
 val signingKey = PowerAuthSignatureKeyId.DEVICE_ML_DSA
 // Unlock the secure vault, fetch the private key, and perform data signing
-powerAuthSDK.calculateJwsSignature(authentication, claimsData, "JWT", true, signingKey, object: IJwsSignatureListener {
+powerAuthSDK.calculateJwsSignature(context, authentication, claimsData, "JWT", true, signingKey, object: IJwsSignatureListener {
     override fun onJwsSignatureSucceed(signedData: String, compactForm: Boolean) {
         // Use signed data
     }

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/DsaSignatureTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/DsaSignatureTest.java
@@ -307,7 +307,7 @@ public class DsaSignatureTest extends BaseTest {
     private void verifyDataSignedWithSignatureKeyId(@PowerAuthSignatureKeyId int signatureKeyId, SignatureType signatureType, PowerAuthAuthentication authentication, boolean shouldPass) throws Exception {
         final byte[] dataForSigning = "This is a very sensitive information and must be signed.".getBytes(StandardCharsets.UTF_8);
         byte[] resultSignature = AsyncHelper.await(resultCatcher -> {
-            ICancelable task = powerAuthSDK.calculateDigitalSignature(authentication, dataForSigning, signatureKeyId, new IDigitalSignatureListener() {
+            ICancelable task = powerAuthSDK.calculateDigitalSignature(testHelper.getContext(), authentication, dataForSigning, signatureKeyId, new IDigitalSignatureListener() {
                 @Override
                 public void onDigitalSignatureSucceed(@NonNull byte[] signature) {
                     resultCatcher.completeWithResult(signature);
@@ -506,7 +506,7 @@ public class DsaSignatureTest extends BaseTest {
     private void verifyJwsSignedWithSignatureKeyId(@PowerAuthSignatureKeyId int signatureKeyId, boolean compact, boolean strict, PowerAuthAuthentication authentication, boolean shouldPass) throws Exception {
         final byte[] dataForSigning = "This is a very sensitive information and must be signed.".getBytes(StandardCharsets.UTF_8);
         String resultSignature = AsyncHelper.await(resultCatcher -> {
-            ICancelable task = powerAuthSDK.calculateJwsSignature(authentication, dataForSigning, null, compact, signatureKeyId, new IJwsSignatureListener() {
+            ICancelable task = powerAuthSDK.calculateJwsSignature(testHelper.getContext(), authentication, dataForSigning, null, compact, signatureKeyId, new IJwsSignatureListener() {
                 @Override
                 public void onJwsSignatureSucceed(@NonNull String signedData, boolean compactForm) {
                     assertEquals(compact, compactForm);

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -1644,6 +1644,7 @@ public class PowerAuthSDK {
      * If the key identifier represents multiple key types, an error is also reported.
      * Hybrid signatures are not supported in this version of the library.
      *
+     * @param context Android context.
      * @param authentication The authentication object used for vault unlocking.
      * @param dataToSign The data to sign.
      * @param keyIdentifier The identifier of the key used for signature calculation.
@@ -1652,7 +1653,8 @@ public class PowerAuthSDK {
      *         the error is detected immediately.
      */
     @Nullable
-    public ICancelable calculateDigitalSignature(@NonNull PowerAuthAuthentication authentication,
+    public ICancelable calculateDigitalSignature(@NonNull Context context,
+                                                 @NonNull PowerAuthAuthentication authentication,
                                                  @Nullable byte[] dataToSign,
                                                  @PowerAuthSignatureKeyId int keyIdentifier,
                                                  @NonNull IDigitalSignatureListener listener) {
@@ -1714,12 +1716,12 @@ public class PowerAuthSDK {
      * @param data Data to be signed.
      * @param listener Listener with callbacks to signature status.
      * @return Async task associated with vault unlock request.
-     * @deprecated Method is deprecated, please use {@link #calculateDigitalSignature(PowerAuthAuthentication, byte[], int, IDigitalSignatureListener)} instead.
+     * @deprecated Method is deprecated, please use {@link #calculateDigitalSignature(Context, PowerAuthAuthentication, byte[], int, IDigitalSignatureListener)} instead.
      */
     @Deprecated // 2.0.0
     @Nullable
     public ICancelable signDataWithDevicePrivateKey(@NonNull final Context context, @NonNull PowerAuthAuthentication authentication, @NonNull final byte[] data, @NonNull final IDataSignatureListener listener) {
-        return calculateDigitalSignature(authentication, data, PowerAuthSignatureKeyId.DEVICE_EC, new IDigitalSignatureListener() {
+        return calculateDigitalSignature(context, authentication, data, PowerAuthSignatureKeyId.DEVICE_EC, new IDigitalSignatureListener() {
             @Override
             public void onDigitalSignatureSucceed(@NonNull byte[] signature) {
                 listener.onDataSignedSucceed(signature);
@@ -1766,6 +1768,7 @@ public class PowerAuthSDK {
      * The selected key must support signature calculation; otherwise, an error is reported.
      * If the key identifier represents multiple key types, compact format cannot be used for output.
      *
+     * @param context Android context.
      * @param authentication The authentication object used for vault unlocking.
      * @param dataToSign The data to sign.
      * @param dataType Data type set to JOSE header. Use {@code "JWT"} or {@code null} if no type is set.
@@ -1776,7 +1779,8 @@ public class PowerAuthSDK {
      *         the error is detected immediately.
      */
     @Nullable
-    public ICancelable calculateJwsSignature(@NonNull PowerAuthAuthentication authentication,
+    public ICancelable calculateJwsSignature(@NonNull Context context,
+                                             @NonNull PowerAuthAuthentication authentication,
                                              @Nullable byte[] dataToSign,
                                              @Nullable String dataType,
                                              boolean compactForm,
@@ -1823,13 +1827,13 @@ public class PowerAuthSDK {
      * @param claims Claims to be signed with the private key.
      * @param listener Listener with the callback methods
      * @return {@link ICancelable} object associated with the underlying HTTP request.
-     * @deprecated Method is deprecated, please use {@link #calculateJwsSignature(PowerAuthAuthentication, byte[], String, boolean, int, IJwsSignatureListener)} instead.
+     * @deprecated Method is deprecated, please use {@link #calculateJwsSignature(Context, PowerAuthAuthentication, byte[], String, boolean, int, IJwsSignatureListener)} instead.
      */
     @Deprecated // 2.0.0
     @Nullable
     public ICancelable signJwtWithDevicePrivateKey(@NonNull Context context, @NonNull PowerAuthAuthentication authentication, @NonNull Map<String, Object> claims, @NonNull IJwtSignatureListener listener) {
         byte[] dataForSign = new JsonSerialization().serializeObject(claims);
-        return calculateJwsSignature(authentication, dataForSign, "JWT", true, PowerAuthSignatureKeyId.DEVICE_EC, new IJwsSignatureListener() {
+        return calculateJwsSignature(context, authentication, dataForSign, "JWT", true, PowerAuthSignatureKeyId.DEVICE_EC, new IJwsSignatureListener() {
             @Override
             public void onJwsSignatureSucceed(@NonNull String signedData, boolean compactForm) {
                 listener.onJwtSignatureSucceed(signedData);


### PR DESCRIPTION
This PR adds Android `Context` parameter to all new APIs added to `PowerAuthSDK` class. This allows us to improve functionality in the future without another API breaking change. See #836 ticket for more details.