### PR TITLE
Fix tvOS support

### DIFF
--- a/proj-xcode/PowerAuth2.xcodeproj/xcshareddata/xcschemes/PowerAuth2_IntegrationTests_tvOS.xcscheme
+++ b/proj-xcode/PowerAuth2.xcodeproj/xcshareddata/xcschemes/PowerAuth2_IntegrationTests_tvOS.xcscheme
@@ -78,10 +78,202 @@
             </BuildableReference>
             <SkippedTests>
                <Test
+                  Identifier = "BaseTestWithActivation">
+               </Test>
+               <Test
                   Identifier = "PowerAuthConcurrencyTests">
                </Test>
                <Test
                   Identifier = "PowerAuthInvalidCurveTests">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testActivationCodeSignature">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testActivationStatus">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testActivationStatusConcurrent">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testActivationStatusFailCounters">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testActivationStatusMaxFailAttempts">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testAlgorithmSetup">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testAuthentication">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testBasicTokenOperations">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testBiometrySignatureWhenNotConfigured">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCallToCreateActivationInWrongState">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCancelEnqueuedHttpOperation">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testChangePassword">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testChangePasswordDeprecated">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCleanupActivationData">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCounterSync_ClientIsAhead">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCounterSync_ServerIsAhead">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCreateActivationAndPersistWithCorePassword">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCreateActivationAndPersistWithPassword">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCreateActivationWhenApplicationIsUnsupported">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCreateActivationWithOtpAndSignature">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCreateActivationWithSignature">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCreateActivationWithoutSignature">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCreateCSR">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCreateTokenWithDifferentAuth">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testCustomOfflineAuthCode">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testEncryptorCreation">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testExportDevicePublicKey">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testExternalEncryptionKeyDiscontinue">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testFailedStatusFetch">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testGroupedCreateTokenRequests">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testJwsSignDataWithDevicePrivateKey">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testJwtSignature">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testPasswordCorrect">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testPasswordCorrectWhenBlocked">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testPersistActivationFailRecovery">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testProtocolUpgrade">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testProtocolUpgradeWithBiometry">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testProtocolUpgrade_fetchStatusFailure">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testProtocolUpgrade_newBiometryKekWithoutBiometryFactorSet">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testProtocolUpgrade_upgradeConfirmRequestAndStatusResponseFailure">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testProtocolUpgrade_upgradeConfirmRequestFailure">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testProtocolUpgrade_upgradeConfirmResponseFailure">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testProtocolUpgrade_upgradeStartResponseFailure">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testProtocolUpgrade_withRestarts">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testRemoveActivation">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testRestoreSessionState">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testSignDataWithDevicePrivateKey">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testSimulatedHttpResponseFailure">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testTokens_ConcurrentCreationAndRemove">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testUnsupportedDataHandling">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testUpgradeSDKDetection">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testUserInfo">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testVaultEncryptionKeys">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testVerifyJwsServerSignedData">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testVerifyOfflineServerSignedData">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKBaseTests/testVerifyServerSignedData">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKSharedBaseTests">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKSharedBaseTests/testConcurrentActivation">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKSharedBaseTests/testConcurrentSignatureCalculations">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKSharedBaseTests/testConcurrentTokens">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKSharedBaseTests/testProtocolUpgrade_Concurrent">
+               </Test>
+               <Test
+                  Identifier = "PowerAuthSDKSharedBaseTests/testProtocolUpgrade_ConcurrentLegacyVsV4">
                </Test>
             </SkippedTests>
          </TestableReference>

--- a/proj-xcode/PowerAuth2/PowerAuthAuthentication.m
+++ b/proj-xcode/PowerAuth2/PowerAuthAuthentication.m
@@ -405,17 +405,24 @@
 - (NSError*) validateUsage:(BOOL)forPersist
 {
     NSString * errorMessage;
+    PowerAuthErrorCode errorCode = PowerAuthErrorCode_WrongParameter;
     if (forPersist != (_objectUsage == AUTH_FOR_PERSIST)) {
         errorMessage = forPersist
             ? @"Using PowerAuthAuthentication object for a different purpose. The object for activation persist is expected."
             : @"Using PowerAuthAuthentication object for a different purpose. The object for authentication code calculation is expected.";
     } else if (_overridenPossessionKey) {
         errorMessage = @"Using PowerAuthAuthentication with a custom possession key is no longer supported.";
+#if !defined(PA2_BIOMETRY_SUPPORT)
+    } else if (_useBiometry) {
+        errorMessage = @"Biometry is not supported on this device.";
+        errorCode = PowerAuthErrorCode_BiometryNotAvailable;
+#endif // !defined(PA2_BIOMETRY_SUPPORT)
     } else {
         errorMessage = nil;
     }
+
     if (errorMessage) {
-        return PA2MakeError(PowerAuthErrorCode_WrongParameter, errorMessage);
+        return PA2MakeError(errorCode, errorMessage);
     }
     return nil;
 }

