### PR TITLE
Remove unnecessary locks from task implementations

### DIFF
--- a/src/PowerAuth/task/ConfirmActivationTask.cpp
+++ b/src/PowerAuth/task/ConfirmActivationTask.cpp
@@ -18,8 +18,6 @@
 
 namespace powerAuth {
 
-#define LOCK_GUARD() std::lock_guard<std::recursive_mutex> _lock_guard(*_mutex)
-
 ConfirmActivationTask::ConfirmActivationTask(const ContextPtr& context, const InitialCredentialsPtr& credentials) :
     Task("ConfirmActivation", context),
     _credentials(credentials),
@@ -31,7 +29,7 @@ ConfirmActivationTask::ConfirmActivationTask(const ContextPtr& context, const In
 
 void ConfirmActivationTask::onTaskStart()
 {
-    LOCK_GUARD();
+    Task::onTaskStart();
     if (_session_data->getCurrentProtocolVersion() < Version_V4) {
         throw Exception(EC_InternalError, "Confirm task is not supported in V3");
     }

--- a/src/PowerAuth/task/ProtocolUpgradeTask.cpp
+++ b/src/PowerAuth/task/ProtocolUpgradeTask.cpp
@@ -83,7 +83,6 @@ void ProtocolUpgradeTask::onTaskEnd()
 
 void ProtocolUpgradeTask::startProtocolUpgrade()
 {
-    LOCK_GUARD();
     auto current_context = lockContext();
     
     if (!_password) {
@@ -181,7 +180,6 @@ ProtocolUpgradeResultPtr ProtocolUpgradeTask::processResponseStartProtocolUpgrad
 
 void ProtocolUpgradeTask::confirmProtocolUpgrade()
 {
-    LOCK_GUARD();
     auto context = lockContext();
     
     auto request = RequestBuilder(*context, v4::Endpoint_ProtocolUpgradeConfirm)


### PR DESCRIPTION
This PR removes LOCK_GUARDs from Task implementations in situations, when the lock is already acquired in parent class implementation. For example, `onTaskStart()` method is always called when shared lock is acquired.