### PR TITLE
Prepare forward data compatibility

### DIFF
--- a/docs/Migration-from-1.9-to-2.0.md
+++ b/docs/Migration-from-1.9-to-2.0.md
@@ -92,6 +92,11 @@ Notable changes on Android:
   - `PowerAuthAuthorizationHttpHeader` is deprecated, use functions that provide `PowerAuthHttpHeader` instead.
 
   - `PowerAuthMissingConfigException` is removed. The configuration is validated in `PowerAuthConfiguration.Builder.build()` method.
+  
+  - `PowerAuthErrorCodes` interface now contains the following new error codes:
+    - `.UPGRADE_SDK` is reported when local activation data format was created in newer SDK version.
+    - `.WRONG_SIGNATURE` is reported from functions validating digital or JWS signatures.
+    - `.OTHER` is reported for unknown errors.
 
   - `PowerAuthActivationStatus` is a new class that replaces `io.getlime.security.powerauth.core.ActivationStatus`. This change affects the following APIs:
     - `IActivationStatusListener` callback interface now gets `PowerAuthActivationStatus` in success.
@@ -228,6 +233,11 @@ Notable changes on iOS:
   - `authenticateUsingBiometry(withPrompt:callback:)`
   - `authenticateUsingBiometry(withContext:callback:)`
 
+- `PowerAuthErrorCode` enumeration now contains the following new error codes:
+  - `.upgradeSDK` is reported when local activation data format was created in newer SDK version.
+  - `.wrongSignature` is reported from functions validating digital or JWS signatures.
+  - `.other` is reported for unknown errors.
+
 - Due to discontinued support for "External Encryption Key" feature, the following methods has been changed:
   - `PowerAuthSDK.setExternalEncryptionKey()` method has been removed.
   - `PowerAuthSDK.addExternalEncryptionKey()` method has been removed.
@@ -257,7 +267,7 @@ Notable changes on iOS:
 
 ### Other changes
 
-- TBA
+If you're using [Activation Data Sharing](PowerAuth-SDK-for-iOS.md#share-activation-data) feature, then please refer to the [Upgrade from older SDKs](PowerAuth-SDK-for-iOS.md#upgrade-from-older-sdks) section for more information.
 
 ## iOS & tvOS App Extensions
 

--- a/docs/PowerAuth-SDK-for-Android.md
+++ b/docs/PowerAuth-SDK-for-Android.md
@@ -112,8 +112,22 @@ try {
     val powerAuthSDK = PowerAuthSDK.Builder(configuration)
         .build(applicationContext)
 } catch (exception: PowerAuthErrorException) {
-    // Failed to construct `PowerAuthSDK` due to insufficient keychain protection.
-    // (See next chapter for details)
+    when (exception.powerAuthErrorCode) {
+        PowerAuthErrorCodes.INVALID_ACTIVATION_DATA -> {
+            // Activation data format is not recognized
+            // Clear activation data and retry PowerAuthSDK object construction
+            PowerAuthSDK.cleanupInstanceData(applicationContext, configuration)
+        }
+        PowerAuthErrorCodes.INSUFFICIENT_KEYCHAIN_PROTECTION -> {
+            // This device doesn't support the requested level of keychain protection.
+            // See next chapters for details
+        }
+        PowerAuthErrorCodes.UPGRADE_SDK -> {
+            // You have somehow downgraded your application and activation data
+            // is in newer format. You can clear activation data and retry the operation.
+        }
+        else -> Log.d(TAG, "Other error")
+    }    
 }
 ```
 
@@ -2048,9 +2062,13 @@ when (t) {
             PowerAuthErrorCodes.OPERATION_CANCELED -> Log.d(TAG, "Error code for cancelled operations")
             PowerAuthErrorCodes.ENCRYPTION_ERROR -> Log.d(TAG, "Error code for errors related to end-to-end encryption")
             PowerAuthErrorCodes.INVALID_TOKEN -> Log.d(TAG, "Error code for errors related to token-based auth.")
+            PowerAuthErrorCodes.INSUFFICIENT_KEYCHAIN_PROTECTION -> Log.d(TAG, "Device doesn't support requested keychain protection.")
             PowerAuthErrorCodes.PROTOCOL_UPGRADE -> Log.d(TAG, "Error code for error that occurs when protocol upgrade fails at unrecoverable error.")
             PowerAuthErrorCodes.PENDING_PROTOCOL_UPGRADE -> Log.d(TAG, "The operation is temporarily unavailable, due to pending protocol upgrade.")
             PowerAuthErrorCodes.TIME_SYNCHRONIZATION -> Log.d(TAG, "Failed to synchronize time with the server.")
+            PowerAuthErrorCodes.WRONG_SIGNATURE -> Log.d(TAG, "Digital or JWS signature is not valid.")
+            PowerAuthErrorCodes.UPGRADE_SDK -> Log.d(TAG, "Upgrade PowerAuth Mobile SDK in your application.")
+            PowerAuthErrorCodes.OTHER -> Log.d(TAG, "Unspecified error.")
         }
         // Process additional information
         val additionalInfo = error.additionalInformation

--- a/docs/PowerAuth-SDK-for-iOS.md
+++ b/docs/PowerAuth-SDK-for-iOS.md
@@ -133,9 +133,23 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
         instanceId: Bundle.main.bundleIdentifier!,
         baseEndpointUrl: "https://<your-domain>/enrollment-server",
         configuration: "ARDDj6EB6iAUtNm...KKEcBxbnH9bMk8Ju3K1wmjbA==")
-
-    // Create a PowerAuthSDK instance with the configuration
-    let powerAuth = try PowerAuthSDK(configuration)
+    do {
+        // Create a PowerAuthSDK instance with the configuration
+        let powerAuth = try PowerAuthSDK(configuration: configuration)
+    } catch let err as NSError {
+        switch err.powerAuthErrorCode {
+        case .wrongParameter:
+            // Invalid configuration.
+        case .invalidActivationData:
+            // Unrecognized data format. You can log this event, clear data and retry SDK construction
+            try PowerAuthSDK.cleanupInstanceData(configuration: configuration)
+        case .upgradeSDK:
+            // Upgrade SDK in your application
+        default:
+            // other errors
+            break
+        }
+    }
 }
 ```
 
@@ -230,7 +244,7 @@ let configuration = PowerAuthConfiguration(
     algorithm: .EC_P384_ML_L5)
 
 // Create a PowerAuthSDK instance with the configuration
-let powerAuth = try PowerAuthSDK(configuration)
+let powerAuth = try PowerAuthSDK(configuration: configuration)
 ```
 
 The selected algorithm cannot be changed after a `PowerAuthSDK` instance is created, but it can be updated across the lifetime of your application. If the selected algorithm does not match the one used for the activation currently present on the device, the [authenticated protocol upgrade](#authenticated-protocol-upgrade) process must be performed to switch to the new algorithm.
@@ -1307,7 +1321,7 @@ let biometricConfiguration = PowerAuthBiometricConfiguration()
 biometricConfiguration.invalidateBiometricFactorAfterChange = true
 
 // Init PowerAuthSDK instance
-let powerAuthSDK = PowerAuthSDK(configuration: configuration, biometricConfiguration: biometricConfiguration, clientConfiguration: nil)
+let powerAuthSDK = try PowerAuthSDK(configuration: configuration, biometricConfiguration: biometricConfiguration, clientConfiguration: nil)
 ```
 
 <!-- begin box warning -->
