### PR TITLE
Fixed failing tests on iOS

### DIFF
--- a/docs/PowerAuth-SDK-for-iOS.md
+++ b/docs/PowerAuth-SDK-for-iOS.md
@@ -2127,10 +2127,16 @@ let powerAuthSDK = try PowerAuthSDK(configuration: configuration)
 The `PowerAuthSharingConfiguration` object contains the following properties:
 
 - `appGroup` is the name of the app group shared between your applications. Be aware, that the length of app group encoded in UTF-8, should not exceed 26 characters. See [troubleshooting](#length-of-application-group) section for more details.
-- `appIdentifier` is an identifier unique across your all applications or extensions that are supposed to use the shared activation data. You can use your applications' bundle identifiers or any other identifier that can be then processed in all your applications. Due to technical limitations, the length of the identifier must not exceed 127 bytes, if represented in UTF-8.
+- `appIdentifier` is an identifier unique across all your applications or extensions that are supposed to use the shared activation data. You can use your applications' bundle identifiers or any other identifier that can be then identified in all your applications (such as `smartBank`, `smartBank.walletExt`, `investmentsApp`, etc.) Due to technical limitations, the length of the identifier must not exceed 127 bytes, if represented in UTF-8.
 - `keychainAccessGroup` is an access group for keychain sharing.
 
+<!-- begin box info -->
 Unlike the regular configuration the `instanceId` value in `PowerAuthConfiguration` should not be derived on the application's bundle identifier. This is because all applications and extensions that share PowerAuth data must use the same identifier. To ensure consistency, use a predefined constant string or an identifier based on the first application that integrated PowerAuth. This guarantees that all related components can access the same PowerAuth instance without conflicts.
+<!-- end -->
+
+<!-- begin box warning -->
+It is also strongly recommended not to use the same `appIdentifier` for more than one instance of `PowerAuthSDK` running in the same application or extension (i.e. do not share the data between multiple instances running in the same process).
+<!-- end -->
 
 ### External pending operations
 

--- a/proj-xcode/PowerAuth2.xcodeproj/xcshareddata/xcschemes/PowerAuth2_IntegrationTests_iOS.xcscheme
+++ b/proj-xcode/PowerAuth2.xcodeproj/xcshareddata/xcschemes/PowerAuth2_IntegrationTests_iOS.xcscheme
@@ -78,6 +78,9 @@
             </BuildableReference>
             <SkippedTests>
                <Test
+                  Identifier = "BaseTestWithActivation">
+               </Test>
+               <Test
                   Identifier = "BaseTests_V3/testCustomOfflineSignature">
                </Test>
                <Test
@@ -99,6 +102,9 @@
                   Identifier = "PowerAuthSDKBaseTests">
                </Test>
                <Test
+                  Identifier = "PowerAuthSDKBaseTests/testActivationCodeSignature">
+               </Test>
+               <Test
                   Identifier = "PowerAuthSDKBaseTests/testActivationStatus">
                </Test>
                <Test
@@ -114,6 +120,15 @@
                   Identifier = "PowerAuthSDKBaseTests/testAddingBiometryFactor">
                </Test>
                <Test
+                  Identifier = "PowerAuthSDKBaseTests/testAlgorithmSetup">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testAuthentication">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testBasicTokenOperations">
+               </Test>
+               <Test
                   Identifier = "PowerAuthSDKBaseTests/testBiometrySignatureWhenNotConfigured">
                </Test>
                <Test
@@ -124,6 +139,12 @@
                </Test>
                <Test
                   Identifier = "PowerAuthSDKBaseTests/testChangePassword">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testChangePasswordDeprecated">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCleanupActivationData">
                </Test>
                <Test
                   Identifier = "PowerAuthSDKBaseTests/testCounterSync_ClientIsAhead">
@@ -144,6 +165,9 @@
                   Identifier = "PowerAuthSDKBaseTests/testCreateActivationWithBiometry">
                </Test>
                <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCreateActivationWithExternalBiometry">
+               </Test>
+               <Test
                   Identifier = "PowerAuthSDKBaseTests/testCreateActivationWithOtpAndSignature">
                </Test>
                <Test
@@ -153,10 +177,34 @@
                   Identifier = "PowerAuthSDKBaseTests/testCreateActivationWithoutSignature">
                </Test>
                <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCreateCSR">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCreateTokenWithDifferentAuth">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCustomOfflineAuthCode">
+               </Test>
+               <Test
                   Identifier = "PowerAuthSDKBaseTests/testCustomOfflineSignature">
                </Test>
                <Test
                   Identifier = "PowerAuthSDKBaseTests/testEncryptorCreation">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testExportDevicePublicKey">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testExternalEncryptionKeyDiscontinue">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testFailedStatusFetch">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testGroupedCreateTokenRequests">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testJwsSignDataWithDevicePrivateKey">
                </Test>
                <Test
                   Identifier = "PowerAuthSDKBaseTests/testJwtSignature">
@@ -168,19 +216,76 @@
                   Identifier = "PowerAuthSDKBaseTests/testPasswordCorrectWhenBlocked">
                </Test>
                <Test
+                  Identifier = "PowerAuthSDKBaseTests/testPersistActivationFailRecovery">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testProtocolUpgrade">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testProtocolUpgradeWithBiometry">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testProtocolUpgrade_fetchStatusFailure">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testProtocolUpgrade_newBiometryKekWithoutBiometryFactorSet">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testProtocolUpgrade_upgradeConfirmRequestAndStatusResponseFailure">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testProtocolUpgrade_upgradeConfirmRequestFailure">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testProtocolUpgrade_upgradeConfirmResponseFailure">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testProtocolUpgrade_upgradeStartResponseFailure">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testProtocolUpgrade_withRestarts">
+               </Test>
+               <Test
                   Identifier = "PowerAuthSDKBaseTests/testRemoveActivation">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testRestoreSessionState">
                </Test>
                <Test
                   Identifier = "PowerAuthSDKBaseTests/testSignDataWithDevicePrivateKey">
                </Test>
                <Test
+                  Identifier = "PowerAuthSDKBaseTests/testSimulatedHttpResponseFailure">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testSynchronizeBiometricFactorWithServer">
+               </Test>
+               <Test
                   Identifier = "PowerAuthSDKBaseTests/testTemporaryKeyExpiration">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testTokens_ConcurrentCreationAndRemove">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testUnsupportedDataHandling">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testUpgradeSDKDetection">
                </Test>
                <Test
                   Identifier = "PowerAuthSDKBaseTests/testUserInfo">
                </Test>
                <Test
                   Identifier = "PowerAuthSDKBaseTests/testValidateSignature">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testVaultEncryptionKeys">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testVerifyJwsServerSignedData">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testVerifyOfflineServerSignedData">
                </Test>
                <Test
                   Identifier = "PowerAuthSDKBaseTests/testVerifyServerSignedData">
@@ -297,6 +402,9 @@
                   Identifier = "PowerAuthSDKSharedBaseTests/testConcurrentTokens">
                </Test>
                <Test
+                  Identifier = "PowerAuthSDKSharedBaseTests/testProtocolUpgrade_Concurrent">
+               </Test>
+               <Test
                   Identifier = "PowerAuthSDKSharedTests/testActivationStatus">
                </Test>
                <Test
@@ -408,295 +516,7 @@
                   Identifier = "PowerAuthTokenTests/testGroupedCreateTokenRequests">
                </Test>
                <Test
-                  Identifier = "SharedTests_V3">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V3/testConcurrentActivation">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V3/testConcurrentSignatureCalculations">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V3/testConcurrentTokens">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testActivationStatus">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testActivationStatusConcurrent">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testActivationStatusFailCounters">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testActivationStatusMaxFailAttempts">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testAddingBiometryFactor">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testAlgorithmSetup">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testAuthentication">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testBasicTokenOperations">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testBiometrySignatureWhenNotConfigured">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testCallToCreateActivationInWrongState">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testCancelEnqueuedHttpOperation">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testChangePassword">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testConcurrentActivation">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testConcurrentSignatureCalculations">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testConcurrentTokens">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testCounterSync_ClientIsAhead">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testCounterSync_ServerIsAhead">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testCreateActivationAndPersistWithCorePassword">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testCreateActivationAndPersistWithPassword">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testCreateActivationWhenApplicationIsUnsupported">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testCreateActivationWithBiometry">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testCreateActivationWithExternalBiometry">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testCreateActivationWithOtpAndSignature">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testCreateActivationWithSignature">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testCreateActivationWithoutSignature">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testCreateTokenWithDifferentAuth">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testCustomOfflineAuthCode">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testEncryptorCreation">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testGroupedCreateTokenRequests">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testJwtSignature">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testPasswordCorrect">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testPasswordCorrectWhenBlocked">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testRemoveActivation">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testRestoreSessionState">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testSignDataWithDevicePrivateKey">
-               </Test>
-               <Test
                   Identifier = "SharedTests_V4_EC_P384/testTemporaryKeyExpiration">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testTokens_ConcurrentCreationAndRemove">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testUserInfo">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testVerifyServerSignedData">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384/testWithWrongLAContext">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L3">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L3/testConcurrentActivation">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L3/testConcurrentSignatureCalculations">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L3/testConcurrentTokens">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testActivationCodeSignature">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testActivationStatus">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testActivationStatusConcurrent">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testActivationStatusFailCounters">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testActivationStatusMaxFailAttempts">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testAddingBiometryFactor">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testAlgorithmSetup">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testAuthentication">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testBasicTokenOperations">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testBiometrySignatureWhenNotConfigured">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testCallToCreateActivationInWrongState">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testCancelEnqueuedHttpOperation">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testChangePassword">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testConcurrentActivation">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testConcurrentSignatureCalculations">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testConcurrentTokens">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testCounterSync_ClientIsAhead">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testCounterSync_ServerIsAhead">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testCreateActivationAndPersistWithCorePassword">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testCreateActivationAndPersistWithPassword">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testCreateActivationWhenApplicationIsUnsupported">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testCreateActivationWithBiometry">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testCreateActivationWithExternalBiometry">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testCreateActivationWithOtpAndSignature">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testCreateActivationWithSignature">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testCreateActivationWithoutSignature">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testCreateTokenWithDifferentAuth">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testCustomOfflineAuthCode">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testEncryptorCreation">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testExportDevicePublicKey">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testFailedStatusFetch">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testGroupedCreateTokenRequests">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testJwsSignDataWithDevicePrivateKey">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testJwtSignature">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testPasswordCorrect">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testPasswordCorrectWhenBlocked">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testRemoveActivation">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testRestoreSessionState">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testSignDataWithDevicePrivateKey">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testSimulatedHttpResponseFailure">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testTokens_ConcurrentCreationAndRemove">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testUserInfo">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testVaultEncryptionKeys">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testVerifyJwsServerSignedData">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testVerifyOfflineServerSignedData">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testVerifyServerSignedData">
-               </Test>
-               <Test
-                  Identifier = "SharedTests_V4_EC_P384_ML_L5/testWithWrongLAContext">
                </Test>
             </SkippedTests>
          </TestableReference>

--- a/proj-xcode/PowerAuth2.xcodeproj/xcshareddata/xcschemes/PowerAuth2_IntegrationTests_tvOS.xcscheme
+++ b/proj-xcode/PowerAuth2.xcodeproj/xcshareddata/xcschemes/PowerAuth2_IntegrationTests_tvOS.xcscheme
@@ -78,10 +78,202 @@
             </BuildableReference>
             <SkippedTests>
                <Test
+                  Identifier = "BaseTestWithActivation">
+               </Test>
+               <Test
                   Identifier = "PowerAuthConcurrencyTests">
                </Test>
                <Test
                   Identifier = "PowerAuthInvalidCurveTests">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testActivationCodeSignature">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testActivationStatus">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testActivationStatusConcurrent">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testActivationStatusFailCounters">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testActivationStatusMaxFailAttempts">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testAlgorithmSetup">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testAuthentication">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testBasicTokenOperations">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testBiometrySignatureWhenNotConfigured">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCallToCreateActivationInWrongState">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCancelEnqueuedHttpOperation">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testChangePassword">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testChangePasswordDeprecated">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCleanupActivationData">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCounterSync_ClientIsAhead">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCounterSync_ServerIsAhead">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCreateActivationAndPersistWithCorePassword">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCreateActivationAndPersistWithPassword">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCreateActivationWhenApplicationIsUnsupported">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCreateActivationWithOtpAndSignature">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCreateActivationWithSignature">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCreateActivationWithoutSignature">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCreateCSR">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCreateTokenWithDifferentAuth">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCustomOfflineAuthCode">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testEncryptorCreation">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testExportDevicePublicKey">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testExternalEncryptionKeyDiscontinue">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testFailedStatusFetch">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testGroupedCreateTokenRequests">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testJwsSignDataWithDevicePrivateKey">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testJwtSignature">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testPasswordCorrect">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testPasswordCorrectWhenBlocked">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testPersistActivationFailRecovery">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testProtocolUpgrade">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testProtocolUpgradeWithBiometry">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testProtocolUpgrade_fetchStatusFailure">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testProtocolUpgrade_newBiometryKekWithoutBiometryFactorSet">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testProtocolUpgrade_upgradeConfirmRequestAndStatusResponseFailure">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testProtocolUpgrade_upgradeConfirmRequestFailure">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testProtocolUpgrade_upgradeConfirmResponseFailure">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testProtocolUpgrade_upgradeStartResponseFailure">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testProtocolUpgrade_withRestarts">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testRemoveActivation">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testRestoreSessionState">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testSignDataWithDevicePrivateKey">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testSimulatedHttpResponseFailure">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testTokens_ConcurrentCreationAndRemove">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testUnsupportedDataHandling">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testUpgradeSDKDetection">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testUserInfo">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testVaultEncryptionKeys">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testVerifyJwsServerSignedData">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testVerifyOfflineServerSignedData">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testVerifyServerSignedData">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKSharedBaseTests">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKSharedBaseTests/testConcurrentActivation">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKSharedBaseTests/testConcurrentSignatureCalculations">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKSharedBaseTests/testConcurrentTokens">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKSharedBaseTests/testProtocolUpgrade_Concurrent">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKSharedBaseTests/testProtocolUpgrade_ConcurrentLegacyVsV4">
                </Test>
             </SkippedTests>
          </TestableReference>

--- a/proj-xcode/PowerAuth2/PowerAuthActivationStatus.m
+++ b/proj-xcode/PowerAuth2/PowerAuthActivationStatus.m
@@ -54,6 +54,24 @@
     return _status.customObject;
 }
 
