### PR TITLE
Fixed possible NPE in PA2SharedSessionInterface implementation

### DIFF
--- a/proj-xcode/PowerAuth2/private/PA2SharedSessionInterface.m
+++ b/proj-xcode/PowerAuth2/private/PA2SharedSessionInterface.m
@@ -828,7 +828,7 @@ static void _ThrowInternalInitFail(void)
             // Some task requested write access, so save the state.
             result = [self saveState:error];
             if (result) {
-                // Clear dirty flag if save succeeds
+                // Clear save-on-unlock flag if save succeeds
                 _saveOnUnlock = NO;
             }
         }

--- a/proj-xcode/PowerAuth2/private/PA2SharedSessionInterface.m
+++ b/proj-xcode/PowerAuth2/private/PA2SharedSessionInterface.m
@@ -823,10 +823,12 @@ static void _ThrowInternalInitFail(void)
         // The shared lock will be released at the end of this function. If error is already
         // triggered, then do nothing at this step. We don't want to save session if
         // operation failed.
-        if (_saveOnUnlock && !*error) {
+        BOOL isFailure = error && (*error != nil);
+        if (_saveOnUnlock && !isFailure) {
             // Some task requested write access, so save the state.
             result = [self saveState:error];
             if (result) {
+                // Clear dirty flag if save succeeds
                 _saveOnUnlock = NO;
             }
         }


### PR DESCRIPTION
This PR fixes possible crash by access to null address in PA2SharedSessionInterface.