@@ -1329,7 +1343,7 @@ let biometricConfiguration = PowerAuthBiometricConfiguration()
 biometricConfiguration.allowFallbackToDevicePasscode = true
 
 // Init PowerAuthSDK instance
-let powerAuthSDK = PowerAuthSDK(configuration: configuration, biometricConfiguration: biometricConfiguration, clientConfiguration: nil)
+let powerAuthSDK = try PowerAuthSDK(configuration: configuration, biometricConfiguration: biometricConfiguration, clientConfiguration: nil)
 ``` 
 
 Once the configuration above is used, then the `invalidateBiometricFactorAfterChange` option does not affect the biometry factor-related key lifetime. 
@@ -2035,6 +2049,10 @@ This chapter explains how to share the `PowerAuthSDK` activation state between a
 This feature is not supported on the macOS Catalyst platform.
 <!-- end -->
 
+<!-- begin box warning -->
+If you used this feature in an SDK version older than 2.0.0, please read the [Upgrade from older SDKs](#upgrade-from-older-sdks) chapter first.
+<!-- end -->
+
 ### Prepare Activation Data Sharing
 
 The App Extension normally doesn't have access to data created by the main application, so the first step is to set up data sharing for your project.
@@ -2097,7 +2115,7 @@ configuration.sharingConfiguration = PowerAuthSharingConfiguration(
     keychainAccessGroup: keychainSharing)
 
 // Create a PowerAuthSDK instance
-let powerAuthSDK = PowerAuthSDK(configuration)
+let powerAuthSDK = try PowerAuthSDK(configuration: configuration)
 ```
 
 The `PowerAuthSharingConfiguration` object contains the following properties:
@@ -2128,7 +2146,7 @@ powerAuthSDK.createActivation(activation) { (result, error) in
         }
     }
 }
-``` 
+```
 
 ## Synchronized Time
 