+- (NSString*) description
+{
+    NSString * state;
+    switch (_status.state) {
+        case PowerAuthCoreActivationState_Active:       state = @"active"; break;
+        case PowerAuthCoreActivationState_Blocked:      state = @"blocked"; break;
+        case PowerAuthCoreActivationState_Removed:      state = @"removed"; break;
+        case PowerAuthCoreActivationState_PendingCommit:state = @"pendingCommit"; break;
+        case PowerAuthCoreActivationState_Deadlock:     state = @"deadlock"; break;
+        default:
+            state = @"???";
+            break;
+    }
+    NSString * upgrade = _status.isProtocolUpgradeAvailable ? @", upgradeAvail" : @"";
+    return [NSString stringWithFormat:@"<PowerAuthActivationStatus state=%@, remaining=%@/%@%@>",
+            state, @(_status.remainingAttempts), @(_status.maxFailCount), upgrade];
+}
+
 @end
 
 @implementation PowerAuthActivationStatus (Private)

--- a/proj-xcode/PowerAuth2/PowerAuthAuthentication.m
+++ b/proj-xcode/PowerAuth2/PowerAuthAuthentication.m
@@ -405,17 +405,24 @@
 - (NSError*) validateUsage:(BOOL)forPersist
 {
     NSString * errorMessage;
+    PowerAuthErrorCode errorCode = PowerAuthErrorCode_WrongParameter;
     if (forPersist != (_objectUsage == AUTH_FOR_PERSIST)) {
         errorMessage = forPersist
             ? @"Using PowerAuthAuthentication object for a different purpose. The object for activation persist is expected."
             : @"Using PowerAuthAuthentication object for a different purpose. The object for authentication code calculation is expected.";
     } else if (_overridenPossessionKey) {
         errorMessage = @"Using PowerAuthAuthentication with a custom possession key is no longer supported.";
+#if !defined(PA2_BIOMETRY_SUPPORT)
+    } else if (_useBiometry) {
+        errorMessage = @"Biometry is not supported on this device.";
+        errorCode = PowerAuthErrorCode_BiometryNotAvailable;
+#endif // !defined(PA2_BIOMETRY_SUPPORT)
     } else {
         errorMessage = nil;
     }
+
     if (errorMessage) {
-        return PA2MakeError(PowerAuthErrorCode_WrongParameter, errorMessage);
+        return PA2MakeError(errorCode, errorMessage);
     }
     return nil;
 }

--- a/proj-xcode/PowerAuth2/PowerAuthExternalPendingOperation.m
+++ b/proj-xcode/PowerAuth2/PowerAuthExternalPendingOperation.m
@@ -29,4 +29,10 @@
     return self;
 }
 