--- a/proj-xcode/PowerAuth2IntegrationTests/BaseTestWithActivation.h
+++ b/proj-xcode/PowerAuth2IntegrationTests/BaseTestWithActivation.h
@@ -27,6 +27,7 @@
 @property (nonatomic, strong, readonly) PowerAuthSDK * sdk;
 @property (nonatomic, readonly) PowerAuthAlgorithm powerAuthAlgorithm;  // override in subclass
 @property (nonatomic, readonly) BOOL supportsActivationWithSignature;
+@property (nonatomic, readonly) BOOL hasBiometrySupport;
 
 - (void) prepareConfigs:(PowerAuthConfiguration**)configuration
         biometricConfig:(PowerAuthBiometricConfiguration**)biometricConfiguration

--- a/proj-xcode/PowerAuth2IntegrationTests/BaseTestWithActivation.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/BaseTestWithActivation.m
@@ -90,6 +90,15 @@
     return relativePath;
 }
 
+- (BOOL) hasBiometrySupport
+{
+#if defined(PA2_BIOMETRY_SUPPORT)
+    return YES;
+#else
+    return NO;
+#endif
+}
+
 - (BOOL) isRequestFailureSimulatorAvailable
 {
 #if defined(DEBUG)

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKBaseTests.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKBaseTests.m
@@ -381,7 +381,9 @@
     PowerAuthAuthentication * auth = activation.credentials;
     PowerAuthAuthentication * auth_possession = _helper.authPossession;
     PowerAuthAuthentication * auth_possession_knowledge = _helper.authPossessionWithKnowledge;
-    PowerAuthAuthentication * auth_possession_biometry = _helper.authPossessionWithBiometry;
+    PowerAuthAuthentication * auth_possession_biometry = self.hasBiometrySupport
+                                ? _helper.authPossessionWithBiometry
+                                : _helper.authPossessionWithKnowledge;
     
     //
     // Online & offline signatures (calculated as http auth header)
@@ -467,20 +469,22 @@
                                                                           componentLength:componentLength];
     XCTAssertTrue(response.signatureValid);
     