@@ -2294,6 +2312,15 @@ if error == nil {
             
         case .timeSynchronization:
             print("Failed to synchronize time with the server.")
+
+        case .wrongSignature:
+            print("Digital or JWS signature is not valid.")
+
+        case .upgradeSDK:
+            print("Upgrade PowerAuth Mobile SDK in your application.")
+
+        case .other:
+            print("Unspecified error.")
             
         default:
             print("Unknown error")
@@ -2310,6 +2337,7 @@ Here's the list of important error codes, which the application should properly 
 - `PowerAuthErrorCode.biometryFallback` is reported when the user cancels the biometric authentication dialog with a fallback button
 - `PowerAuthErrorCode.pendingProtocolUpgrade` is reported when the requested SDK operation cannot be completed due to a pending PowerAuth protocol upgrade. You can retry the operation later. The error code is typically reported in situations when SDK is performing protocol upgrade and the application wants to calculate the PowerAuth authentication code in parallel operation. Such kind of concurrency is forbidden since SDK version `1.0.0`
 - `PowerAuthErrorCode.externalPendingOperation` is reported when the requested operation collides with the same operation type already started in the external application.
+- `PowerAuthErrorCode.upgradeSDK` is reported when the local activation data format is not understandable by this version of PowerAuth Mobile SDK.
 
 ### Working with Invalid SSL Certificates
 
@@ -2562,3 +2590,18 @@ private func migrateUserDefaults(appGroup: String) {
     }
 }
 ```
+
+### Upgrade from older SDKs
+
+PowerAuth Mobile SDK version `2.0.0` introduced a new internal activation data format that is incompatible with previous SDK versions. This change is particularly important if you are using the [Activation Data Sharing](#share-activation-data) feature to share activation data between multiple applications. In such a setup, you may encounter a situation where one of your applications is already upgraded to a newer SDK version and the modified data is not recognized by an application using an older SDK version. This situation may lead to unexpected removal of activation data.
+
+To prevent this, it is very important to carefully plan how you roll out application updates to your users. It is recommended to follow these steps to reliably upgrade your applications to PowerAuth SDK 2.0 (and later):
+
+1. First, upgrade all your applications to SDK 2.0+ and set the [algorithm](#algorithms-for-communication) to `LEGACY_P256`. In this setup, the activation data format remains fully compatible with older SDK versions.
+2. Wait until a significant portion of your users are using version `2.0+` across all your applications.
+3. Then switch the [algorithm](#algorithms-for-communication) to the one you intend to use going forward (for example, `EC_P384_ML_L3`).
+
+<!-- begin box info -->
+The procedure above is not required if you are using activation data sharing to share data between a single application and its extensions. This setup is safe because the extensions are part of the main application and are upgraded at the same time.
+<!-- end -->
+

--- a/include/PowerAuth/Exception.h
+++ b/include/PowerAuth/Exception.h
@@ -36,8 +36,7 @@ enum ErrorCode
     EC_NotAllowed,
     /// Operation require synchronized time.
     EC_TimeNotSynchronized,
-    /// Invalid data. Error is reported in situations, when configuration or
-    /// serialized data format is not valid.
+    /// Invalid data. Error is reported in situations, when configuration is not valid.
     EC_InvalidData,
     /// Invalid response received from the server.
     EC_InvalidResponse,
@@ -52,7 +51,11 @@ enum ErrorCode
     /// Operation is not allowed due to pending protocol upgrade. Try again later.
     EC_PendingProtocolUpgrade,
     /// Other, unspecified type of error.
-    EC_Other
+    EC_Other,
+    /// Unknown activation data.
+    EC_InvalidActivationData,
+    /// Upgrade SDK is required. A newer version of local activation data detected.
+    EC_UpgradeSDK
 };
 
 /// The `Exception` class is error type reported from this library in case the operation fails.

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BaseSdkTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BaseSdkTest.java
@@ -20,12 +20,16 @@ import androidx.annotation.NonNull;
 
 import io.getlime.security.powerauth.core.CoreEncryptor;
 import io.getlime.security.powerauth.core.SecureData;
+import io.getlime.security.powerauth.keychain.Keychain;
+import io.getlime.security.powerauth.keychain.KeychainFactory;
+import io.getlime.security.powerauth.keychain.KeychainProtection;
 import io.getlime.security.powerauth.sdk.PowerAuthActivationState;
 import io.getlime.security.powerauth.sdk.PowerAuthActivationStatus;
 import io.getlime.security.powerauth.sdk.PowerAuthAlgorithm;
 import io.getlime.security.powerauth.networking.response.*;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -37,6 +41,9 @@ import io.getlime.security.powerauth.integration.support.model.ActivationDetail;
 import io.getlime.security.powerauth.networking.interfaces.ICancelable;
 import io.getlime.security.powerauth.sdk.PowerAuthActivation;
 import io.getlime.security.powerauth.sdk.PowerAuthAuthentication;
+import io.getlime.security.powerauth.sdk.PowerAuthConfiguration;
+import io.getlime.security.powerauth.sdk.PowerAuthKeychainConfiguration;
+import io.getlime.security.powerauth.sdk.PowerAuthSDK;
 import io.getlime.security.powerauth.system.PowerAuthSystem;
 
 import static org.junit.Assert.*;
@@ -722,5 +729,72 @@ public class BaseSdkTest extends BaseTest {
         });
         assertNotNull(result);
         System.out.println("Server name: " + result.getApplicationName() + ", version: " + result.getApplicationVersion());
+    }
+
+    @Test
+    public void cleanupActivationData() throws Exception {
+        activationHelper.createStandardActivation(false, null);
+        assertTrue(powerAuthSDK.hasValidActivation());
+        PowerAuthSDK.cleanupInstanceData(testHelper.getContext(), powerAuthSDK.getConfiguration(), powerAuthSDK.getKeychainConfiguration());
+        powerAuthSDK = activationHelper.reCreateSdk();
+        assertFalse(powerAuthSDK.hasValidActivation());
+    }
+
+    Keychain getInstanceKeychain() throws Exception {
+        String keychainId = powerAuthSDK.getKeychainConfiguration().getKeychainStatusId();
+        return KeychainFactory.getKeychain(testHelper.getContext(), keychainId, KeychainProtection.NONE);
+    }
+
+    @Test
+    public void testUnsupportedDataHandling() throws Exception {
+        byte[] unsupportedData = "HELLO".getBytes(StandardCharsets.UTF_8);
+        String instanceId = powerAuthSDK.getConfiguration().getInstanceId();
+        PowerAuthConfiguration configuration = powerAuthSDK.getConfiguration();
+        PowerAuthKeychainConfiguration keychainConfiguration = powerAuthSDK.getKeychainConfiguration();
+
+        // Insert status data
+        Keychain keychain = getInstanceKeychain();
+        keychain.putData(unsupportedData, instanceId);
+
+        // re-create SDK
+        PowerAuthErrorException exception = assertThrows(PowerAuthErrorException.class, () ->
+            new PowerAuthSDK.Builder(configuration)
+                    .keychainConfiguration(keychainConfiguration)
+                    .build(testHelper.getContext())
+        );
+        assertEquals(PowerAuthErrorCodes.INVALID_ACTIVATION_DATA, exception.getPowerAuthErrorCode());
+
+        // Erase instance data
+        PowerAuthSDK.cleanupInstanceData(testHelper.getContext(), configuration, keychainConfiguration);
+
+        // re-create should work now
+        powerAuthSDK = activationHelper.reCreateSdk();
+    }
+
+    @Test
+    public void testUpgradeSDKDetection() throws Exception {
+        // Session's data blob begins with sequence 'P' 'A' (data version) and status flag.
+        byte[] unsupportedData = "PX0".getBytes(StandardCharsets.UTF_8);
+        String instanceId = powerAuthSDK.getConfiguration().getInstanceId();
+        PowerAuthConfiguration configuration = powerAuthSDK.getConfiguration();
+        PowerAuthKeychainConfiguration keychainConfiguration = powerAuthSDK.getKeychainConfiguration();
+
+        // Insert status data
+        Keychain keychain = getInstanceKeychain();
+        keychain.putData(unsupportedData, instanceId);
+
+        // re-create SDK
+        PowerAuthErrorException exception = assertThrows(PowerAuthErrorException.class, () ->
+                new PowerAuthSDK.Builder(configuration)
+                        .keychainConfiguration(keychainConfiguration)
+                        .build(testHelper.getContext())
+        );
+        assertEquals(PowerAuthErrorCodes.UPGRADE_SDK, exception.getPowerAuthErrorCode());
+
+        // Erase instance data
+        PowerAuthSDK.cleanupInstanceData(testHelper.getContext(), configuration, keychainConfiguration);
+
+        // re-create should work now
+        powerAuthSDK = activationHelper.reCreateSdk();
     }
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreErrorCode.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreErrorCode.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Retention;
 @Retention(SOURCE)
 @IntDef({MISSING_ACTIVATION, WRONG_ACTIVATION_STATE, WRONG_PARAMETER, BIOMETRY_NOT_ALLOWED, NOT_ALLOWED,
         TIME_NOT_SYNCHRONIZED, INVALID_DATA, INVALID_RESPONSE, WRONG_SIGNATURE, INTERNAL_ERROR,
-        CRYPTOGRAPHY, CANCELED, PENDING_PROTOCOL_UPGRADE, OTHER})
+        CRYPTOGRAPHY, CANCELED, PENDING_PROTOCOL_UPGRADE, OTHER, INVALID_ACTIVATION_DATA, UPGRADE_SDK})
 public @interface CoreErrorCode {
     /**
      * Session has no activation but activation is required for the operation.
@@ -53,7 +53,7 @@ public @interface CoreErrorCode {
      */
     int TIME_NOT_SYNCHRONIZED = 6;
     /**
-     * Invalid data. Error is reported in situations, when configuration or serialized data format is not valid.
+     * Invalid data. Error is reported in situations, when configuration data format is not valid.
      */
     int INVALID_DATA = 7;
     /**
@@ -84,4 +84,12 @@ public @interface CoreErrorCode {
      * Other, unspecified type of error.
      */
     int OTHER = 14;
+    /**
+     * Unknown activation data format.
+     */
+    int INVALID_ACTIVATION_DATA = 15;
+    /**
+     * Upgrade SDK is required. A newer version of local activation data detected.
+     */
+    int UPGRADE_SDK = 16;
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/exception/PowerAuthErrorCodes.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/exception/PowerAuthErrorCodes.java
@@ -34,7 +34,7 @@ import static java.lang.annotation.RetentionPolicy.SOURCE;
         PROTOCOL_UPGRADE, PENDING_PROTOCOL_UPGRADE,
         BIOMETRY_NOT_SUPPORTED, BIOMETRY_NOT_AVAILABLE, BIOMETRY_NOT_RECOGNIZED,
         INSUFFICIENT_KEYCHAIN_PROTECTION, BIOMETRY_LOCKOUT, TIME_SYNCHRONIZATION,
-        BIOMETRY_NOT_ENROLLED, WRONG_SIGNATURE, OTHER})
+        BIOMETRY_NOT_ENROLLED, WRONG_SIGNATURE, OTHER, UPGRADE_SDK})
 public @interface PowerAuthErrorCodes {
 
     /**
@@ -173,7 +173,14 @@ public @interface PowerAuthErrorCodes {
      */
     int WRONG_SIGNATURE = 25;
     /**
+     * Upgrade the PowerAuth Mobile SDK in your application. This error may occur if the local
+     * activation data was created with a newer version of the SDK than the one currently used
+     * in your application. This situation can happen if you downgraded your application during
+     * testing.
+     */
+    int UPGRADE_SDK = 26;
+    /**
      * Other, unspecified error.
      */
-    int OTHER = 26;
+    int OTHER = 27;
 }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/exception/PowerAuthErrorException.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/exception/PowerAuthErrorException.java
@@ -179,6 +179,12 @@ public class PowerAuthErrorException extends Exception {
             case CoreErrorCode.PENDING_PROTOCOL_UPGRADE:
                 errorCode = PowerAuthErrorCodes.PENDING_PROTOCOL_UPGRADE;
                 break;
+            case CoreErrorCode.INVALID_ACTIVATION_DATA:
+                errorCode = PowerAuthErrorCodes.INVALID_ACTIVATION_DATA;
+                break;
+            case CoreErrorCode.UPGRADE_SDK:
+                errorCode = PowerAuthErrorCodes.UPGRADE_SDK;
+                break;
             default:
                 errorCode = suggestedErrorCode;
                 break;

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -83,6 +83,7 @@ public class PowerAuthSDK {
         private PowerAuthKeychainConfiguration mKeychainConfiguration;
         private ISavePowerAuthStateListener mStateListener;
         private ICallbackDispatcher mCallbackDispatcher;
+        private boolean ignoreInitialStateLoadFail;
 
         /**
          * Creates a builder for {@link PowerAuthSDK}.
@@ -142,6 +143,16 @@ public class PowerAuthSDK {
          */
         public @NonNull Builder callbackDispatcher(ICallbackDispatcher callbackDispatcher) {
             this.mCallbackDispatcher = callbackDispatcher;
+            return this;
+        }
+
+        /**
+         * Set flag indicating that initial state load failure can be ignored. This flag is used
+         * internally for constructing a temporary PowerAuthSDK instance.
+         * @return {@link Builder}
+         */
+        @NonNull Builder ignoreInitialStateLoadFail() {
+            this.ignoreInitialStateLoadFail = true;
             return this;
         }
 
@@ -250,7 +261,14 @@ public class PowerAuthSDK {
             // Register time service for automatic reset.
             PowerAuthAppLifecycleListener.getInstance().registerTimeSynchronizationService(context, timeSynchronizationService);
             // Restore state of this SDK instance.
-            instance.restoreState(instance.mStateListener.serializedState(mConfiguration.getInstanceId()));
+            try {
+                instance.restoreState(instance.mStateListener.serializedState(mConfiguration.getInstanceId()));
+            } catch (PowerAuthErrorException exception) {
+                if (!ignoreInitialStateLoadFail) {
+                    // Rethrow exception if ignore is off
+                    throw exception;
+                }
+            }
             return instance;
         }
 
@@ -364,6 +382,37 @@ public class PowerAuthSDK {
         }
         // Possession only
         return CoreCredentials.possession();
+    }
+
+    /**
+     * Erases local data associated with the {@code PowerAuthSDK} instance identified by the provided configuration and keychain configuration.
+     * <p>
+     * Use this method when {@code PowerAuthSDK} initialization fails with an error indicating an unsupported local activation data format
+     * and the stored local activation data must be removed before retrying initialization.
+     * @param context Android context.
+     * @param configuration The configuration used to identify the instance data.
+     * @param keychainConfiguration The keychain configuration used to locate the instance data. If {@code null}, the default configuration is applied.
+     * @throws PowerAuthErrorException In case the configuration is not valid.
+     */
+    public static void cleanupInstanceData(@NonNull Context context, @NonNull PowerAuthConfiguration configuration, @Nullable PowerAuthKeychainConfiguration keychainConfiguration) throws PowerAuthErrorException {
+        PowerAuthSDK temporary = new Builder(configuration)
+                .keychainConfiguration(keychainConfiguration)
+                .ignoreInitialStateLoadFail()
+                .build(context);
+        temporary.removeActivationLocal(context);
+    }
+
+    /**
+     * Erases local data associated with the {@code PowerAuthSDK} instance identified by the provided configuration.
+     * <p>
+     * Use this method when {@code PowerAuthSDK} initialization fails with an error indicating an unsupported local activation data format
+     * and the stored local activation data must be removed before retrying initialization.
+     * @param context Android context.
+     * @param configuration The configuration used to identify the instance data.
+     * @throws PowerAuthErrorException In case the configuration is not valid.
+     */
+    public static void cleanupInstanceData(@NonNull Context context, @NonNull PowerAuthConfiguration configuration) throws PowerAuthErrorException {
+        cleanupInstanceData(context, configuration, null);
     }
 
     /**

--- a/proj-xcode/PowerAuth2/PowerAuthErrorConstants.h
+++ b/proj-xcode/PowerAuth2/PowerAuthErrorConstants.h
@@ -151,17 +151,21 @@ typedef NS_ENUM(NSInteger, PowerAuthErrorCode) {
      */
     PowerAuthErrorCode_TimeSynchronization          = 20,
     /**
-     Error from PowerAuthCore module.
+     Digital or JWS signature is not valid.
      */
-    PowerAuthErrorCode_CoreError                    = 21,
+    PowerAuthErrorCode_WrongSignature               = 21,
+    /**
+     Upgrade the PowerAuth Mobile SDK in your application. This error may occur if the local activation data was created
+     with a newer version of the SDK than the one currently used in your application.
+
+     This situation can happen if you downgraded your application during testing, or if you are using the activation
+     data sharing feature and another application upgraded the shared activation data to a newer format.
+     */
+    PowerAuthErrorCode_UpgradeSDK                   = 22,
     /**
      Other, unspecified error.
      */
-    PowerAuthErrorCode_Other                        = 22,
-    /**
-     Digital or JWS signature is not valid.
-     */
-    PowerAuthErrorCode_WrongSignature               = 23
+    PowerAuthErrorCode_Other                        = 23,
 };
 
 @interface NSError (PowerAuthErrorCode)

--- a/proj-xcode/PowerAuth2/PowerAuthErrorConstants.m
+++ b/proj-xcode/PowerAuth2/PowerAuthErrorConstants.m
@@ -53,9 +53,10 @@ NSString * PA2MakeDefaultErrorDescription(NSInteger errorCode, NSString * messag
         _CODE_DESC(PowerAuthErrorCode_InvalidToken, @"Invalid or unknown token")
         _CODE_DESC(PowerAuthErrorCode_WatchConnectivity, @"Watch connectivity error")
         _CODE_DESC(PowerAuthErrorCode_ProtocolUpgrade, @"Protocol upgrade error")
-        _CODE_DESC(PowerAuthErrorCode_PendingProtocolUpgrade, @"Pending protocol ugprade, try later")
+        _CODE_DESC(PowerAuthErrorCode_PendingProtocolUpgrade, @"Pending protocol upgrade, try later")
         _CODE_DESC(PowerAuthErrorCode_ExternalPendingOperation, @"Other application does critical operation")
         _CODE_DESC(PowerAuthErrorCode_TimeSynchronization, @"Failed to synchronize time with the server")
+        _CODE_DESC(PowerAuthErrorCode_WrongSignature, @"Wrong digital signature")
         _CODE_DESC(PowerAuthErrorCode_UpgradeSDK, @"PowerAuth Mobile SDK update is required")
         _CODE_DESC(PowerAuthErrorCode_Other, @"Unspecified error")
         default:

--- a/proj-xcode/PowerAuth2/PowerAuthErrorConstants.m
+++ b/proj-xcode/PowerAuth2/PowerAuthErrorConstants.m
@@ -56,7 +56,7 @@ NSString * PA2MakeDefaultErrorDescription(NSInteger errorCode, NSString * messag
         _CODE_DESC(PowerAuthErrorCode_PendingProtocolUpgrade, @"Pending protocol ugprade, try later")
         _CODE_DESC(PowerAuthErrorCode_ExternalPendingOperation, @"Other application does critical operation")
         _CODE_DESC(PowerAuthErrorCode_TimeSynchronization, @"Failed to synchronize time with the server")
-        _CODE_DESC(PowerAuthErrorCode_CoreError, @"PowerAuthCore error")
+        _CODE_DESC(PowerAuthErrorCode_UpgradeSDK, @"PowerAuth Mobile SDK update is required")
         _CODE_DESC(PowerAuthErrorCode_Other, @"Unspecified error")
         default:
             return [NSString stringWithFormat:@"Unknown error %@", @(errorCode)];
@@ -99,8 +99,14 @@ NSError * PA2WrapError(NSError * error, NSError** out_error)
             case PowerAuthCoreError_PendingProtocolUpgrade:
                 errorCode = PowerAuthErrorCode_PendingProtocolUpgrade;
                 break;
+            case PowerAuthCoreError_InvalidActivationData:
+                errorCode = PowerAuthErrorCode_InvalidActivationData;
+                break;
+            case PowerAuthCoreError_UpgradeSDK:
+                errorCode = PowerAuthErrorCode_UpgradeSDK;
+                break;
             default:
-                errorCode = PowerAuthErrorCode_CoreError;
+                errorCode = PowerAuthErrorCode_Other;
                 break;
         }
     } else {

--- a/proj-xcode/PowerAuth2/PowerAuthSDK.h
+++ b/proj-xcode/PowerAuth2/PowerAuthSDK.h
@@ -44,15 +44,12 @@
 
 @interface PowerAuthSDK : NSObject<PowerAuthSessionStatusProvider>
 
-/** Reference to object that provides the low-level PowerAuthCoreSession class.
+/** Reference to an object that provides the low-level PowerAuthCoreSession class.
  
  WARNING
  
- This property is exposed only for the purpose of giving developers full low-level control over the cryptographic algorithm and
- managed activation state. For example, you can call a direct password change method without prior check of the password correctness
- in cooperation with the server API. Be extremely careful when calling any methods of this instance directly. There are very few
- protective mechanisms for keeping the session state actually consistent in the functional (not low level) sense. As a result, you
- may break your activation state (for example, by changing password from incorrect value to some other value).
+ This property is exposed solely for SDK testing purposes. The API defined in the provider may change
+ without further notice and may not be mentioned in the release notes or migration guide.
  */
 @property (nonatomic, strong, nonnull, readonly) id<PowerAuthCoreSessionProvider> sessionProvider;
 
@@ -92,7 +89,7 @@
 @property (nonatomic, strong, nonnull, readonly) id<PowerAuthTokenStore> tokenStore;
 
 /**
- Object providing functions to sychronize time with the server. The time is automatically synchronized with the server
+ Object providing functions to synchronize time with the server. The time is automatically synchronized with the server
  */
 @property (nonatomic, strong, nonnull, readonly) id<PowerAuthTimeSynchronizationService> timeSynchronizationService;
 
@@ -145,6 +142,32 @@
  */
 - (nullable instancetype) initWithConfiguration:(nonnull PowerAuthConfiguration *)configuration
                                           error:(NSError*_Nullable*_Nullable)error;
+
+/// Erases local data associated with the `PowerAuthSDK` instance identified by the provided configuration and keychain configuration.
+///
+/// Use this method when `PowerAuthSDK` initialization fails with an error indicating an unsupported local activation data format
+/// and the stored local activation data must be removed before retrying initialization.
+///
+/// @param configuration The configuration used to identify the instance data.
+/// @param keychainConfiguration The keychain configuration used to locate the instance data. If nil, the default configuration is applied.
+/// @param error Pointer where error is set in case of failure.
+/// @return true in case of success, false otherwise.
++ (BOOL) cleanupInstanceDataForConfiguration:(nonnull PowerAuthConfiguration*)configuration
+                       keychainConfiguration:(nullable PowerAuthKeychainConfiguration*)keychainConfiguration
+                                       error:(NSError*_Nullable*_Nullable)error
+                            NS_SWIFT_NAME(cleanupInstanceData(configuration:keychainConfiguration:));
+
+/// Erases local data associated with the `PowerAuthSDK` instance identified by the provided configuration.
+///
+/// Use this method when `PowerAuthSDK` initialization fails with an error indicating an unsupported local activation data format
+/// and the stored local activation data must be removed before retrying initialization.
+///
+/// @param configuration The configuration used to identify the instance data.
+/// @param error Pointer where error is set in case of failure.
+/// @return true in case of success, false otherwise.
++ (BOOL) cleanupInstanceDataForConfiguration:(nonnull PowerAuthConfiguration*)configuration
+                                       error:(NSError*_Nullable*_Nullable)error
+                            NS_SWIFT_NAME(cleanupInstanceData(configuration:));
 
 /** Creates an instance of SDK and initializes it with given configuration objects.
  

--- a/proj-xcode/PowerAuth2/PowerAuthSDK.m
+++ b/proj-xcode/PowerAuth2/PowerAuthSDK.m
@@ -114,12 +114,14 @@ static NSData * _BuildDeviceSpecificData(void)
 ///   - biometricConfiguration: Optional biometric configuration.
 ///   - clientConfiguration: Optional client configuration.
 ///   - keychainConfiguration: Optional keychain configuration.
+///   - clearUnsupportedData: If true, then unsupported session data will be erased.
 ///   - error: Pointer to store error.
 /// - Returns: YES in case of success, NO otherwise.
 - (BOOL) initializeWithConfiguration:(PowerAuthConfiguration*)configuration
               biometricConfiguration:(PowerAuthBiometricConfiguration*)biometricConfiguration
                  clientConfiguration:(PowerAuthClientConfiguration*)clientConfiguration
                keychainConfiguration:(PowerAuthKeychainConfiguration*)keychainConfiguration
+                clearUnsupportedData:(BOOL)clearUnsupportedData
                                error:(NSError**)error
 {
     NSError * localError = nil;
@@ -259,6 +261,13 @@ static NSData * _BuildDeviceSpecificData(void)
     }
     // Link core session and session interface together
     coreSession.delegate = _sessionInterface;
+    
+    // Load initial session's state
+    if (![_sessionInterface loadInitialState:clearUnsupportedData error:&localError]) {
+        PowerAuthCoreLog(@"ERROR: Failed to load initial session state");
+        PA2WrapError(localError, error);
+        return NO;
+    }
     
     // Create and setup a new HTTP client
     _client = [[PA2CoreHttpClient alloc] initWithConfiguration:_clientConfiguration
@@ -499,6 +508,7 @@ static NSData * _BuildDeviceSpecificData(void)
                         biometricConfiguration:biometricConfiguration
                            clientConfiguration:clientConfiguration
                          keychainConfiguration:keychainConfiguration
+                          clearUnsupportedData:NO
                                          error:error]) {
             return nil;
         }
@@ -526,6 +536,45 @@ static NSData * _BuildDeviceSpecificData(void)
                    clientConfiguration:nil
                  keychainConfiguration:nil
                                  error:error];
+}
+
+// Private init function
+
+- (instancetype) initForCleanupWithConfiguration:(nonnull PowerAuthConfiguration *)configuration
+                           keychainConfiguration:(nullable PowerAuthKeychainConfiguration *)keychainConfiguration
+                                           error:(NSError **)error
+{
+    self = [super init];
+    if (self) {
+        if (![self initializeWithConfiguration:configuration
+                        biometricConfiguration:nil
+                           clientConfiguration:nil
+                         keychainConfiguration:keychainConfiguration
+                          clearUnsupportedData:YES
+                                         error:error]) {
+            return nil;
+        }
+    }
+    return self;
+}
+
+
++ (BOOL) cleanupInstanceDataForConfiguration:(nonnull PowerAuthConfiguration*)configuration
+                       keychainConfiguration:(nullable PowerAuthKeychainConfiguration*)keychainConfiguration
+                                       error:(NSError*_Nullable*_Nullable)error
+{
+    PowerAuthSDK * temporary = [[PowerAuthSDK alloc] initForCleanupWithConfiguration:configuration
+                                                               keychainConfiguration:keychainConfiguration error:error];
+    if (temporary) {
+        [temporary removeActivationLocal];
+    }
+    return temporary != nil;
+}
+
++ (BOOL) cleanupInstanceDataForConfiguration:(nonnull PowerAuthConfiguration*)configuration
+                                       error:(NSError*_Nullable*_Nullable)error
+{
+    return [self cleanupInstanceDataForConfiguration:configuration keychainConfiguration:nil error:error];
 }
 
 static void _ThrowDeprecatedInitException(NSError * error)

--- a/proj-xcode/PowerAuth2/private/PA2DefaultSessionInterface.m
+++ b/proj-xcode/PowerAuth2/private/PA2DefaultSessionInterface.m
@@ -62,17 +62,12 @@ if (![self unlockImpl:&lerr] || lerr) {         \
         _lock = [[NSRecursiveLock alloc] init];
         _session = session;
         _dataProvider = dataProvider;
-        if (![self loadState:error]) {
-            return nil;
-        }
     }
     return self;
 }
 
-
-#pragma mark - Private
-
-- (BOOL) loadState:(NSError**)error
+- (BOOL) loadInitialState:(BOOL)clearUnsupportedData
+                    error:(NSError*_Nullable*_Nullable)error
 {
     // We don't need to acquire access lock, because the object is still
     // in its initialization phase. We need to just temporarily simulate
@@ -80,20 +75,39 @@ if (![self unlockImpl:&lerr] || lerr) {         \
     _readWriteAccessCount = 1;
     _saveOnUnlock = YES;
     
+    NSError * localError = nil;
     NSData * statusData = [_dataProvider sessionData];
+    BOOL loadSuccess;
     if (statusData) {
-        [_session deserializeState:statusData error:error];
+        loadSuccess = [_session deserializeState:statusData error:&localError];
+        if (!loadSuccess) {
+            PowerAuthCoreError coreError = localError.powerAuthCoreErrorCode;
+            if (clearUnsupportedData && (coreError == PowerAuthCoreError_InvalidActivationData || coreError == PowerAuthCoreError_UpgradeSDK)) {
+                // If cleanup is requested, then ignore the error and reset the session
+                [_session resetSession];
+                loadSuccess = YES;
+            } else {
+                // Otherwise wrap
+                PA2WrapError(localError, error);
+            }
+        }
     } else {
         [_session resetSession];
+        loadSuccess = YES;
     }
-    _stateBefore = [_session serializedState:error];
+    if (loadSuccess) {
+        _stateBefore = statusData;
+    }
     
     // Set counters to initial state
     _readWriteAccessCount = 0;
     _saveOnUnlock = NO;
     
-    return _stateBefore != nil;
+    return loadSuccess;
 }
+
+
+#pragma mark - Private
 
 - (void) lockImpl:(BOOL)write
 {

--- a/proj-xcode/PowerAuth2/private/PA2SessionInterface.h
+++ b/proj-xcode/PowerAuth2/private/PA2SessionInterface.h
@@ -29,6 +29,13 @@
 @protocol PA2SessionInterface <PowerAuthCoreSessionProvider, PowerAuthCoreSessionDelegate, PA2TokenDataLock>
 @required
 
+/// Load initial session state and optionally clear unsupported data.
+///
+/// @param clearUnsupportedData If YES, then unsupported data will be erased.
+/// @param error Pointer where error is set in case of failure.
+- (BOOL) loadInitialState:(BOOL)clearUnsupportedData
+                    error:(NSError*_Nullable*_Nullable)error;
+
 /**
  Contains instance to `PowerAuthExternalPendingOperation` in case that other application is doing the critical
  operation right now.

--- a/proj-xcode/PowerAuth2/private/PA2SharedSessionInterface.m
+++ b/proj-xcode/PowerAuth2/private/PA2SharedSessionInterface.m
@@ -27,9 +27,11 @@
 #pragma mark Private constants
 
 // Acquire read lock
-#define ACQ_READ     0
+#define ACQ_READ        0
 // Acquire write lock
-#define ACQ_WRITE    1
+#define ACQ_WRITE       1
+// Erase invalid state data
+#define ACQ_ERASE_INVD  2
 
 /// Lenght of SHA256 hash, calculated from PowerAuthConfiguration.instanceId
 #define INSTANCE_ID_SIZE    32
@@ -435,8 +437,6 @@ static BOOL _ValidateSharedMemoryData(LocalContext * ctx, void * bytes, NSUInteg
         }
         // Acquire local recursive lock to get a thread safety for debug and support functions
         _localLock = [_statusLock createLocalRecursiveLock];
-        // Everything looks OK, so restore the state and unlock the shared lock.
-        [self loadState:YES error:error];
         
         // Finally, release the shared lock
         [_statusLock unlock];
@@ -444,6 +444,21 @@ static BOOL _ValidateSharedMemoryData(LocalContext * ctx, void * bytes, NSUInteg
     return self;
 }
 
+- (BOOL) loadInitialState:(BOOL)clearUnsupportedData
+                    error:(NSError*_Nullable*_Nullable)error
+{
+    NSError * localError = nil;
+    int access = ACQ_WRITE;
+    if (clearUnsupportedData) access |= ACQ_ERASE_INVD;
+    if ([self lockWithAccess:access error:&localError]) {
+        // Simple lock - unlock will guarantee initial state load.
+        [self unlockWithError:&localError];
+    }
+    if (localError) {
+        PA2WrapError(localError, error);
+    }
+    return localError == nil;
+}
 
 #pragma mark - PowerAuthCoreSessionProvider protocol
 
@@ -713,7 +728,7 @@ static void _ThrowInternalInitFail(void)
  is NO, then function try to determine whether local session needs to deserialize its state.
  If force is YES, then the session's state is always restored from the persistent storage.
  */
-- (BOOL) loadState:(BOOL)force error:(NSError**)error
+- (BOOL) loadState:(BOOL)force clearInvalidData:(BOOL)clearInvalidData error:(NSError**)error
 {
     if (!force && !_LocalContextStateIsDirty(&_localContext)) {
         // Do nothing if local session has still valid data.
@@ -728,16 +743,23 @@ static void _ThrowInternalInitFail(void)
     NSData * statusData = [_dataProvider sessionData];
     if (statusData) {
         if (![_session deserializeState:statusData error:&localError]) {
-            PA2WrapError(localError, error);
-            return NO;
+            PowerAuthCoreError coreError = localError.powerAuthCoreErrorCode;
+            if (clearInvalidData && (coreError == PowerAuthCoreError_InvalidActivationData || coreError == PowerAuthCoreError_UpgradeSDK)) {
+                // Explicit clear is requested, so reset the session and pretend that everything's OK
+                [_session resetSession];
+                localError = nil;
+            } else {
+                PA2WrapError(localError, error);
+                // Clear temporary granted access.
+                _internalAccessGranted = NO;
+                return NO;
+            }
         }
     } else {
         [_session resetSession];
     }
-    if (!(_stateBefore = [_session serializedState:&localError])) {
-        PA2WrapError(localError, error);
-        return NO;
-    }
+    
+    _stateBefore = statusData;
     
     // Clear temporary granted access.
     _internalAccessGranted = NO;
@@ -754,7 +776,7 @@ static void _ThrowInternalInitFail(void)
 {
     NSData * serializedState = [_session serializedState:error];
     if (serializedState) {
-        if (![serializedState isEqualToData:_stateBefore]) {
+        if (![_stateBefore isEqualToData:serializedState]) {
             // Data is different, so we really need to save the data.
             [_dataProvider saveSessionData:serializedState];
             _stateBefore = serializedState;
@@ -774,13 +796,14 @@ static void _ThrowInternalInitFail(void)
     [_statusLock lock];
     
     _readWriteAccessCount++;
-    if (access == ACQ_WRITE) {
+    if ((access & ACQ_WRITE) == ACQ_WRITE) {
         _saveOnUnlock = YES;
     }
     
     if (_readWriteAccessCount == 1) {
         // First lock, we should restore session's data if needed.
-        if (![self loadState:NO error:error]) {
+        BOOL clearInvalidData = (access & ACQ_ERASE_INVD) == ACQ_ERASE_INVD;
+        if (![self loadState:NO clearInvalidData:clearInvalidData error:error]) {
             // state load failed, release lock and return error
             _readWriteAccessCount = 0;
             [_statusLock unlock];

--- a/proj-xcode/PowerAuth2/private/PA2SharedSessionInterface.m
+++ b/proj-xcode/PowerAuth2/private/PA2SharedSessionInterface.m
@@ -33,7 +33,7 @@
 // Erase invalid state data
 #define ACQ_ERASE_INVD  2
 
-/// Lenght of SHA256 hash, calculated from PowerAuthConfiguration.instanceId
+/// Length of SHA256 hash, calculated from PowerAuthConfiguration.instanceId
 #define INSTANCE_ID_SIZE    32
 
 /// Length of application identifier, reserved in SharedData.

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKBaseTests.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKBaseTests.m
@@ -3206,4 +3206,136 @@
     [_helper cleanup];
 }
 
+// Forward data compatibility
+
+- (PowerAuthKeychain*) instanceKeychain
+{
+    NSString * keychainId = _sdk.keychainConfiguration.keychainInstanceName_Status;
+    NSString * accessGroup = _sdk.configuration.sharingConfiguration.appGroup;
+    return [[PowerAuthKeychain alloc] initWithIdentifier:keychainId accessGroup:accessGroup];
+}
+
+- (void) insertInstanceActivationData:(NSData*)data instanceId:(NSString*)instanceId
+{
+    PowerAuthKeychain * keychain = [self instanceKeychain];
+    
+    if ([keychain containsDataForKey:instanceId]) {
+        [keychain updateValue:data forKey:instanceId];
+    } else {
+        [keychain addValue:data forKey:instanceId];
+    }
+}
+
+- (NSData*) getInstanceActivationData:(NSString*)instanceId
+{
+    PowerAuthKeychain * keychain = [self instanceKeychain];
+    NSData * data = [keychain dataForKey:instanceId status:NULL];
+    return data;
+}
+
+- (void) testCleanupActivationData
+{
+    CHECK_TEST_CONFIG();
+    
+    PowerAuthSdkActivation * activation = [_helper createActivation:YES];
+    if (!activation) {
+        return;
+    }
+    XCTAssertTrue(_sdk.hasValidActivation);
+    NSError * error = nil;
+    BOOL result = [PowerAuthSDK cleanupInstanceDataForConfiguration:_sdk.configuration error:&error];
+    XCTAssertTrue(result);
+    XCTAssertNil(error);
+    
+    // re-instantiate SDK object
+    _sdk = [_helper reCreateSdkInstance];
+    
+    // Activation should be gone
+    XCTAssertFalse(_sdk.hasValidActivation);
+}
+
+
+- (void) testUnsupportedDataHandling
+{
+    NSData * unsupportedData = [@"HELLO" dataUsingEncoding:NSASCIIStringEncoding];
+    
+    NSString * instanceId = _sdk.configuration.instanceId;
+    PowerAuthConfiguration * configuration = [_sdk.configuration copy];
+    PowerAuthKeychainConfiguration * keychainConfiguration = [_sdk.keychainConfiguration copy];
+        
+    // Insert unsupported data
+    [self insertInstanceActivationData:unsupportedData instanceId:instanceId];
+        
+    NSError * error = nil;
+    _sdk = [[PowerAuthSDK alloc] initWithConfiguration:configuration
+                                biometricConfiguration:nil
+                                   clientConfiguration:nil
+                                 keychainConfiguration:keychainConfiguration
+                                                 error:&error];
+    XCTAssertNil(_sdk);
+    XCTAssertEqual(PowerAuthErrorCode_InvalidActivationData, error.powerAuthErrorCode);
+    
+    // Check whether keychain is not modified after initialization
+    XCTAssertEqualObjects(unsupportedData, [self getInstanceActivationData:instanceId]);
+    
+    error = nil;
+    BOOL result = [PowerAuthSDK cleanupInstanceDataForConfiguration:configuration
+                                              keychainConfiguration:keychainConfiguration
+                                                              error:&error];
+    XCTAssertTrue(result);
+    XCTAssertNil(error);
+    
+    _sdk = [[PowerAuthSDK alloc] initWithConfiguration:configuration
+                                biometricConfiguration:nil
+                                   clientConfiguration:nil
+                                 keychainConfiguration:keychainConfiguration
+                                                 error:&error];
+
+    XCTAssertNotNil(_sdk);
+    XCTAssertNil(error);
+    XCTAssertFalse(_sdk.hasValidActivation);
+}
+
+- (void) testUpgradeSDKDetection
+{
+    // Session's data blob begins with sequence 'P' 'A' (data version) and status flag.
+    NSData * unsupportedData = [@"PX0" dataUsingEncoding:NSASCIIStringEncoding];
+    
+    NSString * instanceId = _sdk.configuration.instanceId;
+    PowerAuthConfiguration * configuration = [_sdk.configuration copy];
+    PowerAuthKeychainConfiguration * keychainConfiguration = [_sdk.keychainConfiguration copy];
+        
+    // Insert unsupported data
+    [self insertInstanceActivationData:unsupportedData instanceId:instanceId];
+        
+    NSError * error = nil;
+    _sdk = [[PowerAuthSDK alloc] initWithConfiguration:configuration
+                                biometricConfiguration:nil
+                                   clientConfiguration:nil
+                                 keychainConfiguration:keychainConfiguration
+                                                 error:&error];
+    XCTAssertNil(_sdk);
+    XCTAssertEqual(PowerAuthErrorCode_UpgradeSDK, error.powerAuthErrorCode);
+    
+    // Check whether keychain is not modified after initialization
+    XCTAssertEqualObjects(unsupportedData, [self getInstanceActivationData:instanceId]);
+    
+    error = nil;
+    BOOL result = [PowerAuthSDK cleanupInstanceDataForConfiguration:configuration
+                                              keychainConfiguration:keychainConfiguration
+                                                              error:&error];
+    XCTAssertTrue(result);
+    XCTAssertNil(error);
+    
+    _sdk = [[PowerAuthSDK alloc] initWithConfiguration:configuration
+                                biometricConfiguration:nil
+                                   clientConfiguration:nil
+                                 keychainConfiguration:keychainConfiguration
+                                                 error:&error];
+
+    XCTAssertNotNil(_sdk);
+    XCTAssertNil(error);
+    XCTAssertFalse(_sdk.hasValidActivation);
+}
+
 @end

--- a/proj-xcode/PowerAuthCore/PowerAuthCoreError.h
+++ b/proj-xcode/PowerAuthCore/PowerAuthCoreError.h
@@ -39,8 +39,7 @@ typedef NS_ENUM(NSInteger, PowerAuthCoreError) {
     PowerAuthCoreError_NotAllowed,
     /// Operation require synchronized time.
     PowerAuthCoreError_TimeNotSynchronized,
-    /// Invalid data. Error is reported in situations, when configuration or
-    /// serialized data format is not valid.
+    /// Invalid data. Error is reported in situations, when SDK configuration data format is not valid.
     PowerAuthCoreError_InvalidData,
     /// Invalid response received from the server.
     PowerAuthCoreError_InvalidResponse,
@@ -55,7 +54,11 @@ typedef NS_ENUM(NSInteger, PowerAuthCoreError) {
     /// Operation is not allowed due to pending protocol upgrade. Try again later.
     PowerAuthCoreError_PendingProtocolUpgrade,
 	/// Other, unspecified type of error.
-    PowerAuthCoreError_Other
+    PowerAuthCoreError_Other,
+    /// Unknown activation data.
+    PowerAuthCoreError_InvalidActivationData,
+    /// Upgrade SDK is required. A newer version of local activation data detected.
+    PowerAuthCoreError_UpgradeSDK,
 };
 
 @interface NSError (PowerAuthCoreError)

--- a/src/PowerAuth/model/Constants.h
+++ b/src/PowerAuth/model/Constants.h
@@ -78,10 +78,10 @@ const size_t PASSKDF_SALT_SIZE = 32;
 /// Length of all factor keys
 const size_t FACTOR_KEY_SIZE = 32;
 
-/// Lenght of factor key encrypted with UKE
+/// Length of factor key encrypted with UKE
 const size_t UKE_PROTECTED_KEY_SIZE = 16 + 32;
 
-/// Lenght of factor (or similar) key encrypted with AEAD
+/// Length of factor (or similar) key encrypted with AEAD
 const size_t AEAD_PROTECTED_KEY_SIZE = 12 + 32 + 32;
 
 /// Length of vault key.

--- a/src/PowerAuth/model/PersistentData.cpp
+++ b/src/PowerAuth/model/PersistentData.cpp
@@ -135,15 +135,15 @@ PersistentDataPtr PersistentData::deserialize(cc7::utils::DataReader& reader)
 {
     auto result = reader.openVersion(PD_TAG, PD_VERSION_V2);
     if (!result) {
-        throw Exception(EC_InvalidData, "Unknown persistent data format");
+        throw Exception(EC_InvalidActivationData, "Unknown persistent data format");
     }
     auto data_version = reader.currentVersion();
     if (data_version < PD_VERSION_V5) {
         // We don't support upgrade from SDK older than 1.3.x (December 2019)
-        throw Exception(EC_InvalidData, "Persistent data format is too old");
+        throw Exception(EC_InvalidActivationData, "Persistent data format is too old");
     } else if (data_version > PD_VERSION_V6) {
         // Seems that newer version of SDK serialized its data. We cannot understand this format.
-        throw Exception(EC_InvalidData, "Persistent data format is too new");
+        throw Exception(EC_UpgradeSDK, "Persistent data created in newer SDK version");
     }
     
     // Build data depending on serialized version
@@ -151,7 +151,7 @@ PersistentDataPtr PersistentData::deserialize(cc7::utils::DataReader& reader)
         // V3 Legacy data
         auto data = std::make_unique<V3>();
         if (!deserializeV3(reader, *data)) {
-            throw Exception(EC_InvalidData, "Failed to deserialize legacy persistent data");
+            throw Exception(EC_InvalidActivationData, "Failed to deserialize legacy persistent data");
         }
         return std::unique_ptr<PersistentData>(new PersistentData(data, false));
         //
@@ -159,7 +159,7 @@ PersistentDataPtr PersistentData::deserialize(cc7::utils::DataReader& reader)
         // V4 data
         auto data = std::make_unique<V4>();
         if (!deserializeV4(reader, *data)) {
-            throw Exception(EC_InvalidData, "Failed to deserialize persistent data");
+            throw Exception(EC_InvalidActivationData, "Failed to deserialize persistent data");
         }
         return std::unique_ptr<PersistentData>(new PersistentData(data, false));
         //

--- a/src/PowerAuth/model/SessionData.cpp
+++ b/src/PowerAuth/model/SessionData.cpp
@@ -187,7 +187,7 @@ UpgradeData& SessionData::upgradeData()
 // Serialization
 
 static const cc7::byte SD_TAG   = 'P';
-static const cc7::byte SD_VER1  = 'A';                // SDK 0.x.y - 1.x.y
+static const cc7::byte SD_VER1  = 'A';                // SDK 0.x.y - 2.x.y
 
 static const cc7::byte SD_VER1_FLAG_NONE  = 0;        // No additional data included
 static const cc7::byte SD_VER1_FLAG_PD    = 1 << 1;   // PersistentData included
@@ -213,8 +213,14 @@ void SessionData::deserialize(const cc7::ByteRange& serialized_data)
 {
     cc7::byte flags = 0;
     cc7::utils::DataReader reader(serialized_data, false);
-    if (!reader.openVersion(SD_TAG, SD_VER1, SD_VER1) || !reader.readByte(flags)) {
-        throw Exception(EC_InvalidData, "Unknown SessionData format");
+    if (!reader.openVersion(SD_TAG, SD_VER1)) {
+        throw Exception(EC_InvalidActivationData, "Unknown session data format");
+    }
+    if (reader.currentVersion() > SD_VER1) {
+        throw Exception(EC_UpgradeSDK, "Session data created in newer SDK version");
+    }
+    if (!reader.readByte(flags)) {
+        throw Exception(EC_InvalidActivationData, "Unknown session data format");
     }
     if (flags & SD_VER1_FLAG_PD) {
         auto pd = PersistentData::deserialize(reader);

--- a/src/PowerAuthJni/ClassSpecs.cpp
+++ b/src/PowerAuthJni/ClassSpecs.cpp
@@ -132,7 +132,9 @@ ClassSpecs ClassSpecs::buildSpecs(JNI &jni)
             "CRYPTOGRAPHY",
             "CANCELED",
             "PENDING_PROTOCOL_UPGRADE",
-            "OTHER"
+            "OTHER",
+            "INVALID_ACTIVATION_DATA",
+            "UPGRADE_SDK"
         });
         spec.coreException = jni.buildClassSpec<CoreException>("io/getlime/security/powerauth/core/CoreException");
 


### PR DESCRIPTION
This PR prepares the SDK for future changes to the local activation data format, similar to the upgrade from protocol V3 to V4.

To support this, we have introduced a new error code (UPGRADE_SDK) and added a function for cleaning up local activation data. This allows applications to remove unsupported data before creating a `PowerAuthSDK` instance.

Other notable changes:

- Added public documentation for missing error codes (both Android and iOS)
- `PA2SessionInterface` now has two step initialization sequence
  - In 1st step, instance is created
  - In 2nd step, initial data load is performed
- `PA2SharedSessionInterface` optimizations
  - There's no longer data re-serialization in the lock function. This is not necessary and in fact, just complicated a lot of things.
- `PA2DefaultSessionInterface` optimizations
  - The initial load doesn't re-serialize session's state. The situation is similar than in PA2SharedSessionInterface implementation
- Removed `PowerAuthErrorCode_CoreError` error code on iOS. That was redundant with "Other" error code