### PR TITLE
Cleanup when core request or task is abandoned

### DIFF
--- a/include/PowerAuth/Task.h
+++ b/include/PowerAuth/Task.h
@@ -63,6 +63,9 @@ public:
     /// Cancel the task.
     void cancel() noexcept;
     
+    /// Cancels the task if it has not completed yet.
+    void cancelIfNotDone() noexcept;
+    
     /// Test whether task is finished its execution no matter of the type of the result.
     bool isDone() const noexcept;
     
@@ -129,6 +132,11 @@ protected:
     ///
     /// The shared lock is acquired before the call.
     virtual void onTaskEnd();
+    
+    /// Overridable method, called when task is canceled.
+    ///
+    /// The shared lock is acquired before the call.
+    virtual void onTaskCancel();
 
     /// Overridable method, called when partial request ends with success.
     ///

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreRequest.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreRequest.java
@@ -72,8 +72,12 @@ public class CoreRequest<TResponse> extends NativeObject {
 
     @Override
     protected void finalize() {
+        // Make sure the request is also canceled if it has not completed yet. If this happens,
+        // it means that the Java wrapper was abandoned and destroyed before completion.
+        // This is important for some requests that modify state on the parent Session.
+        // The cancel() also releases `responseBuilderHandle` if still set.
+        cancel();
         super.finalize();
-        NativeObject.safeNativeDestroy(responseBuilderHandle);
     }
 
     /**

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreRequest.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreRequest.java
@@ -72,12 +72,17 @@ public class CoreRequest<TResponse> extends NativeObject {
 
     @Override
     protected void finalize() {
-        // Make sure the request is also canceled if it has not completed yet. If this happens,
-        // it means that the Java wrapper was abandoned and destroyed before completion.
-        // This is important for some requests that modify state on the parent Session.
-        // The cancel() also releases `responseBuilderHandle` if still set.
-        cancel();
-        super.finalize();
+        try {
+            // Make sure the request is also canceled if it has not completed yet. If this happens,
+            // it means that the Java wrapper was abandoned and destroyed before completion.
+            // This is important for some requests that modify state on the parent Session.
+            // The cancel() also releases `responseBuilderHandle` if still set.
+            cancel();
+        } catch (Throwable ignored) {
+            // Ignore failures during native cancellation to allow superclass finalization.
+        } finally {
+            super.finalize();
+        }
     }
 
     /**

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreTask.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreTask.java
@@ -78,12 +78,17 @@ public class CoreTask<TResponse> extends NativeObject {
 
     @Override
     protected void finalize() {
-        // Make sure the task is also canceled if it has not completed yet. If this happens,
-        // it means that the Java wrapper was abandoned and being destroyed before completion.
-        // This is important for some tasks that modify pending flags on the parent Session.
-        // The cancelIfNotDone() also releases `responseBuilderHandle` if still set.
-        cancelIfNotDone();
-        super.finalize();
+        try {
+            // Make sure the task is also canceled if it has not completed yet. If this happens,
+            // it means that the Java wrapper was abandoned and being destroyed before completion.
+            // This is important for some tasks that modify pending flags on the parent Session.
+            // The cancelIfNotDone() also releases `responseBuilderHandle` if still set.
+            cancelIfNotDone();
+        } catch (Throwable ignore) {
+            // Ignore failures during native cancellation to allow superclass finalization.
+        } finally {
+            super.finalize();
+        }
     }
 
     /**

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreTask.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreTask.java
@@ -75,10 +75,15 @@ public class CoreTask<TResponse> extends NativeObject {
      * Property is modified from JNI.
      */
     private Object responseJson;
+
     @Override
     protected void finalize() {
+        // Make sure the task is also canceled if it has not completed yet. If this happens,
+        // it means that the Java wrapper was abandoned and being destroyed before completion.
+        // This is important for some tasks that modify pending flags on the parent Session.
+        // The cancelIfNotDone() also releases `responseBuilderHandle` if still set.
+        cancelIfNotDone();
         super.finalize();
-        NativeObject.safeNativeDestroy(responseBuilderHandle);
     }
 
     /**
@@ -144,6 +149,11 @@ public class CoreTask<TResponse> extends NativeObject {
      * Cancel the task.
      */
     public native void cancel();
+
+    /**
+     * Cancels the task if it has not completed yet.
+     */
+    private native void cancelIfNotDone();
 
     /**
      * Get the next request to execute as a part of this task.

--- a/src/PowerAuth/Task.cpp
+++ b/src/PowerAuth/Task.cpp
@@ -82,12 +82,28 @@ void Task::start() noexcept
 void Task::cancel() noexcept
 {
     LOCK_GUARD();
+    auto notify_about_cancel = _state != State::CANCELED;
     _state = State::CANCELED;
     if (_next_request) {
         _next_request->cancel();
         _next_request = nullptr;
     }
     cancelCurrentRequest();
+    if (notify_about_cancel) {
+        try {
+            onTaskCancel();
+        } catch (...) {
+            log("cancel failed with exception");
+        }
+    }
+}
+
+void Task::cancelIfNotDone() noexcept
+{
+    LOCK_GUARD();
+    if (_state <= State::PENDING) {
+        cancel();
+    }
 }
 
 bool Task::isDone() const noexcept
@@ -295,6 +311,11 @@ void Task::onTaskEnd()
         default:
             break;
     }
+}
+
+void Task::onTaskCancel()
+{
+    log("Task canceled");
 }
 
 void Task::onRequestSuccess(const Request& request)

--- a/src/PowerAuth/task/ProtocolUpgradeTask.cpp
+++ b/src/PowerAuth/task/ProtocolUpgradeTask.cpp
@@ -81,6 +81,12 @@ void ProtocolUpgradeTask::onTaskEnd()
     resetState();
 }
 
+void ProtocolUpgradeTask::onTaskCancel()
+{
+    Task::onTaskCancel();
+    resetState();
+}
+
 void ProtocolUpgradeTask::startProtocolUpgrade()
 {
     auto current_context = lockContext();

--- a/src/PowerAuth/task/ProtocolUpgradeTask.h
+++ b/src/PowerAuth/task/ProtocolUpgradeTask.h
@@ -32,6 +32,7 @@ protected:
     void onRequestSuccess(const Request &request) override;
     void onRequestFailure(const Request &request) override;
     void onTaskEnd() override;
+    void onTaskCancel() override;
     
     enum RequestId
     {

--- a/src/PowerAuthJni/CoreTaskJNI.cpp
+++ b/src/PowerAuthJni/CoreTaskJNI.cpp
@@ -161,19 +161,38 @@ CC7_JNI_METHOD(void, updateResponse)
     NH_CATCH()
 }
 
-CC7_JNI_METHOD(void, cancel)
+/// Common cancel implementation.
+/// @param env JNI context.
+/// @param thiz Java "this" object.
+/// @param regular_cancel If true, then perform a regular cancel, otherwise cleanup from finalize().
+static void cancelImpl(JNIEnv * env, jobject thiz, bool regular_cancel)
 {
     NH_TRY
     {
         auto& specs = NH_SPECS();
         auto this_wrapped = jni.fromJava(thiz, specs.coreTask.native.classRef);
         auto this_obj = jni.fromHandle<Task>(this_wrapped.getLong(specs.coreTask.native.handle));
-        // Cancel task
-        this_obj->cancel();
+        if (regular_cancel) {
+            // regular cancel
+            this_obj->cancel();
+        } else {
+            // cleanup from finalize()
+            this_obj->cancelIfNotDone();
+        }
         // Cleanup builder
         jni::ClearResponseBuilderClosure(jni, specs, this_wrapped);
     }
-    NH_CATCH()
+    NH_CATCH_RT_ONLY()
+}
+
+CC7_JNI_METHOD(void, cancel)
+{
+    cancelImpl(env, thiz, true);
+}
+
+CC7_JNI_METHOD(void, cancelIfNotDone)
+{
+    cancelImpl(env, thiz, false);
 }
 
 CC7_JNI_METHOD(jobject, getNextRequestImpl)


### PR DESCRIPTION
This PR improves cleanup when objects wrapping C++ Task or Request instances into the Java or Objective-C runtime are abandoned and destroyed without any prior processing. The low-level task or request may modify the state of the Session and usually expects the operation to be either completed or canceled. Without such cleanup, the Session may end up in an undesired state.

Other changes:
- `ProtocolUpgradeTask` implements proper reset on cancel.