-    // possession + biometry
-    code = [AsyncHelper synchronizeAsynchronousBlock:^(AsyncHelper *waiting) {
-        [_sdk offlineAuthenticationCodeWithAuthentication:_helper.authPossessionWithBiometry uriId:@"/some/uriId" body:nil nonce:nonce callback:^(NSString * _Nullable authenticationCode, NSError * _Nullable error) {
-            [waiting reportCompletion:authenticationCode];
+    if (self.hasBiometrySupport) {
+        // possession + biometry
+        code = [AsyncHelper synchronizeAsynchronousBlock:^(AsyncHelper *waiting) {
+            [_sdk offlineAuthenticationCodeWithAuthentication:_helper.authPossessionWithBiometry uriId:@"/some/uriId" body:nil nonce:nonce callback:^(NSString * _Nullable authenticationCode, NSError * _Nullable error) {
+                [waiting reportCompletion:authenticationCode];
+            }];
         }];
-    }];
-    XCTAssertNotNil(code);
-    XCTAssertEqual(componentLength*2+1, code.length);
-    response = [_helper.testServerApi verifyOfflineAuthCode:activation.activationData.activationId
-                                                       data:normalized_data
-                                                   authCode:code
-                                              allowBiometry:YES
-                                            componentLength:componentLength];
-    XCTAssertTrue(response.signatureValid);
+        XCTAssertNotNil(code);
+        XCTAssertEqual(componentLength*2+1, code.length);
+        response = [_helper.testServerApi verifyOfflineAuthCode:activation.activationData.activationId
+                                                           data:normalized_data
+                                                       authCode:code
+                                                  allowBiometry:YES
+                                                componentLength:componentLength];
+        XCTAssertTrue(response.signatureValid);
+    }
 }
 
 - (void) testActivationStatus
@@ -1003,9 +1007,11 @@
     // By default, EEK is not set
     XCTAssertFalse(_sdk.hasExternalEncryptionKey);
     XCTAssertTrue([_helper checkForCorePassword:activation.credentials.password]);
-    // Check biometry
-    result = [_helper validateAuthentication:_helper.authPossessionWithBiometry data:[@"data" dataUsingEncoding:NSUTF8StringEncoding] method:@"POST" uriId:@"/hello/hacker" online:YES cripple:0];
-    XCTAssertTrue(result);
+    if (self.hasBiometrySupport) {
+        // Check biometry
+        result = [_helper validateAuthentication:_helper.authPossessionWithBiometry data:[@"data" dataUsingEncoding:NSUTF8StringEncoding] method:@"POST" uriId:@"/hello/hacker" online:YES cripple:0];
+        XCTAssertTrue(result);
+    }
     
     if (self.powerAuthAlgorithm == PowerAuthAlgorithm_LEGACY_P256) {
         // V3 activations
@@ -1038,9 +1044,11 @@
         XCTAssertTrue(_sdk.hasExternalEncryptionKey);
         // auth codes should not work
         XCTAssertFalse([_helper checkForCorePassword:activation.credentials.password]);
-        // biometry
-        result = [_helper validateAuthentication:_helper.authPossessionWithBiometry data:[@"B10" dataUsingEncoding:NSUTF8StringEncoding] method:@"POST" uriId:@"/hello/hacker" online:YES cripple:0];
-        XCTAssertFalse(result);
+        if (self.hasBiometrySupport) {
+            // biometry
+            result = [_helper validateAuthentication:_helper.authPossessionWithBiometry data:[@"B10" dataUsingEncoding:NSUTF8StringEncoding] method:@"POST" uriId:@"/hello/hacker" online:YES cripple:0];
+            XCTAssertFalse(result);
+        }
         // knowledge - offline
         result = [_helper validateAuthentication:_helper.authPossessionWithKnowledge data:[@"0ffl1n3" dataUsingEncoding:NSUTF8StringEncoding] method:@"POST" uriId:@"/hello/hacker" online:NO cripple:0];
         XCTAssertFalse(result);
@@ -1059,9 +1067,11 @@
         
         XCTAssertFalse(_sdk.hasExternalEncryptionKey);
         XCTAssertTrue([_helper checkForCorePassword:activation.credentials.password]);
-        // biometry
-        result = [_helper validateAuthentication:_helper.authPossessionWithBiometry data:[@"data" dataUsingEncoding:NSUTF8StringEncoding] method:@"POST" uriId:@"/hello/hacker" online:YES cripple:0];
-        XCTAssertTrue(result);
+        if (self.hasBiometrySupport) {
+            // biometry
+            result = [_helper validateAuthentication:_helper.authPossessionWithBiometry data:[@"data" dataUsingEncoding:NSUTF8StringEncoding] method:@"POST" uriId:@"/hello/hacker" online:YES cripple:0];
+            XCTAssertTrue(result);
+        }
         // knowledge - offline
         result = [_helper validateAuthentication:_helper.authPossessionWithKnowledge data:[@"0ffl1n3" dataUsingEncoding:NSUTF8StringEncoding] method:@"POST" uriId:@"/hello/hacker" online:NO cripple:0];
         XCTAssertTrue(result);
@@ -1110,12 +1120,6 @@
 - (void) testBiometrySignatureWhenNotConfigured
 {
     CHECK_TEST_CONFIG();
-
-#if defined(PA2_BIOMETRY_SUPPORT)
-    BOOL supportsBiometry = YES;
-#else
-    BOOL supportsBiometry = NO;
-#endif
     
     //
     // This test validates that signing with biometry doesn't work when
@@ -1134,7 +1138,7 @@
     authentication = [PowerAuthAuthentication possessionWithBiometry];
     header = [_sdk authenticationHeaderForRequestWithBodyWithAuthentication:authentication method:@"POST" uriId:@"/some/uri/id" body:[NSData data] error:&error];
     XCTAssertNil(header);
-    if (supportsBiometry) {
+    if (self.hasBiometrySupport) {
         XCTAssertEqual(PowerAuthErrorCode_BiometryFailed, error.powerAuthErrorCode);
     } else {
         XCTAssertEqual(PowerAuthErrorCode_BiometryNotAvailable, error.powerAuthErrorCode);
@@ -1145,7 +1149,7 @@
     header = [_sdk authenticationHeaderForRequestWithBodyWithAuthentication:authentication method:@"POST" uriId:@"/some/uri/id" body:[NSData data] error:&error];
     XCTAssertNil(header);
     
-    if (supportsBiometry) {
+    if (self.hasBiometrySupport) {
         XCTAssertEqual(PowerAuthErrorCode_BiometryFailed, error.powerAuthErrorCode);
     } else {
         XCTAssertEqual(PowerAuthErrorCode_BiometryNotAvailable, error.powerAuthErrorCode);
@@ -2201,8 +2205,10 @@
         any2fa = [self fetchVaultEncryptionKey:PowerAuthSecureVaultKeyId_KnowledgeOrBiometry credentials:activation.credentials shouldPass:YES];
         otherKDK = [self fetchVaultEncryptionKey:PowerAuthSecureVaultKeyId_KnowledgeOrBiometry credentials:activation.credentials shouldPass:YES];
         XCTAssertEqualObjects(any2fa, otherKDK);
-        otherKDK = [self fetchVaultEncryptionKey:PowerAuthSecureVaultKeyId_KnowledgeOrBiometry credentials:activation.biometryCredentials shouldPass:YES];
-        XCTAssertEqualObjects(any2fa, otherKDK);
+        if (self.hasBiometrySupport) {
+            otherKDK = [self fetchVaultEncryptionKey:PowerAuthSecureVaultKeyId_KnowledgeOrBiometry credentials:activation.biometryCredentials shouldPass:YES];
+            XCTAssertEqualObjects(any2fa, otherKDK);
+        }
 
         knowledge = [self fetchVaultEncryptionKey:PowerAuthSecureVaultKeyId_Knowledge credentials:activation.credentials shouldPass:YES];
         XCTAssertNotEqualObjects(any2fa, knowledge);
@@ -2823,6 +2829,10 @@
 - (void) testProtocolUpgradeWithBiometry
 {
     CHECK_TEST_CONFIG();
+    if (!self.hasBiometrySupport) {
+        NSLog(@"Test skipped, device has no biometry support.");
+        return;
+    }
     
     //
     // Test successful upgrade from V3 to V4 protocol.
@@ -2893,7 +2903,10 @@
     XCTAssertEqual(_sdk.hasProtocolUpgradeAvailable, targetAlgorithm > PowerAuthAlgorithm_LEGACY_P256);
     
     // Assert the old biometry factor key still works.
-    PowerAuthAuthentication * oldBiometryAuth = _helper.currentActivation.biometryCredentials;
+    // If biometry not supported, then use knowledge factor.
+    PowerAuthAuthentication * oldBiometryAuth = self.hasBiometrySupport
+                ? _helper.currentActivation.biometryCredentials
+                : _helper.currentActivation.credentials;
     NSData * randomData = [[[PowerAuthCoreCryptoUtils randomBytes:42] base64EncodedStringWithOptions:0] dataUsingEncoding:NSASCIIStringEncoding];
     BOOL authenticationValid = [_helper validateAuthentication:oldBiometryAuth
                                                           data:randomData
@@ -2933,7 +2946,11 @@
     XCTAssertEqual(_sdk.hasProtocolUpgradeAvailable, targetAlgorithm > PowerAuthAlgorithm_LEGACY_P256);
     
     // Assert the old biometry factor key still works.
-    PowerAuthAuthentication * oldBiometryAuth = _helper.currentActivation.biometryCredentials;
+    // If biometry not supported, then use knowledge factor.
+    PowerAuthAuthentication * oldBiometryAuth = self.hasBiometrySupport
+                    ? _helper.currentActivation.biometryCredentials
+                    : _helper.currentActivation.credentials;
+    
     NSData * randomData = [[[PowerAuthCoreCryptoUtils randomBytes:42] base64EncodedStringWithOptions:0] dataUsingEncoding:NSASCIIStringEncoding];
     BOOL authenticationValid = [_helper validateAuthentication:oldBiometryAuth
                                                           data:randomData
@@ -2992,24 +3009,26 @@
     XCTAssertFalse(_sdk.hasProtocolUpgradeAvailable);
     XCTAssertFalse(_sdk.hasPendingProtocolUpgrade);
     
-    // Check that the old biometry factor does not work anymore.
-    PowerAuthAuthentication * oldBiometryAuth = _helper.currentActivation.biometryCredentials;
-    NSData * randomData = [[[PowerAuthCoreCryptoUtils randomBytes:42] base64EncodedStringWithOptions:0] dataUsingEncoding:NSASCIIStringEncoding];
-    BOOL authenticationValid = [_helper validateAuthentication:oldBiometryAuth
-                                                          data:randomData
-                                                        method:@"POST"
-                                                         uriId:@"/hello/there"
-                                                        online:YES
-                                                       cripple:0];
-    XCTAssertFalse(authenticationValid);
+    if (self.hasBiometrySupport) {
+        // Check that the old biometry factor does not work anymore.
+        PowerAuthAuthentication * oldBiometryAuth = _helper.currentActivation.biometryCredentials;
+        NSData * randomData = [[[PowerAuthCoreCryptoUtils randomBytes:42] base64EncodedStringWithOptions:0] dataUsingEncoding:NSASCIIStringEncoding];
+        BOOL authenticationValid = [_helper validateAuthentication:oldBiometryAuth
+                                                              data:randomData
+                                                            method:@"POST"
+                                                             uriId:@"/hello/there"
+                                                            online:YES
+                                                           cripple:0];
+        XCTAssertFalse(authenticationValid);
+    }
 
     [_helper cleanup];
 }
 
+
 - (void) testProtocolUpgrade_upgradeConfirmRequestFailure
 {
     CHECK_TEST_CONFIG();
-    CHECK_BIOMETRY();
     
     //
     // Test successful upgrade from V3 to V4 protocol. In this case
@@ -3020,7 +3039,7 @@
     // required to confirm the protocol upgrade in the background.
     //
     const PowerAuthAlgorithm targetAlgorithm = self.powerAuthAlgorithm;
-    PowerAuthCoreData * newBiometryKek = [PowerAuthCoreCryptoUtils randomCoreData:32];
+    PowerAuthCoreData * newBiometryKek = self.hasBiometrySupport ? [PowerAuthCoreCryptoUtils randomCoreData:32] : nil;
     _sdk = [_helper prepareActivationForUpgradeTest:targetAlgorithm withFlags:TestActivationFlags_PersistWithBiometry];
     
     // Set 3 failures in a row, as there are 3 confirm attempts in the task.
@@ -3043,19 +3062,21 @@
     XCTAssertNil(_sdk.externalPendingOperation);
     
     // Check biometry factor not possible during upgrade.
-    PowerAuthAuthentication * newBiometryAuth = [PowerAuthAuthentication possessionWithBiometryWithCustomBiometryKey:newBiometryKek];
+    PowerAuthAuthentication * newAuth = self.hasBiometrySupport
+            ? [PowerAuthAuthentication possessionWithBiometryWithCustomBiometryKey:newBiometryKek]
+            : [_helper.authPossessionWithKnowledge copy];
     NSData * randomData = [[[PowerAuthCoreCryptoUtils randomBytes:42] base64EncodedStringWithOptions:0] dataUsingEncoding:NSASCIIStringEncoding];
     
     // Authentication header calculation not allowed when protocol upgrade pending.
     NSError * authCalcError;
-    [_sdk authenticationHeaderForRequestWithBodyWithAuthentication:newBiometryAuth method:@"POST" uriId:@"/hello/there" body:randomData error:&authCalcError];
+    [_sdk authenticationHeaderForRequestWithBodyWithAuthentication:newAuth method:@"POST" uriId:@"/hello/there" body:randomData error:&authCalcError];
     XCTAssertEqual(PowerAuthErrorCode_PendingProtocolUpgrade, authCalcError.powerAuthErrorCode);
     // Same applies to offline.
-    [_sdk offlineAuthenticationCodeWithAuthentication:newBiometryAuth uriId:@"/hello/there" body:randomData nonce:@"trustmeitisarandomstring" callback:^(NSString * authenticationCode, NSError * error){
+    [_sdk offlineAuthenticationCodeWithAuthentication:newAuth uriId:@"/hello/there" body:randomData nonce:@"trustmeitisarandomstring" callback:^(NSString * authenticationCode, NSError * error){
         XCTAssertEqual(PowerAuthErrorCode_PendingProtocolUpgrade, error.powerAuthErrorCode);
     }];
     
-    BOOL authenticationValid = [_helper validateAuthentication:newBiometryAuth
+    BOOL authenticationValid = [_helper validateAuthentication:newAuth
                                                           data:randomData
                                                         method:@"POST"
                                                          uriId:@"/hello/there"
@@ -3086,7 +3107,7 @@
     
     // Simulate application restart before testing authentication.
     _sdk = [_helper reCreateSdkInstance];
-    authenticationValid = [_helper validateAuthentication:newBiometryAuth
+    authenticationValid = [_helper validateAuthentication:newAuth
                                                      data:randomData
                                                    method:@"POST"
                                                     uriId:@"/hello/there"
@@ -3094,7 +3115,6 @@
                                                   cripple:0];
     XCTAssertTrue(authenticationValid);
     
-
     [_helper cleanup];
 }
 

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSdkTestHelper.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSdkTestHelper.m
@@ -523,9 +523,13 @@ static NSString * PA_Ver_Current = @"4.0";
     PowerAuthActivationStatus * status = [self fetchActivationStatus];
     XCTAssertTrue(status.state == PowerAuthActivationState_Active);
     
+#if defined(PA2_BIOMETRY_SUPPORT)
     if (flags & (TestActivationFlags_PersistWithFakeBiometry | TestActivationFlags_PersistWithBiometry)) {
         XCTAssertTrue(_sdk.hasBiometryFactor);
     }
+#else
+    XCTAssertFalse(_sdk.hasBiometryFactor);
+#endif
     
     return _sdk;
 }
@@ -648,6 +652,10 @@ static NSString * PA_Ver_Current = @"4.0";
 {
     NSArray<NSString*> * veryCleverPasswords = [self veryStrongPasswords];
     NSString * newPassword = veryCleverPasswords[arc4random_uniform((uint32_t)veryCleverPasswords.count)];
+#if !defined(PA2_BIOMETRY_SUPPORT)
+    // Clear persist with biometry if biometry not supported on this platform.
+    flags &= ~(TestActivationFlags_PersistWithBiometry | TestActivationFlags_PersistWithFakeBiometry);
+#endif // !defined(PA2_BIOMETRY_SUPPORT)
 
     if (flags & TestActivationFlags_PersistWithBiometry) {
         return [PowerAuthAuthentication persistWithPasswordAndBiometry:newPassword];

--- a/proj-xcode/PowerAuth2Tests/PowerAuthAuthenticationTests.m
+++ b/proj-xcode/PowerAuth2Tests/PowerAuthAuthenticationTests.m
@@ -26,6 +26,7 @@
 @property (nonatomic, strong) PowerAuthCoreData * customPossessionKey;
 @property (nonatomic, strong) NSString * biometryPrompt;
 @property (nonatomic, strong) id biometryContext;
+@property (nonatomic, readonly) BOOL hasBiometry;
 @end
 
 @implementation PowerAuthAuthenticationTests
@@ -42,6 +43,11 @@
 #else
     #define XCTAssertContextNil(x)
 #endif // PA2_HAS_LACONTEXT
+#if defined(PA2_BIOMETRY_SUPPORT)
+    _hasBiometry = YES;
+#else
+    _hasBiometry = NO;
+#endif
     
     PowerAuthLogSetEnabled(YES);
 }
@@ -78,7 +84,11 @@
     XCTAssertNil(auth.biometryPrompt);
     XCTAssertContextNil(auth.biometryContext);
     XCTAssertNil(auth.customBiometryKey);
-    XCTAssertNil([auth validateUsage:YES]);
+    if (self.hasBiometry) {
+        XCTAssertNil([auth validateUsage:YES]);
+    } else {
+        XCTAssertNotNil([auth validateUsage:YES]);
+    }
     
     auth = [PowerAuthAuthentication persistWithPasswordAndBiometry:@"4321" customBiometryKey:_customBiometryKey];
     XCTAssertTrue(auth.usePossession);
@@ -87,7 +97,11 @@
     XCTAssertNil(auth.biometryPrompt);
     XCTAssertContextNil(auth.biometryContext);
     XCTAssertEqualObjects(self.customBiometryKey, auth.customBiometryKey);
-    XCTAssertNil([auth validateUsage:YES]);
+    if (self.hasBiometry) {
+        XCTAssertNil([auth validateUsage:YES]);
+    } else {
+        XCTAssertNotNil([auth validateUsage:YES]);
+    }
     
     // core password variants
     
@@ -98,7 +112,11 @@
     XCTAssertNil(auth.biometryPrompt);
     XCTAssertContextNil(auth.biometryContext);
     XCTAssertNil(auth.customBiometryKey);
-    XCTAssertNil([auth validateUsage:YES]);
+    if (self.hasBiometry) {
+        XCTAssertNil([auth validateUsage:YES]);
+    } else {
+        XCTAssertNotNil([auth validateUsage:YES]);
+    }
     
     auth = [PowerAuthAuthentication persistWithCorePasswordAndBiometry:[PowerAuthCorePassword passwordWithString:@"4321"] customBiometryKey:_customBiometryKey];
     XCTAssertTrue(auth.usePossession);
@@ -107,7 +125,11 @@
     XCTAssertNil(auth.biometryPrompt);
     XCTAssertContextNil(auth.biometryContext);
     XCTAssertEqualObjects(self.customBiometryKey, auth.customBiometryKey);
-    XCTAssertNil([auth validateUsage:YES]);
+    if (self.hasBiometry) {
+        XCTAssertNil([auth validateUsage:YES]);
+    } else {
+        XCTAssertNotNil([auth validateUsage:YES]);
+    }
 }
 
 - (void) testSignPossessionOnly
@@ -154,7 +176,11 @@
     XCTAssertNil(auth.biometryPrompt);
     XCTAssertContextNil(auth.biometryContext);
     XCTAssertNil(auth.customBiometryKey);
-    XCTAssertNil([auth validateUsage:NO]);
+    if (self.hasBiometry) {
+        XCTAssertNil([auth validateUsage:NO]);
+    } else {
+        XCTAssertNotNil([auth validateUsage:NO]);
+    }
 
     auth = [PowerAuthAuthentication possessionWithBiometryWithCustomBiometryKey:_customBiometryKey];
     XCTAssertTrue(auth.usePossession);
@@ -163,7 +189,11 @@
     XCTAssertNil(auth.biometryPrompt);
     XCTAssertContextNil(auth.biometryContext);
     XCTAssertEqualObjects(self.customBiometryKey, auth.customBiometryKey);
-    XCTAssertNil([auth validateUsage:NO]);
+    if (self.hasBiometry) {
+        XCTAssertNil([auth validateUsage:NO]);
+    } else {
+        XCTAssertNotNil([auth validateUsage:NO]);
+    }
     
     auth = [PowerAuthAuthentication possessionWithBiometryPrompt:_biometryPrompt];
     XCTAssertTrue(auth.usePossession);
@@ -172,7 +202,11 @@
     XCTAssertEqualObjects(_biometryPrompt, auth.biometryPrompt);
     XCTAssertContextNil(auth.biometryContext);
     XCTAssertNil(auth.customBiometryKey);
-    XCTAssertNil([auth validateUsage:NO]);
+    if (self.hasBiometry) {
+        XCTAssertNil([auth validateUsage:NO]);
+    } else {
+        XCTAssertNotNil([auth validateUsage:NO]);
+    }
         
 #if PA2_HAS_LACONTEXT
     auth = [PowerAuthAuthentication possessionWithBiometryContext:_biometryContext];


### PR DESCRIPTION
This PR fixes support for tvOS platform in tests. The platform has no biometry support, so there's additional validation test in `PowerAuthAuthentication` that fails when biometric authentication is requested, but is not supported on the platform.