+- (NSString*) description
+{
+    return [NSString stringWithFormat:@"<PowerAuthExternalPendingOperation type=%@, appId=\"%@\">",
+            @(_externalOperationType), _externalApplicationId];
+}
+
 @end

--- a/proj-xcode/PowerAuth2/PowerAuthSDK.m
+++ b/proj-xcode/PowerAuth2/PowerAuthSDK.m
@@ -304,12 +304,21 @@ static NSData * _BuildDeviceSpecificData(void)
 
 - (void) dealloc
 {
+    [self unsubscribeBeforeDestroy];
+}
+
+/// The private method unregisters this instance from all external subscribers.
+/// Be aware that the method is exposed for the integration tests, allowing us to simulate
+/// the application restart.
+- (void) unsubscribeBeforeDestroy
+{
     [(PA2TimeSynchronizationService*)_timeSynchronizationService unsubscribeForSystemNotifications];
 #if defined(PA2_WATCH_SUPPORT)
     // Unregister this instance for processing packets...
     [[PowerAuthWCSessionManager sharedInstance] unregisterDataHandler:self];
 #endif
     [self cancelAllPendingTasks];
+    [_sessionInterface releaseResourcesBeforeDestroy];
 }
 
 - (id<PowerAuthTokenStore>) tokenStore
@@ -703,15 +712,14 @@ static PowerAuthSDK * s_inst;
     PA2DictionarySafeSet(L2data, @"activationOtp", activation.additionalActivationOtp);
     PA2DictionarySafeSet(L2data, @"platform", [PowerAuthSystem platform]);
     PA2DictionarySafeSet(L2data, @"deviceInfo", [PowerAuthSystem deviceInfo]);
-    
-    // Notify other applications about pending activation
-    if (![_sessionInterface startExternalPendingOperation:PowerAuthExternalPendingOperationType_Activation error:&error]) {
-        callback(nil, error);
-        return nil;
-    }
-    
+        
     // Start an activation
     PowerAuthCoreRequest * request = [_sessionInterface writeTaskWithSession:^PowerAuthCoreRequest*(PowerAuthCoreSession * session, NSError ** error) {
+        // Notify other applications about pending activation
+        if (![_sessionInterface startExternalPendingOperation:PowerAuthExternalPendingOperationType_Activation error:error]) {
+            return nil;
+        }
+        // Create activation in session
         return [session createActivation:L1data withL2Data:L2data error:error];
     } error:&error];
     
@@ -979,9 +987,7 @@ static PowerAuthSDK * s_inst;
         if (customBiometryKek) {
             biometryKek = customBiometryKek;
         } else {
-            biometryKek = [_sessionInterface readTaskWithSession:^PowerAuthCoreData* _Nullable(PowerAuthCoreSession* session, NSError** error) {
-                return [PowerAuthCoreSession generateFactorKekForProtocolVersion:PowerAuthCoreProtocolVersion_V4 error:error];
-            } error:&localError];
+            biometryKek = [PowerAuthCoreSession generateFactorKekForProtocolVersion:PowerAuthCoreProtocolVersion_V4 error:&localError];
         }
     }
     if (localError) {
@@ -990,9 +996,14 @@ static PowerAuthSDK * s_inst;
     }
     
     id<PowerAuthOperationTask> task = [_sessionInterface writeTaskWithSession:^PowerAuthCoreTask*(PowerAuthCoreSession * session, NSError ** error) {
-            return [session startProtocolUpgradeWithPassword:password
-                                             withBiometryKek:biometryKek
-                                                       error:error];
+        // Notify other applications about pending upgrade
+        if (![_sessionInterface startExternalPendingOperation:PowerAuthExternalPendingOperationType_ProtocolUpgrade error:error]) {
+            return nil;
+        }
+        // Start upgrade in session
+        return [session startProtocolUpgradeWithPassword:password
+                                         withBiometryKek:biometryKek
+                                                   error:error];
     } error:&localError];
     if (localError) {
         callback(nil, localError);

--- a/proj-xcode/PowerAuth2/private/PA2CoreTaskWrapper.m
+++ b/proj-xcode/PowerAuth2/private/PA2CoreTaskWrapper.m
@@ -17,6 +17,7 @@
 #import "PA2CoreTaskWrapper.h"
 #import "PA2PrivateMacros.h"
 #import "PA2CoreHttpClient.h"
+#import "PA2SessionInterface.h"
 
 @implementation PA2CoreTaskWrapper
 {
@@ -42,9 +43,11 @@
 - (nullable id<PowerAuthOperationTask>) processNext
 {
     NSError * localError = nil;
-    PowerAuthCoreRequest * request = [_task nextRequest:&localError];
+    PowerAuthCoreRequest * request = [_client.sessionInterface writeTaskWithSession:^PowerAuthCoreRequest* _Nullable(PowerAuthCoreSession * session, NSError ** error) {
+        return [_task nextRequest:error];
+    } error:&localError];
     if (localError) {
-        [self setFinished:nil error:PA2WrapError(localError, NULL)];
+        [self setFinished:nil error:localError];
         return nil;
     }
     if (request) {
@@ -85,7 +88,10 @@
     if (_task.isCanceled) {
         return;
     }
-    [_task cancel];
+    [_client.sessionInterface writeTaskWithSession:^id _Nullable(PowerAuthCoreSession * session, NSError ** error) {
+        [_task cancel];
+        return nil;
+    } error:nil];
     dispatch_async(dispatch_get_main_queue(), ^{
         [_current_async_operation cancel];
         _current_async_operation = nil;

--- a/proj-xcode/PowerAuth2/private/PA2DefaultSessionInterface.m
+++ b/proj-xcode/PowerAuth2/private/PA2DefaultSessionInterface.m
@@ -66,6 +66,10 @@ if (![self unlockImpl:&lerr] || lerr) {         \
     return self;
 }
 
+- (void) releaseResourcesBeforeDestroy
+{
+}
+
 - (BOOL) loadInitialState:(BOOL)clearUnsupportedData
                     error:(NSError*_Nullable*_Nullable)error
 {

--- a/proj-xcode/PowerAuth2/private/PA2SessionInterface.h
+++ b/proj-xcode/PowerAuth2/private/PA2SessionInterface.h
@@ -36,6 +36,9 @@
 - (BOOL) loadInitialState:(BOOL)clearUnsupportedData
                     error:(NSError*_Nullable*_Nullable)error;
 
+/// Release acquired resources before the instance is destroyed
+- (void) releaseResourcesBeforeDestroy;
+
 /**
  Contains instance to `PowerAuthExternalPendingOperation` in case that other application is doing the critical
  operation right now.

--- a/proj-xcode/PowerAuth2/private/PA2SharedSessionInterface.m
+++ b/proj-xcode/PowerAuth2/private/PA2SharedSessionInterface.m
@@ -305,7 +305,7 @@ static BOOL _LocalContextRestoreSpecialOp(LocalContext * ctx, PA2SharedLock * op
             PowerAuthLog(@"PA2SharedSessionProvider: Failed to acquire special operation lock.");
             return NO;
         }
-        // Lock acquired, we owns a special operation now
+        // Lock acquired, we own a special operation now
         PowerAuthLog(@"PA2SharedSessionProvider: Restoring ownership of special operation type %@", @(operationType));
         ctx->specialOpType = operationType;
         ctx->specialOpTicket = ctx->sharedData->specialOpTicket;
@@ -514,7 +514,7 @@ static BOOL _ValidateSharedMemoryData(LocalContext * ctx, void * bytes, NSUInteg
         if (restoreOpType) {
             if (!_LocalContextRestoreSpecialOp(&_localContext, _operationLock, restoreOpType)) {
                 // The restore may fail only if another instance of PowerAuthSDK did acquire operation lock before this instance.
-                // This is in general wrong and it indicate that more than one PowerAuthSDK with the same instance is in this process.
+                // This is in general wrong and it indicates that more than one PowerAuthSDK with the same instance is in this process.
                 localError = PA2MakeError(PowerAuthErrorCode_ExternalPendingOperation, @"Two PowerAuthSDK instances use the same application ID for activation data sharing.");
             }
         }

--- a/proj-xcode/PowerAuth2/private/PA2SharedSessionInterface.m
+++ b/proj-xcode/PowerAuth2/private/PA2SharedSessionInterface.m
@@ -281,6 +281,38 @@ static void _LocalContextUpdateSpecialOp(LocalContext * ctx, PA2SharedLock * opL
     }
 }
 
+/**
+ Abandon ownership of special operation due to instance destroy.
+ */
+static void _LocalContextAbandonSpecialOp(LocalContext * ctx, PA2SharedLock * opLock)
+{
+    PowerAuthLog(@"PA2SharedSessionProvider: WARNING: Abandoning special operation type %@ due to instance destroy.", @(ctx->specialOpType));
+    ctx->specialOpType = 0;
+    [opLock unlock];
+}
+
+/**
+ Try to take ownership of special operation. If NO is returned, then it indicates that there's another instance of PowerAuthSDK with the same
+ application identifier.
+ */
+static BOOL _LocalContextRestoreSpecialOp(LocalContext * ctx, PA2SharedLock * opLock, PowerAuthExternalPendingOperationType operationType)
+{
+    BOOL canRestoreOp = ctx->sharedData->specialOpType == operationType &&
+                        !memcmp(ctx->thisAppIdentifier, ctx->sharedData->specialOpAppId, ctx->thisAppIdentifierSize);
+    if (canRestoreOp) {
+        if (![opLock tryLock]) {
+            // This basically indicate that there are two instances of PowerAuthSDK with the same application ID.
+            PowerAuthLog(@"PA2SharedSessionProvider: Failed to acquire special operation lock.");
+            return NO;
+        }
+        // Lock acquired, we owns a special operation now
+        PowerAuthLog(@"PA2SharedSessionProvider: Restoring ownership of special operation type %@", @(operationType));
+        ctx->specialOpType = operationType;
+        ctx->specialOpTicket = ctx->sharedData->specialOpTicket;
+        ctx->sharedData->specialOpStart = [NSDate date].timeIntervalSince1970;
+    }
+    return YES;
+}
 
 #pragma mark Private shared memory
 
@@ -444,6 +476,28 @@ static BOOL _ValidateSharedMemoryData(LocalContext * ctx, void * bytes, NSUInteg
     return self;
 }
 
+- (void) dealloc
+{
+    [self releaseResourcesBeforeDestroy];
+}
+
+- (void) releaseResourcesBeforeDestroy
+{
+    if (_statusLock) {
+        [_statusLock lock];
+        if (_LocalContextThisRunningSpecialOp(&_localContext)) {
+            // This instance holds a lock for a special operation and is about to be destroyed. This is bad.
+            // We have to release the lock and keep the information about the special operation in shared memory.
+            // This is similar to a sudden application crash, but in that case the kernel releases the lock.
+            //
+            // Keeping the data in the shared region allows us to restore the state once the same instance
+            // of PowerAuthSDK is re-created.
+            _LocalContextAbandonSpecialOp(&_localContext, _operationLock);
+        }
+        [_statusLock unlock];
+    }
+}
+
 - (BOOL) loadInitialState:(BOOL)clearUnsupportedData
                     error:(NSError*_Nullable*_Nullable)error
 {
@@ -451,7 +505,19 @@ static BOOL _ValidateSharedMemoryData(LocalContext * ctx, void * bytes, NSUInteg
     int access = ACQ_WRITE;
     if (clearUnsupportedData) access |= ACQ_ERASE_INVD;
     if ([self lockWithAccess:access error:&localError]) {
-        // Simple lock - unlock will guarantee initial state load.
+        // Simple lock - unlock is enough to restore the state.
+        // We have to also try to restore ownership of the special operation.
+        int restoreOpType = 0;
+        if (_session.hasPendingProtocolUpgrade) {
+            restoreOpType = PowerAuthExternalPendingOperationType_ProtocolUpgrade;
+        }
+        if (restoreOpType) {
+            if (!_LocalContextRestoreSpecialOp(&_localContext, _operationLock, restoreOpType)) {
+                // The restore may fail only if another instance of PowerAuthSDK did acquire operation lock before this instance.
+                // This is in general wrong and it indicate that more than one PowerAuthSDK with the same instance is in this process.
+                localError = PA2MakeError(PowerAuthErrorCode_ExternalPendingOperation, @"Two PowerAuthSDK instances use the same application ID for activation data sharing.");
+            }
+        }
         [self unlockWithError:&localError];
     }
     if (localError) {

--- a/proj-xcode/PowerAuth2/private/PA2TokenDataLock.h
+++ b/proj-xcode/PowerAuth2/private/PA2TokenDataLock.h
@@ -25,15 +25,19 @@
  */
 @protocol PA2TokenDataLock <NSObject>
 
-/**
- Lock token store data and return whether the local cached context
- should be invalidated.
- */
+///  Lock token store data and return information whether the local cached context should be invalidated.
+/// - Parameters:
+///   - dirty: Pointer where information about local cache invalidation is set.
+///   - error: Pointer where error is set in case of failure.
+/// - Returns: YES if operation succeeds, NO otherwise.
 - (BOOL) lockTokenStore:(BOOL*_Nonnull)dirty error:(NSError * _Nullable * _Nonnull)error;
 
-/**
- Unlock token store data and mark that token store has been modified.
- */
+
+/// Unlock token store data and mark that token store has been modified.
+/// - Parameters:
+///   - contentModified: If YES, then shared token data has been modified.
+///   - error: Pointer where error is set in case of failure.
+/// - Returns: YES if operation succeeds, NO otherwise.
 - (BOOL) unlockTokenStore:(BOOL)contentModified error:(NSError * _Nullable * _Nonnull)error;
 
 @end

--- a/proj-xcode/PowerAuth2IntegrationTests/BaseTestWithActivation.h
+++ b/proj-xcode/PowerAuth2IntegrationTests/BaseTestWithActivation.h
@@ -27,6 +27,7 @@
 @property (nonatomic, strong, readonly) PowerAuthSDK * sdk;
 @property (nonatomic, readonly) PowerAuthAlgorithm powerAuthAlgorithm;  // override in subclass
 @property (nonatomic, readonly) BOOL supportsActivationWithSignature;
+@property (nonatomic, readonly) BOOL hasBiometrySupport;
 
 - (void) prepareConfigs:(PowerAuthConfiguration**)configuration
         biometricConfig:(PowerAuthBiometricConfiguration**)biometricConfiguration

--- a/proj-xcode/PowerAuth2IntegrationTests/BaseTestWithActivation.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/BaseTestWithActivation.m
@@ -90,6 +90,15 @@
     return relativePath;
 }
 
+- (BOOL) hasBiometrySupport
+{
+#if defined(PA2_BIOMETRY_SUPPORT)
+    return YES;
+#else
+    return NO;
+#endif
+}
+
 - (BOOL) isRequestFailureSimulatorAvailable
 {
 #if defined(DEBUG)

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKBaseTests.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKBaseTests.m
@@ -381,7 +381,9 @@
     PowerAuthAuthentication * auth = activation.credentials;
     PowerAuthAuthentication * auth_possession = _helper.authPossession;
     PowerAuthAuthentication * auth_possession_knowledge = _helper.authPossessionWithKnowledge;
-    PowerAuthAuthentication * auth_possession_biometry = _helper.authPossessionWithBiometry;
+    PowerAuthAuthentication * auth_possession_biometry = self.hasBiometrySupport
+                                ? _helper.authPossessionWithBiometry
+                                : _helper.authPossessionWithKnowledge;
     
     //
     // Online & offline signatures (calculated as http auth header)
@@ -467,20 +469,22 @@
                                                                           componentLength:componentLength];
     XCTAssertTrue(response.signatureValid);
     
-    // possession + biometry
-    code = [AsyncHelper synchronizeAsynchronousBlock:^(AsyncHelper *waiting) {
-        [_sdk offlineAuthenticationCodeWithAuthentication:_helper.authPossessionWithBiometry uriId:@"/some/uriId" body:nil nonce:nonce callback:^(NSString * _Nullable authenticationCode, NSError * _Nullable error) {
-            [waiting reportCompletion:authenticationCode];
+    if (self.hasBiometrySupport) {
+        // possession + biometry
+        code = [AsyncHelper synchronizeAsynchronousBlock:^(AsyncHelper *waiting) {
+            [_sdk offlineAuthenticationCodeWithAuthentication:_helper.authPossessionWithBiometry uriId:@"/some/uriId" body:nil nonce:nonce callback:^(NSString * _Nullable authenticationCode, NSError * _Nullable error) {
+                [waiting reportCompletion:authenticationCode];
+            }];
         }];
-    }];
-    XCTAssertNotNil(code);
-    XCTAssertEqual(componentLength*2+1, code.length);
-    response = [_helper.testServerApi verifyOfflineAuthCode:activation.activationData.activationId
-                                                       data:normalized_data
-                                                   authCode:code
-                                              allowBiometry:YES
-                                            componentLength:componentLength];
-    XCTAssertTrue(response.signatureValid);
+        XCTAssertNotNil(code);
+        XCTAssertEqual(componentLength*2+1, code.length);
+        response = [_helper.testServerApi verifyOfflineAuthCode:activation.activationData.activationId
+                                                           data:normalized_data
+                                                       authCode:code
+                                                  allowBiometry:YES
+                                                componentLength:componentLength];
+        XCTAssertTrue(response.signatureValid);
+    }
 }
 
 - (void) testActivationStatus
@@ -1003,9 +1007,11 @@
     // By default, EEK is not set
     XCTAssertFalse(_sdk.hasExternalEncryptionKey);
     XCTAssertTrue([_helper checkForCorePassword:activation.credentials.password]);
-    // Check biometry
-    result = [_helper validateAuthentication:_helper.authPossessionWithBiometry data:[@"data" dataUsingEncoding:NSUTF8StringEncoding] method:@"POST" uriId:@"/hello/hacker" online:YES cripple:0];
-    XCTAssertTrue(result);
+    if (self.hasBiometrySupport) {
+        // Check biometry
+        result = [_helper validateAuthentication:_helper.authPossessionWithBiometry data:[@"data" dataUsingEncoding:NSUTF8StringEncoding] method:@"POST" uriId:@"/hello/hacker" online:YES cripple:0];
+        XCTAssertTrue(result);
+    }
     
     if (self.powerAuthAlgorithm == PowerAuthAlgorithm_LEGACY_P256) {
         // V3 activations
@@ -1038,9 +1044,11 @@
         XCTAssertTrue(_sdk.hasExternalEncryptionKey);
         // auth codes should not work
         XCTAssertFalse([_helper checkForCorePassword:activation.credentials.password]);
-        // biometry
-        result = [_helper validateAuthentication:_helper.authPossessionWithBiometry data:[@"B10" dataUsingEncoding:NSUTF8StringEncoding] method:@"POST" uriId:@"/hello/hacker" online:YES cripple:0];
-        XCTAssertFalse(result);
+        if (self.hasBiometrySupport) {
+            // biometry
+            result = [_helper validateAuthentication:_helper.authPossessionWithBiometry data:[@"B10" dataUsingEncoding:NSUTF8StringEncoding] method:@"POST" uriId:@"/hello/hacker" online:YES cripple:0];
+            XCTAssertFalse(result);
+        }
         // knowledge - offline
         result = [_helper validateAuthentication:_helper.authPossessionWithKnowledge data:[@"0ffl1n3" dataUsingEncoding:NSUTF8StringEncoding] method:@"POST" uriId:@"/hello/hacker" online:NO cripple:0];
         XCTAssertFalse(result);
@@ -1059,9 +1067,11 @@
         
         XCTAssertFalse(_sdk.hasExternalEncryptionKey);
         XCTAssertTrue([_helper checkForCorePassword:activation.credentials.password]);
-        // biometry
-        result = [_helper validateAuthentication:_helper.authPossessionWithBiometry data:[@"data" dataUsingEncoding:NSUTF8StringEncoding] method:@"POST" uriId:@"/hello/hacker" online:YES cripple:0];
-        XCTAssertTrue(result);
+        if (self.hasBiometrySupport) {
+            // biometry
+            result = [_helper validateAuthentication:_helper.authPossessionWithBiometry data:[@"data" dataUsingEncoding:NSUTF8StringEncoding] method:@"POST" uriId:@"/hello/hacker" online:YES cripple:0];
+            XCTAssertTrue(result);
+        }
         // knowledge - offline
         result = [_helper validateAuthentication:_helper.authPossessionWithKnowledge data:[@"0ffl1n3" dataUsingEncoding:NSUTF8StringEncoding] method:@"POST" uriId:@"/hello/hacker" online:NO cripple:0];
         XCTAssertTrue(result);
@@ -1110,12 +1120,6 @@
 - (void) testBiometrySignatureWhenNotConfigured
 {
     CHECK_TEST_CONFIG();
-
-#if defined(PA2_BIOMETRY_SUPPORT)
-    BOOL supportsBiometry = YES;
-#else
-    BOOL supportsBiometry = NO;
-#endif
     
     //
     // This test validates that signing with biometry doesn't work when
@@ -1134,7 +1138,7 @@
     authentication = [PowerAuthAuthentication possessionWithBiometry];
     header = [_sdk authenticationHeaderForRequestWithBodyWithAuthentication:authentication method:@"POST" uriId:@"/some/uri/id" body:[NSData data] error:&error];
     XCTAssertNil(header);
-    if (supportsBiometry) {
+    if (self.hasBiometrySupport) {
         XCTAssertEqual(PowerAuthErrorCode_BiometryFailed, error.powerAuthErrorCode);
     } else {
         XCTAssertEqual(PowerAuthErrorCode_BiometryNotAvailable, error.powerAuthErrorCode);
@@ -1145,7 +1149,7 @@
     header = [_sdk authenticationHeaderForRequestWithBodyWithAuthentication:authentication method:@"POST" uriId:@"/some/uri/id" body:[NSData data] error:&error];
     XCTAssertNil(header);
     
-    if (supportsBiometry) {
+    if (self.hasBiometrySupport) {
         XCTAssertEqual(PowerAuthErrorCode_BiometryFailed, error.powerAuthErrorCode);
     } else {
         XCTAssertEqual(PowerAuthErrorCode_BiometryNotAvailable, error.powerAuthErrorCode);
@@ -2201,8 +2205,10 @@
         any2fa = [self fetchVaultEncryptionKey:PowerAuthSecureVaultKeyId_KnowledgeOrBiometry credentials:activation.credentials shouldPass:YES];
         otherKDK = [self fetchVaultEncryptionKey:PowerAuthSecureVaultKeyId_KnowledgeOrBiometry credentials:activation.credentials shouldPass:YES];
         XCTAssertEqualObjects(any2fa, otherKDK);
-        otherKDK = [self fetchVaultEncryptionKey:PowerAuthSecureVaultKeyId_KnowledgeOrBiometry credentials:activation.biometryCredentials shouldPass:YES];
-        XCTAssertEqualObjects(any2fa, otherKDK);
+        if (self.hasBiometrySupport) {
+            otherKDK = [self fetchVaultEncryptionKey:PowerAuthSecureVaultKeyId_KnowledgeOrBiometry credentials:activation.biometryCredentials shouldPass:YES];
+            XCTAssertEqualObjects(any2fa, otherKDK);
+        }
 
         knowledge = [self fetchVaultEncryptionKey:PowerAuthSecureVaultKeyId_Knowledge credentials:activation.credentials shouldPass:YES];
         XCTAssertNotEqualObjects(any2fa, knowledge);
@@ -2823,6 +2829,10 @@
 - (void) testProtocolUpgradeWithBiometry
 {
     CHECK_TEST_CONFIG();
+    if (!self.hasBiometrySupport) {
+        NSLog(@"Test skipped, device has no biometry support.");
+        return;
+    }
     
     //
     // Test successful upgrade from V3 to V4 protocol.
@@ -2893,7 +2903,10 @@
     XCTAssertEqual(_sdk.hasProtocolUpgradeAvailable, targetAlgorithm > PowerAuthAlgorithm_LEGACY_P256);
     
     // Assert the old biometry factor key still works.
-    PowerAuthAuthentication * oldBiometryAuth = _helper.currentActivation.biometryCredentials;
+    // If biometry not supported, then use knowledge factor.
+    PowerAuthAuthentication * oldBiometryAuth = self.hasBiometrySupport
+                ? _helper.currentActivation.biometryCredentials
+                : _helper.currentActivation.credentials;
     NSData * randomData = [[[PowerAuthCoreCryptoUtils randomBytes:42] base64EncodedStringWithOptions:0] dataUsingEncoding:NSASCIIStringEncoding];
     BOOL authenticationValid = [_helper validateAuthentication:oldBiometryAuth
                                                           data:randomData
@@ -2933,7 +2946,11 @@
     XCTAssertEqual(_sdk.hasProtocolUpgradeAvailable, targetAlgorithm > PowerAuthAlgorithm_LEGACY_P256);
     
     // Assert the old biometry factor key still works.
-    PowerAuthAuthentication * oldBiometryAuth = _helper.currentActivation.biometryCredentials;
+    // If biometry not supported, then use knowledge factor.
+    PowerAuthAuthentication * oldBiometryAuth = self.hasBiometrySupport
+                    ? _helper.currentActivation.biometryCredentials
+                    : _helper.currentActivation.credentials;
+    
     NSData * randomData = [[[PowerAuthCoreCryptoUtils randomBytes:42] base64EncodedStringWithOptions:0] dataUsingEncoding:NSASCIIStringEncoding];
     BOOL authenticationValid = [_helper validateAuthentication:oldBiometryAuth
                                                           data:randomData
@@ -2992,24 +3009,26 @@
     XCTAssertFalse(_sdk.hasProtocolUpgradeAvailable);
     XCTAssertFalse(_sdk.hasPendingProtocolUpgrade);
     
-    // Check that the old biometry factor does not work anymore.
-    PowerAuthAuthentication * oldBiometryAuth = _helper.currentActivation.biometryCredentials;
-    NSData * randomData = [[[PowerAuthCoreCryptoUtils randomBytes:42] base64EncodedStringWithOptions:0] dataUsingEncoding:NSASCIIStringEncoding];
-    BOOL authenticationValid = [_helper validateAuthentication:oldBiometryAuth
-                                                          data:randomData
-                                                        method:@"POST"
-                                                         uriId:@"/hello/there"
-                                                        online:YES
-                                                       cripple:0];
-    XCTAssertFalse(authenticationValid);
+    if (self.hasBiometrySupport) {
+        // Check that the old biometry factor does not work anymore.
+        PowerAuthAuthentication * oldBiometryAuth = _helper.currentActivation.biometryCredentials;
+        NSData * randomData = [[[PowerAuthCoreCryptoUtils randomBytes:42] base64EncodedStringWithOptions:0] dataUsingEncoding:NSASCIIStringEncoding];
+        BOOL authenticationValid = [_helper validateAuthentication:oldBiometryAuth
+                                                              data:randomData
+                                                            method:@"POST"
+                                                             uriId:@"/hello/there"
+                                                            online:YES
+                                                           cripple:0];
+        XCTAssertFalse(authenticationValid);
+    }
 
     [_helper cleanup];
 }
 
+
 - (void) testProtocolUpgrade_upgradeConfirmRequestFailure
 {
     CHECK_TEST_CONFIG();
-    CHECK_BIOMETRY();
     
     //
     // Test successful upgrade from V3 to V4 protocol. In this case
@@ -3020,7 +3039,7 @@
     // required to confirm the protocol upgrade in the background.
     //
     const PowerAuthAlgorithm targetAlgorithm = self.powerAuthAlgorithm;
-    PowerAuthCoreData * newBiometryKek = [PowerAuthCoreCryptoUtils randomCoreData:32];
+    PowerAuthCoreData * newBiometryKek = self.hasBiometrySupport ? [PowerAuthCoreCryptoUtils randomCoreData:32] : nil;
     _sdk = [_helper prepareActivationForUpgradeTest:targetAlgorithm withFlags:TestActivationFlags_PersistWithBiometry];
     
     // Set 3 failures in a row, as there are 3 confirm attempts in the task.
@@ -3043,19 +3062,21 @@
     XCTAssertNil(_sdk.externalPendingOperation);
     
     // Check biometry factor not possible during upgrade.
-    PowerAuthAuthentication * newBiometryAuth = [PowerAuthAuthentication possessionWithBiometryWithCustomBiometryKey:newBiometryKek];
+    PowerAuthAuthentication * newAuth = self.hasBiometrySupport
+            ? [PowerAuthAuthentication possessionWithBiometryWithCustomBiometryKey:newBiometryKek]
+            : [_helper.authPossessionWithKnowledge copy];
     NSData * randomData = [[[PowerAuthCoreCryptoUtils randomBytes:42] base64EncodedStringWithOptions:0] dataUsingEncoding:NSASCIIStringEncoding];
     
     // Authentication header calculation not allowed when protocol upgrade pending.
     NSError * authCalcError;
-    [_sdk authenticationHeaderForRequestWithBodyWithAuthentication:newBiometryAuth method:@"POST" uriId:@"/hello/there" body:randomData error:&authCalcError];
+    [_sdk authenticationHeaderForRequestWithBodyWithAuthentication:newAuth method:@"POST" uriId:@"/hello/there" body:randomData error:&authCalcError];
     XCTAssertEqual(PowerAuthErrorCode_PendingProtocolUpgrade, authCalcError.powerAuthErrorCode);
     // Same applies to offline.
-    [_sdk offlineAuthenticationCodeWithAuthentication:newBiometryAuth uriId:@"/hello/there" body:randomData nonce:@"trustmeitisarandomstring" callback:^(NSString * authenticationCode, NSError * error){
+    [_sdk offlineAuthenticationCodeWithAuthentication:newAuth uriId:@"/hello/there" body:randomData nonce:@"trustmeitisarandomstring" callback:^(NSString * authenticationCode, NSError * error){
         XCTAssertEqual(PowerAuthErrorCode_PendingProtocolUpgrade, error.powerAuthErrorCode);
     }];
     
-    BOOL authenticationValid = [_helper validateAuthentication:newBiometryAuth
+    BOOL authenticationValid = [_helper validateAuthentication:newAuth
                                                           data:randomData
                                                         method:@"POST"
                                                          uriId:@"/hello/there"
@@ -3086,7 +3107,7 @@
     
     // Simulate application restart before testing authentication.
     _sdk = [_helper reCreateSdkInstance];
-    authenticationValid = [_helper validateAuthentication:newBiometryAuth
+    authenticationValid = [_helper validateAuthentication:newAuth
                                                      data:randomData
                                                    method:@"POST"
                                                     uriId:@"/hello/there"
@@ -3094,7 +3115,6 @@
                                                   cripple:0];
     XCTAssertTrue(authenticationValid);
     
-
     [_helper cleanup];
 }
 

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKBaseTests.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKBaseTests.m
@@ -2794,6 +2794,7 @@
     const PowerAuthAlgorithm targetAlgorithm = self.powerAuthAlgorithm;
     
     _sdk = [_helper prepareActivationForUpgradeTest:targetAlgorithm withFlags:0];
+    XCTAssertEqual(PowerAuthAlgorithm_LEGACY_P256, _sdk.currentAlgorithm);
     
     [self createTokenAndValidateTokenHeader:@"TestToken" createToken:YES];
         
@@ -3037,7 +3038,9 @@
     XCTAssertTrue(_sdk.hasPendingProtocolUpgrade);
     
     // Simulate application restart before testing authentication.
+    XCTAssertNil(_sdk.externalPendingOperation);
     _sdk = [_helper reCreateSdkInstance];
+    XCTAssertNil(_sdk.externalPendingOperation);
     
     // Check biometry factor not possible during upgrade.
     PowerAuthAuthentication * newBiometryAuth = [PowerAuthAuthentication possessionWithBiometryWithCustomBiometryKey:newBiometryKek];

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKSharedBaseTests.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKSharedBaseTests.m
@@ -54,8 +54,14 @@
     [self waitForTestQueues];
     _app1Queue.suspended = YES;
     _app2Queue.suspended = YES;
-    
+
+    [_altHelper cleanup];
     [super tearDown];
+    
+    // Make sure no external pending operation is left behind. If yes,
+    // then this will likely affect unrelated tests executed after.
+    XCTAssertNil(_sdk.externalPendingOperation);
+    XCTAssertNil(_altSdk.externalPendingOperation);
 }
 
 - (void) prepareConfigs:(PowerAuthConfiguration **)configuration
@@ -82,13 +88,24 @@
 
 - (BOOL) prepareAltSdk
 {
+    return [self prepareAltSdk:YES targetAlgorithm:self.powerAuthAlgorithm];
+}
+
+- (BOOL) prepareAltSdk:(BOOL)removeActivation
+       targetAlgorithm:(PowerAuthAlgorithm)algorithm
+{
     if (!self.sdk) {
         return NO;
     }
     
     PowerAuthConfiguration * altConfig = [self.helper.sdk.configuration copy];
-    altConfig.sharingConfiguration = [[PowerAuthSharingConfiguration alloc] initWithAppGroup:_appGroupId appIdentifier:_app2 keychainAccessGroup:_keychainAccessGroup];
-    _altHelper = [PowerAuthSdkTestHelper clone:self.helper withConfiguration:altConfig];
+    altConfig.algorithm = algorithm;
+    altConfig.sharingConfiguration = [[PowerAuthSharingConfiguration alloc] initWithAppGroup:_appGroupId
+                                                                               appIdentifier:_app2
+                                                                         keychainAccessGroup:_keychainAccessGroup];
+    _altHelper = [PowerAuthSdkTestHelper clone:self.helper
+                             withConfiguration:altConfig
+                              removeActivation:removeActivation];
     _altSdk = _altHelper.sdk;
     
     return _altSdk != nil;
@@ -393,6 +410,67 @@
     XCTAssertFalse([self.sdk.tokenStore hasLocalTokenWithName:token2]);
     XCTAssertFalse([_altSdk.tokenStore hasLocalTokenWithName:token1]);
     XCTAssertFalse([_altSdk.tokenStore hasLocalTokenWithName:token2]);
+}
+
+- (void) testProtocolUpgrade_Concurrent
+{
+    if (self.powerAuthAlgorithm == PowerAuthAlgorithm_LEGACY_P256) {
+        NSLog(@"Test not available for LEGACY_P256");
+        return;
+    }
+    
+    _sdk = [_helper prepareActivationForUpgradeTest:self.powerAuthAlgorithm withFlags:0];
+    
+    if (![self prepareAltSdk:NO targetAlgorithm:self.powerAuthAlgorithm]) {
+        XCTFail(@"Failed to initialize SDK objects");
+        return;
+    }
+    XCTAssertEqual(PowerAuthAlgorithm_LEGACY_P256, _sdk.currentAlgorithm);
+    XCTAssertEqual(PowerAuthAlgorithm_LEGACY_P256, _altSdk.currentAlgorithm);
+    
+    PowerAuthProtocolUpgradeResult * result = [AsyncHelper synchronizeAsynchronousBlock:^(AsyncHelper *waiting) {
+        [_sdk startProtocolUpgradeWithCorePassword:self.helper.authPossessionWithKnowledge.password callback:^(PowerAuthProtocolUpgradeResult * _Nullable result, NSError * _Nullable error) {
+            [waiting reportCompletion:result];
+        }];
+        
+        // Instance initiated upgrade has external pending operation set to nil
+        XCTAssertNil(_sdk.externalPendingOperation);
+        // Other instance has external pending operation available
+        XCTAssertNotNil(_altSdk.externalPendingOperation);
+        XCTAssertEqual(PowerAuthExternalPendingOperationType_ProtocolUpgrade, _altSdk.externalPendingOperation.externalOperationType);
+        
+    }];
+    XCTAssertNotNil(result);
+    
+    XCTAssertEqual(self.powerAuthAlgorithm, _sdk.currentAlgorithm);
+    XCTAssertEqual(self.powerAuthAlgorithm, _altSdk.currentAlgorithm);
+}
+
+- (void) testProtocolUpgrade_ConcurrentLegacyVsV4
+{
+    if (self.powerAuthAlgorithm == PowerAuthAlgorithm_LEGACY_P256) {
+        NSLog(@"Test not available for LEGACY_P256");
+        return;
+    }
+
+    _sdk = [_helper prepareActivationForUpgradeTest:self.powerAuthAlgorithm withFlags:0];
+    
+    if (![self prepareAltSdk:NO targetAlgorithm:PowerAuthAlgorithm_LEGACY_P256]) {
+        XCTFail(@"Failed to initialize SDK objects");
+        return;
+    }
+    XCTAssertEqual(PowerAuthAlgorithm_LEGACY_P256, _sdk.currentAlgorithm);
+    XCTAssertEqual(PowerAuthAlgorithm_LEGACY_P256, _altSdk.currentAlgorithm);
+
+    PowerAuthProtocolUpgradeResult * result = [_helper startProtocolUpgradeWithCustomBiometryKek:nil shouldFinish:YES];
+    XCTAssertNotNil(result);
+    
+    XCTAssertEqual(self.powerAuthAlgorithm, _sdk.currentAlgorithm);
+    XCTAssertEqual(self.powerAuthAlgorithm, _altSdk.currentAlgorithm);
+    
+    PowerAuthCorePassword * password = [_helper.authPossessionWithKnowledge.password copyToImmutable];
+    XCTAssertTrue([_helper checkForCorePassword:password]);
+    XCTAssertTrue([_altHelper checkForCorePassword:password]);
 }
 
 @end

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSdkTestHelper.h
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSdkTestHelper.h
@@ -66,7 +66,8 @@ typedef NS_OPTIONS(NSUInteger, TestActivationFlags) {
  Clone the existing test helper but with altered configuration.
  */
 + (PowerAuthSdkTestHelper*) clone:(PowerAuthSdkTestHelper*)testHelper
-                         withConfiguration:(PowerAuthConfiguration*)configuration;
+                withConfiguration:(PowerAuthConfiguration*)configuration
+                 removeActivation:(BOOL)removeActivation;
 
 @property (nonatomic, readonly, strong) PowerAuthSDK * sdk;
 @property (nonatomic, readonly, strong) PowerAuthTestServerAPI * testServerApi;

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSdkTestHelper.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSdkTestHelper.m
@@ -523,9 +523,13 @@ static NSString * PA_Ver_Current = @"4.0";
     PowerAuthActivationStatus * status = [self fetchActivationStatus];
     XCTAssertTrue(status.state == PowerAuthActivationState_Active);
     
+#if defined(PA2_BIOMETRY_SUPPORT)
     if (flags & (TestActivationFlags_PersistWithFakeBiometry | TestActivationFlags_PersistWithBiometry)) {
         XCTAssertTrue(_sdk.hasBiometryFactor);
     }
+#else
+    XCTAssertFalse(_sdk.hasBiometryFactor);
+#endif
     
     return _sdk;
 }
@@ -648,6 +652,10 @@ static NSString * PA_Ver_Current = @"4.0";
 {
     NSArray<NSString*> * veryCleverPasswords = [self veryStrongPasswords];
     NSString * newPassword = veryCleverPasswords[arc4random_uniform((uint32_t)veryCleverPasswords.count)];
+#if !defined(PA2_BIOMETRY_SUPPORT)
+    // Clear persist with biometry if biometry not supported on this platform.
+    flags &= ~(TestActivationFlags_PersistWithBiometry | TestActivationFlags_PersistWithFakeBiometry);
+#endif // !defined(PA2_BIOMETRY_SUPPORT)
 
     if (flags & TestActivationFlags_PersistWithBiometry) {
         return [PowerAuthAuthentication persistWithPasswordAndBiometry:newPassword];

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSdkTestHelper.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSdkTestHelper.m
@@ -16,6 +16,13 @@
 
 #import "PowerAuthSdkTestHelper.h"
 
+// Expose some private PowerAuthSDK APIs for test purposes
+@interface PowerAuthSDK (PrivateHiddenAPI)
+/// Simulates object deallocation. This is necessary because the instance of PowerAuthSDK
+/// is not always released at controlled points during the tests.
+- (void) unsubscribeBeforeDestroy;
+@end
+
 @implementation PowerAuthSdkActivation
 
 - (id) initWithActivationData:(PATSInitActivationResponse*)activationData
@@ -183,6 +190,7 @@ static NSString * PA_Ver_Current = @"4.0";
 
 + (PowerAuthSdkTestHelper*) clone:(PowerAuthSdkTestHelper*)testHelper
                 withConfiguration:(PowerAuthConfiguration*)configuration
+                 removeActivation:(BOOL)removeActivation
 {
     [self setupLog];
     
@@ -190,7 +198,9 @@ static NSString * PA_Ver_Current = @"4.0";
     PowerAuthSDK *sdk = [[PowerAuthSDK alloc] initWithConfiguration:configuration error:&error];
     XCTAssertNotNil(sdk);
     XCTAssertNil(error);
-    [sdk removeActivationLocal];
+    if (removeActivation) {
+        [sdk removeActivationLocal];
+    }
     
     BOOL result = sdk != nil;
     result = result && [sdk hasPendingActivation] == NO;
@@ -521,7 +531,7 @@ static NSString * PA_Ver_Current = @"4.0";
 }
 
 - (PowerAuthProtocolUpgradeResult*) startProtocolUpgradeWithCustomBiometryKek:(PowerAuthCoreData*)customBiometryKek
-                                      shouldFinish:(BOOL)shouldFinish
+                                                                 shouldFinish:(BOOL)shouldFinish
 {
     PowerAuthProtocolUpgradeResult * result = [AsyncHelper synchronizeAsynchronousBlock:^(AsyncHelper *waiting) {
         // Start protocol upgrade task.
@@ -572,6 +582,7 @@ static NSString * PA_Ver_Current = @"4.0";
         clientConfiguration = [_sdk.clientConfiguration copy];
     }
     NSError * error = nil;
+    [_sdk unsubscribeBeforeDestroy];
     _sdk = [[PowerAuthSDK alloc] initWithConfiguration:configuration
                                 biometricConfiguration:biometricConfiguration
                                    clientConfiguration:clientConfiguration

--- a/proj-xcode/PowerAuth2Tests/PowerAuthAuthenticationTests.m
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthAuthenticationTests.m
@@ -26,6 +26,7 @@
 @property (nonatomic, strong) PowerAuthCoreData * customPossessionKey;
 @property (nonatomic, strong) NSString * biometryPrompt;
 @property (nonatomic, strong) id biometryContext;
+@property (nonatomic, readonly) BOOL hasBiometry;
 @end
 
 @implementation PowerAuthAuthenticationTests
@@ -42,6 +43,11 @@
 #else
     #define XCTAssertContextNil(x)
 #endif // PA2_HAS_LACONTEXT
+#if defined(PA2_BIOMETRY_SUPPORT)
+    _hasBiometry = YES;
+#else
+    _hasBiometry = NO;
+#endif
     
     PowerAuthLogSetEnabled(YES);
 }
@@ -78,7 +84,11 @@
     XCTAssertNil(auth.biometryPrompt);
     XCTAssertContextNil(auth.biometryContext);
     XCTAssertNil(auth.customBiometryKey);
-    XCTAssertNil([auth validateUsage:YES]);
+    if (self.hasBiometry) {
+        XCTAssertNil([auth validateUsage:YES]);
+    } else {
+        XCTAssertNotNil([auth validateUsage:YES]);
+    }
     
     auth = [PowerAuthAuthentication persistWithPasswordAndBiometry:@"4321" customBiometryKey:_customBiometryKey];
     XCTAssertTrue(auth.usePossession);
@@ -87,7 +97,11 @@
     XCTAssertNil(auth.biometryPrompt);
     XCTAssertContextNil(auth.biometryContext);
     XCTAssertEqualObjects(self.customBiometryKey, auth.customBiometryKey);
-    XCTAssertNil([auth validateUsage:YES]);
+    if (self.hasBiometry) {
+        XCTAssertNil([auth validateUsage:YES]);
+    } else {
+        XCTAssertNotNil([auth validateUsage:YES]);
+    }
     
     // core password variants
     
@@ -98,7 +112,11 @@
     XCTAssertNil(auth.biometryPrompt);
     XCTAssertContextNil(auth.biometryContext);
     XCTAssertNil(auth.customBiometryKey);
-    XCTAssertNil([auth validateUsage:YES]);
+    if (self.hasBiometry) {
+        XCTAssertNil([auth validateUsage:YES]);
+    } else {
+        XCTAssertNotNil([auth validateUsage:YES]);
+    }
     
     auth = [PowerAuthAuthentication persistWithCorePasswordAndBiometry:[PowerAuthCorePassword passwordWithString:@"4321"] customBiometryKey:_customBiometryKey];
     XCTAssertTrue(auth.usePossession);
@@ -107,7 +125,11 @@
     XCTAssertNil(auth.biometryPrompt);
     XCTAssertContextNil(auth.biometryContext);
     XCTAssertEqualObjects(self.customBiometryKey, auth.customBiometryKey);
-    XCTAssertNil([auth validateUsage:YES]);
+    if (self.hasBiometry) {
+        XCTAssertNil([auth validateUsage:YES]);
+    } else {
+        XCTAssertNotNil([auth validateUsage:YES]);
+    }
 }
 
 - (void) testSignPossessionOnly
@@ -154,7 +176,11 @@
     XCTAssertNil(auth.biometryPrompt);
     XCTAssertContextNil(auth.biometryContext);
     XCTAssertNil(auth.customBiometryKey);
-    XCTAssertNil([auth validateUsage:NO]);
+    if (self.hasBiometry) {
+        XCTAssertNil([auth validateUsage:NO]);
+    } else {
+        XCTAssertNotNil([auth validateUsage:NO]);
+    }
 
     auth = [PowerAuthAuthentication possessionWithBiometryWithCustomBiometryKey:_customBiometryKey];
     XCTAssertTrue(auth.usePossession);
@@ -163,7 +189,11 @@
     XCTAssertNil(auth.biometryPrompt);
     XCTAssertContextNil(auth.biometryContext);
     XCTAssertEqualObjects(self.customBiometryKey, auth.customBiometryKey);
-    XCTAssertNil([auth validateUsage:NO]);
+    if (self.hasBiometry) {
+        XCTAssertNil([auth validateUsage:NO]);
+    } else {
+        XCTAssertNotNil([auth validateUsage:NO]);
+    }
     
     auth = [PowerAuthAuthentication possessionWithBiometryPrompt:_biometryPrompt];
     XCTAssertTrue(auth.usePossession);
@@ -172,7 +202,11 @@
     XCTAssertEqualObjects(_biometryPrompt, auth.biometryPrompt);
     XCTAssertContextNil(auth.biometryContext);
     XCTAssertNil(auth.customBiometryKey);
-    XCTAssertNil([auth validateUsage:NO]);
+    if (self.hasBiometry) {
+        XCTAssertNil([auth validateUsage:NO]);
+    } else {
+        XCTAssertNotNil([auth validateUsage:NO]);
+    }
         
 #if PA2_HAS_LACONTEXT
     auth = [PowerAuthAuthentication possessionWithBiometryContext:_biometryContext];

--- a/src/PowerAuth/Session.cpp
+++ b/src/PowerAuth/Session.cpp
@@ -204,7 +204,10 @@ TaskPtr Session::startProtocolUpgrade(const PasswordPtr& password, const cc7::By
 {
     LOCK_GUARD();
     checkActivationData();
-    return std::make_shared<ProtocolUpgradeTask>(_context, password, new_biometry_kek);
+    auto task = std::make_shared<ProtocolUpgradeTask>(_context, password, new_biometry_kek);
+    // Start the task to prepare upgrade structure in SessionData class.
+    task->start();
+    return task;
 }
 
 RequestPtr Session::removeActivation(const CredentialsPtr& credentials)

--- a/src/PowerAuth/Task.cpp
+++ b/src/PowerAuth/Task.cpp
@@ -172,6 +172,7 @@ RequestPtr Task::getNextRequest()
         setCompleted();
     }
     if (_state == State::FAILED) {
+        setCompleted();
         reThrowFailure();
     }
     return nullptr;

--- a/src/PowerAuth/task/ProtocolUpgradeTask.cpp
+++ b/src/PowerAuth/task/ProtocolUpgradeTask.cpp
@@ -33,6 +33,8 @@ ProtocolUpgradeTask::ProtocolUpgradeTask(const ContextPtr& context, const Passwo
 void ProtocolUpgradeTask::onTaskStart()
 {
     Task::onTaskStart();
+    // Create upgrade data structure
+    prepareUpgradeData();
     // Fetch activation status to obtain the current state of the protocol upgrade.
     fetchActivationStatus();
 }
@@ -81,6 +83,12 @@ void ProtocolUpgradeTask::onTaskEnd()
     resetState();
 }
 
+void ProtocolUpgradeTask::prepareUpgradeData()
+{
+    auto new_upgrade_data = UpgradeData::create();
+    _session_data->setUpgradeData(new_upgrade_data);
+}
+
 void ProtocolUpgradeTask::startProtocolUpgrade()
 {
     auto current_context = lockContext();
@@ -92,9 +100,6 @@ void ProtocolUpgradeTask::startProtocolUpgrade()
     if (_session_data->persistentData().hasBiometricFactorKey()) {
         Credentials::validateFactorKek(_new_biometry_kek, Version_V4);
     }
-    
-    auto new_ud = UpgradeData::create();
-    _session_data->setUpgradeData(new_ud);
     
     auto upgrade_context = current_context->createTargetAlgorithmContext();
     

--- a/src/PowerAuth/task/ProtocolUpgradeTask.h
+++ b/src/PowerAuth/task/ProtocolUpgradeTask.h
@@ -42,6 +42,8 @@ protected:
     
 private:
     
+    /// Prepare upgrade data and indicate that session is in pending upgrade.
+    void prepareUpgradeData();
     /// Prepare upgrade context and send the start protocol upgrade request to the server.
     void startProtocolUpgrade();
     /// Build the request body for the start protocol upgrade request.


### PR DESCRIPTION
This PR is composed of multiple related commits and fixes the following issues:
- Share information about External Pending Operation on iOS, when an Activation Data Sharing feature is enabled.
- Failing tests related to Activation Data Sharing on iOS.

## Fix for External Pending Operation (EPO)
- Fixed missing EPO start with protocol upgrade type
- `ProtocolUpgradeTask` is now started immediately after its creation. This prevents premature end of the EPO immediately after the task creation.
- Added ability to reclaim EPO created in the same application if PowerAuthSDK instance is re-created and the shared data still contains information about EPO for upgrade.

## Integration tests fix
- Added proper simulation of app restart by force release internal PowerAuthSDK instance resources.

## Other changes:
- Added debug description to `PowerAuthActivationStatus` and `PowerAuthExternalPendingOperation`
- Fixes integration tests for tvOS platform