### PR TITLE
Fix #560: Simplified biometric status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ xcuserdata
 *.xcuserstate
 *.xcscmblueprint
 
+## AI
+.claude
+
 ## VSCode
 .vscode
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -16,6 +16,7 @@
 - You can select a level of security that suits your business needs. See the `PowerAuthConfiguration` documentation for more details.
 - PowerAuth Mobile SDK can optionally operate in a mode fully compatible with legacy PowerAuth protocol version 3.3.
 - A new `PowerAuthBiometricConfiguration` class simplifies biometric configuration of the `PowerAuthSDK` class.
+- A new `PowerAuthBiometricStatus` class simplifies getting overall state of biometry in the system and `PowerAuthSDK` instance.
 - A new `PowerAuthSecureVaultKey` class provides better flexibility for Secure Vault operations.
 - PowerAuth Mobile SDK now ensures sensitive keys are not retained in memory.
 - Activation using a recovery code is no longer supported.
@@ -35,7 +36,7 @@
 <!--------------------------------------------------->
 ## 1.9.6 (October 2025)
 
-## Both platforms
+### Both platforms
 
 - Added support for creating CRS signed with device private key ([707](https://github.com/wultra/powerauth-mobile-sdk/issues/707))
 

--- a/docs/Migration-from-1.9-to-2.0.md
+++ b/docs/Migration-from-1.9-to-2.0.md
@@ -7,6 +7,7 @@ PowerAuth Mobile SDK in version `2.0.0` provides the following improvements:
 - You can select a level of security that suits your business needs. See the `PowerAuthConfiguration` documentation for more details.
 - PowerAuth Mobile SDK can optionally operate in a mode fully compatible with legacy PowerAuth protocol version 3.3.
 - A new `PowerAuthBiometricConfiguration` class simplifies biometric configuration of the `PowerAuthSDK` class.
+- A new `PowerAuthBiometricStatus` class simplifies getting overall state of biometry in the system and `PowerAuthSDK` instance.
 - A new `PowerAuthSecureVaultKey` class provides better flexibility for Secure Vault operations.
 - PowerAuth Mobile SDK now ensures sensitive keys are not retained in memory.
 - Activation using a recovery code is no longer supported.

--- a/docs/PowerAuth-SDK-for-Android.md
+++ b/docs/PowerAuth-SDK-for-Android.md
@@ -1355,16 +1355,40 @@ You have to check for Biometric Authentication on three levels:
 
 PowerAuth SDK for Android provides code for the first and second of these checks.
 
-To check if you can use the biometric authentication, use our helper class:
+#### Overall status
+
+To get information on whether biometric authentication is fully available, you can use the following code:
 
 ```kotlin
-// This method is equivalent to `BiometricManager.canAuthenticate() == BiometricManager.BIOMETRIC_SUCCESS`.
-// Use it to check if the biometric authentication can be used at the moment.
-val isBiometricAuthAvailable = BiometricAuthentication.isBiometricAuthenticationAvailable(context)
+if (powerAuthSDK.isAuthenticationWithBiometricsAvailable(context)) {
+    // Biometric authentication is available, you can construct PowerAuthAuthentication with biometry 
+} else {
+    // Fallback to PIN
+}
+```
 
-// For more fine-grained control about the actual biometric authentication status,
-// you may use the following code:
-when (BiometricAuthentication.canAuthenticate(context)) {
+The function returns `true` only if activation has biometry factor-related data available and the device has a biometric sensor available and biometrics are enrolled in the system.
+
+<!-- begin box info -->
+Note that this doesn't reflect state when the sensor is temporarily or permanently locked out. Such information is available only after you attempt to authenticate with biometrics.
+<!-- end -->
+
+To get more detailed information, use the following code:
+
+```kotlin
+val biometricStatus = powerAuthSDK.getBiometricStatus(context)
+```
+
+The next chapters explain in more detail the usage of the returned `PowerAuthBiometricStatus` object.
+
+#### System Availability
+
+To check, whether the biometrics is available at the system level, use the following code:
+
+```kotlin
+// Get biometric status
+val biometricStatus = powerAuthSDK.getBiometricStatus(context)
+when (biometricStatus.systemStatus) {
     BiometricStatus.OK ->
         print("Everything is OK")
     BiometricStatus.NOT_SUPPORTED ->
@@ -1378,7 +1402,7 @@ when (BiometricAuthentication.canAuthenticate(context)) {
 // If you want to adjust localized strings or icons presented to the user,
 // you can use the following code to determine the type of biometry available
 // on the system:
-when (BiometricAuthentication.getBiometryType(context)) {
+when (biometricStatus.biometryType) {
     BiometryType.NONE ->
         print("Biometry is not supported on the system.")
     BiometryType.GENERIC ->
@@ -1386,8 +1410,8 @@ when (BiometricAuthentication.getBiometryType(context)) {
         // This occurs on Android 10+ systems when the device supports
         // more than one type of biometric authentication. In this case,
         // you should use generic terms in your UI, such as "Authenticate with biometry".
-        // This issue can also arise on devices that support a new type of biometry
-        // sensor, or on older, malfunctioning devices that fail to declare 
+        // This issue can also arise on devices that support a new type of biometric
+        // sensor, or on older malfunctioning devices that fail to declare 
         // support for FEATURE_FINGERPRINT.
         print("Biometry type is GENERIC")
     BiometryType.FINGERPRINT ->
@@ -1399,14 +1423,29 @@ when (BiometricAuthentication.getBiometryType(context)) {
 }
 ```
 
-To check if a given activation has biometry factor-related data available, use the following code:
+#### Activation Availability
+
+To check whether activation is configured for authentication with biometrics, use the following code:
 
 ```kotlin
-// Does activation have biometric factor-related data in place?
-val hasBiometryFactor = powerAuthSDK.hasBiometryFactor(context)
+// Get biometric status
+val biometricStatus = powerAuthSDK.getBiometricStatus(context)
+// Determine overall availability
+if (biometricStatus.isAuthenticationWithBiometricsAvailable) {
+    // Equal to call:
+    //   powerAuthSDK.isAuthenticationWithBiometricsAvailable(context)
+}
+// Determine whether local activation has biometric factor configured.
+if (biometricStatus.isBiometricFactorConfigured) {
+    // Equal to call
+    //   powerAuthSDK.hasBiometryFactor(context)
+}
 ```
 
-The last check is fully under your control. By keeping the biometric settings flag, for example, a `BOOL` in `SharedPreferences`, you can show the user an expected biometric authentication status (in a disabled state, though) even in the case biometric authentication is not enabled or when no fingers are enrolled on the device.
+#### Application Availability
+
+The last check is fully under your control. By keeping the biometric settings flag, for example, a `boolean` in `SharedPreferences`, you can show the user an expected biometric authentication status (in a disabled state, though) even in the case biometric authentication is not enabled or when no fingers are enrolled on the device.
+
 
 ### Enable Biometric Authentication
 

--- a/docs/PowerAuth-SDK-for-iOS.md
+++ b/docs/PowerAuth-SDK-for-iOS.md
@@ -1213,52 +1213,81 @@ PowerAuth SDK for iOS provides an abstraction on top of the base Touch and Face 
 
 You have to check for biometry on three levels:
 
-- **System Availability**:
-  - If Touch ID is present on the system and if an iOS version is 9+
-  - If Face ID is present on the system and if an iOS version is 11+
+- **System Availability**: If Touch ID or Face ID is present on the system.
 - **Activation Availability**: If biometry factor data are available for given activation.
 - **Application Availability**: If the user decides to use Touch ID for a given app. _(optional)_
 
 PowerAuth SDK for iOS provides code for the first two of these checks.
 
-To check if you can use biometry on the system, use the following code from the `PowerAuthKeychain` class:
+#### Overall Status
+
+To get information on whether biometric authentication is fully available, you can use the following code:
 
 ```swift
-// Is biometry available and is enrolled in the system?
-let canUseBiometry = PowerAuthKeychain.canUseBiometricAuthentication
-
-// Or alternative, to get supported biometry type
-let supportedBiometry = PowerAuthKeychain.supportedBiometricAuthentication
-switch supportedBiometry {
-    case .touchID: print("You can use Touch ID")
-    case .faceID: print("You can use Face ID")
-    case .none: print("Biometry is not supported or not enrolled")
+if powerAuthSDK.isAuthenticationWithBiometricsAvailable {
+    // Biometric authentication is available, you can construct PowerAuthAuthentication with biometry 
+} else {
+    // Fallback to PIN
 }
+```
 
-// Or more complex, with full information about the type and current status
-let biometryInfo = PowerAuthKeychain.biometricAuthenticationInfo
-switch biometryInfo.biometryType {
-    case .touchID: print("Touch ID is available on device.")
-    case .faceID: print("Face ID is available on device.")
-    case .none: print("Biometry is not supported.")
-}
-switch biometryInfo.currentStatus {
+The function returns `true` only if activation has biometry factor-related data available and the device has a biometric sensor available and biometrics are enrolled in the system.
+
+To get more detailed information, use the following code:
+
+```swift
+let biometricStatus = powerAuthSDK.biometricStatus
+```
+
+The next chapters explain in more detail the usage of the returned `PowerAuthBiometricStatus` object.
+
+#### System Availability
+
+To check whether the biometrics is available at the system level, use the following code:
+
+```swift
+// Get biometric status
+let biometricStatus = powerAuthSDK.biometricStatus
+switch biometricStatus.systemStatus {
     case .notSupported: print("Biometry is not supported.")
     case .notAvailable: print("Biometry is not available at this moment.")
     case .notEnrolled: print("Biometry is supported, but not enrolled.")
     case .lockout: print("Biometry is supported, but it has been locked out.")
     case .available: print("Biometry is available right now.")
 }
+// If you want to adjust localized strings or icons presented to the user,
+// you can use the following code to determine the type of biometry available
+// on the system:
+switch biometricStatus.biometryType {
+    case .touchID: print("You can use Touch ID")
+    case .faceID: print("You can use Face ID")
+    case .none: print("Biometry is not supported or not enrolled")
+}
 ```
 
-To check if a given activation has biometry factor-related data available, use the following code:
+#### Activation Availability
+
+To check whether activation is configured for authentication with biometrics, use the following code:
 
 ```swift
-// Does activation have biometric factor-related data in place?
-let hasBiometryFactor = powerAuthSDK.hasBiometryFactor()
+// Get biometric status
+let biometricStatus = powerAuthSDK.biometricStatus
+// Determine overall availability
+if biometricStatus.isAuthenticationWithBiometricsAvailable {
+    // Equal to call:
+    //   powerAuthSDK.isAuthenticationWithBiometricsAvailable
+}
+// Determine whether local activation has biometric factor configured.
+if biometricStatus.isBiometricFactorConfigured {
+    // Equal to call
+    //   powerAuthSDK.hasBiometryFactor()
+}
 ```
 
-The last check is fully under your control. By keeping the biometry settings flag, for example, a `BOOL` in `NSUserDefaults`, you are able to show expected user Touch or Face ID status (in a disabled state, though) even in the case biometry is not enabled or when no finger or face is enrolled on the device.
+#### Application Availability
+
+The last check is fully under your control. By keeping the biometry settings flag, for example, a `bool` in `UserDefaults`, you are able to show expected user Touch or Face ID status (in a disabled state, though) even in the case biometry is not enabled or when no finger or face is enrolled on the device.
+
 
 ### Enable Biometry
 

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BiometricTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BiometricTest.java
@@ -16,6 +16,7 @@
 
 package io.getlime.security.powerauth.integration.tests;
 
+import io.getlime.security.powerauth.biometry.BiometricAuthentication;
 import io.getlime.security.powerauth.biometry.IAddBiometryFactorListener;
 import io.getlime.security.powerauth.biometry.IRemoveBiometryFactorListener;
 import io.getlime.security.powerauth.core.CryptoUtils;
@@ -33,6 +34,7 @@ import androidx.annotation.NonNull;
 
 import static org.junit.Assert.*;
 
+import android.content.Context;
 import android.util.Base64;
 
 import java.nio.charset.StandardCharsets;
@@ -332,7 +334,7 @@ public class BiometricTest extends FragmentActivityBaseTest {
             // data and the keystore
             status = activationHelper.fetchActivationStatus();
             assertEquals(PowerAuthActivationState.ACTIVE, status.getState());
-            assertFalse(powerAuthSDK.hasBiometryFactor(testHelper.getContext()));
+            assertFalse(powerAuthSDK.isAuthenticationWithBiometricsAvailable(testHelper.getContext()));
 
             // Now try to add biometric factor. If response from the server is never received, then
             // the server thinks the factor is ON, but local data has no factor set.
@@ -360,7 +362,7 @@ public class BiometricTest extends FragmentActivityBaseTest {
             // "/pa/v4/biometry/remove" request. So, simulate the request to test whether the biometry
             // is really turned ON on the server.
 
-            assertFalse(powerAuthSDK.hasBiometryFactor(testHelper.getContext()));
+            assertFalse(powerAuthSDK.isAuthenticationWithBiometricsAvailable(testHelper.getContext()));
             error = AsyncHelper.await(resultCatcher -> {
                 simulateNetworkErrorOnSend("/pa/v4/biometry/remove");
                 powerAuthSDK.fetchActivationStatusWithCallback(testHelper.getContext(), new IActivationStatusListener() {
@@ -384,13 +386,58 @@ public class BiometricTest extends FragmentActivityBaseTest {
             status = activationHelper.fetchActivationStatus();
 
             assertEquals(PowerAuthActivationState.ACTIVE, status.getState());
-            assertFalse(powerAuthSDK.hasBiometryFactor(testHelper.getContext()));
+            assertFalse(powerAuthSDK.isAuthenticationWithBiometricsAvailable(testHelper.getContext()));
 
             // Simulate biometry remove. If fetch fail, then something's wrong.
             simulateNetworkErrorOnSend("/pa/v4/biometry/remove");
             status = activationHelper.fetchActivationStatus();
             assertNotNull(status);
             clearAllSimulateFailures();
+        });
+    }
+
+    @Test
+    public void testBiometricStatus() throws Exception {
+        runWithFragmentActivity(() -> {
+            final Context context = testHelper.getContext();
+
+            PowerAuthBiometricStatus biometricStatus = powerAuthSDK.getBiometricStatus(context);
+            assertEquals(BiometricAuthentication.canAuthenticate(context), biometricStatus.getSystemStatus());
+            assertEquals(BiometricAuthentication.getBiometryType(context), biometricStatus.getBiometryType());
+            assertFalse(biometricStatus.isAuthenticationWithBiometricsAvailable());
+            assertFalse(biometricStatus.isBiometricFactorConfigured());
+            assertFalse(powerAuthSDK.isAuthenticationWithBiometricsAvailable(context));
+
+            activationHelper.createStandardActivation(ActivationHelper.TF_PERSIST_WITH_BIOMETRY_ACTIVITY, null);
+
+            biometricStatus = powerAuthSDK.getBiometricStatus(context);
+            assertEquals(BiometricAuthentication.canAuthenticate(context), biometricStatus.getSystemStatus());
+            assertEquals(BiometricAuthentication.getBiometryType(context), biometricStatus.getBiometryType());
+            assertTrue(biometricStatus.isAuthenticationWithBiometricsAvailable());
+            assertTrue(biometricStatus.isBiometricFactorConfigured());
+            assertTrue(powerAuthSDK.isAuthenticationWithBiometricsAvailable(context));
+
+            boolean success = AsyncHelper.await(resultCatcher -> {
+                powerAuthSDK.removeBiometryFactor(context, new IRemoveBiometryFactorListener() {
+                    @Override
+                    public void onRemoveBiometryFactorSucceed() {
+                        resultCatcher.completeWithResult(true);
+                    }
+
+                    @Override
+                    public void onRemoveBiometryFactorFailed(@NonNull Throwable throwable) {
+                        resultCatcher.completeWithResult(false);
+                    }
+                });
+            });
+            assertTrue(success);
+
+            biometricStatus = powerAuthSDK.getBiometricStatus(context);
+            assertEquals(BiometricAuthentication.canAuthenticate(context), biometricStatus.getSystemStatus());
+            assertEquals(BiometricAuthentication.getBiometryType(context), biometricStatus.getBiometryType());
+            assertFalse(biometricStatus.isAuthenticationWithBiometricsAvailable());
+            assertFalse(biometricStatus.isBiometricFactorConfigured());
+            assertFalse(powerAuthSDK.isAuthenticationWithBiometricsAvailable(context));
         });
     }
 

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BiometricTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BiometricTest.java
@@ -398,6 +398,7 @@ public class BiometricTest extends FragmentActivityBaseTest {
 
     @Test
     public void testBiometricStatus() throws Exception {
+        assertBiometryEnrolled();
         runWithFragmentActivity(() -> {
             final Context context = testHelper.getContext();
 

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthBiometricStatus.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthBiometricStatus.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.sdk;
+
+import io.getlime.security.powerauth.biometry.BiometricStatus;
+import io.getlime.security.powerauth.biometry.BiometryType;
+
+/**
+ * {@code PowerAuthBiometricStatus} represents the overall availability of biometric authentication
+ * in a {@link PowerAuthSDK} instance.
+ */
+public class PowerAuthBiometricStatus {
+
+    private final boolean authenticationWithBiometricsAvailable;
+    private final boolean biometricFactorConfigured;
+    private final @BiometricStatus int systemStatus;
+    private final @BiometryType int biometryType;
+
+    /**
+     * Construct object with given parameters. The constructor is internal on purpose.
+     * @param biometricFactorConfigured {@code true} if biometric factor is configured in PowerAuthSDK.
+     * @param biometryType The type of biometric sensor.
+     * @param systemStatus The current system status of biometrics.
+     */
+    PowerAuthBiometricStatus(boolean biometricFactorConfigured,
+                             @BiometryType int biometryType,
+                             @BiometricStatus int systemStatus) {
+        this.authenticationWithBiometricsAvailable = biometricFactorConfigured && systemStatus == BiometricStatus.OK;
+        this.biometricFactorConfigured = biometricFactorConfigured;
+        this.systemStatus = systemStatus;
+        this.biometryType = biometryType;
+    }
+
+    /**
+     * Get information whether biometric authentication is fully available and you can call methods
+     * that accept a {@link PowerAuthAuthentication} object configured for biometrics. Note that
+     * this doesn't reflect state when the sensor is temporarily or permanently locked out. Such
+     * information is available only after you attempt to authenticate with biometrics.
+     * <p>
+     * The value is calculated as:
+     * <pre>
+     * isBiometricFactorConfigured && systemStatus == BiometricStatus.OK
+     * </pre>
+     * @return {@code true} if biometric authentication is fully available, {@code false} otherwise.
+     */
+    public boolean isAuthenticationWithBiometricsAvailable() {
+        return authenticationWithBiometricsAvailable;
+    }
+
+    /**
+     * Indicates whether the {@link PowerAuthSDK} instance has a biometric factor configured.
+     * If {@code false}, the user must first set up biometrics via the appropriate registration
+     * method.
+     * @return {@code true} if biometric factor is configured, {@code false} otherwise.
+     */
+    public boolean isBiometricFactorConfigured() {
+        return biometricFactorConfigured;
+    }
+
+    /**
+     * Get the current biometric authentication status reported by the system.
+     * @return The current biometric authentication status reported by the system.
+     */
+    @BiometricStatus
+    public int getSystemStatus() {
+        return systemStatus;
+    }
+
+    /**
+     * Get the type of biometric authentication available on the device (e.g. face, fingerprint, or
+     * iris).
+     * @return The type of biometric authentication available on the device.
+     */
+    @BiometryType
+    public int getBiometryType() {
+        return biometryType;
+    }
+}

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthSDK.java
@@ -2537,6 +2537,31 @@ public class PowerAuthSDK {
     }
 
     /**
+     * Get information whether biometric authentication is fully available and you can call methods
+     * that accept a {@link PowerAuthAuthentication} object configured for biometrics. Note that
+     * this doesn't reflect state when the sensor is temporarily or permanently locked out. Such
+     * information is available only after you attempt to authenticate with biometrics.
+     * @param context Android context.
+     * @return {@code true} if biometric authentication is fully available, {@code false} otherwise.
+     */
+    public boolean isAuthenticationWithBiometricsAvailable(@NonNull Context context) {
+        return getBiometricStatus(context).isAuthenticationWithBiometricsAvailable();
+    }
+
+    /**
+     * Get information about the current state of the biometry.
+     * @param context Android context.
+     * @return {@link PowerAuthBiometricStatus} containing information about the current state of biometry.
+     */
+    @NonNull
+    public PowerAuthBiometricStatus getBiometricStatus(@NonNull Context context) {
+        return new PowerAuthBiometricStatus(
+                hasBiometryFactor(context),
+                BiometricAuthentication.getBiometryType(context),
+                BiometricAuthentication.canAuthenticate(context));
+    }
+
+    /**
      * Check if the current PowerAuth instance has biometry factor in place.
      *
      * @param context Android context object

--- a/proj-xcode/PowerAuth2.xcodeproj/project.pbxproj
+++ b/proj-xcode/PowerAuth2.xcodeproj/project.pbxproj
@@ -342,6 +342,10 @@
 		BFC192AB27FC95A1001455C1 /* PA2TokenDataLock.h in Headers */ = {isa = PBXBuildFile; fileRef = BFC192A927FC951F001455C1 /* PA2TokenDataLock.h */; };
 		BFC8924C2E55DC1C009169A9 /* PowerAuthSDKDerivedTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BFC8924B2E55DC1C009169A9 /* PowerAuthSDKDerivedTests.m */; };
 		BFC8924D2E55DC1C009169A9 /* PowerAuthSDKDerivedTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BFC8924B2E55DC1C009169A9 /* PowerAuthSDKDerivedTests.m */; };
+		BFC9A73D2F60512B00BCC6F6 /* PowerAuthBiometricStatus.h in Headers */ = {isa = PBXBuildFile; fileRef = BFC9A73B2F60512B00BCC6F6 /* PowerAuthBiometricStatus.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BFC9A73E2F60512B00BCC6F6 /* PowerAuthBiometricStatus.m in Sources */ = {isa = PBXBuildFile; fileRef = BFC9A73C2F60512B00BCC6F6 /* PowerAuthBiometricStatus.m */; };
+		BFC9A73F2F60512B00BCC6F6 /* PowerAuthBiometricStatus.h in Headers */ = {isa = PBXBuildFile; fileRef = BFC9A73B2F60512B00BCC6F6 /* PowerAuthBiometricStatus.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BFC9A7402F60512B00BCC6F6 /* PowerAuthBiometricStatus.m in Sources */ = {isa = PBXBuildFile; fileRef = BFC9A73C2F60512B00BCC6F6 /* PowerAuthBiometricStatus.m */; };
 		BFCEE09C216E280600B41201 /* PA2GetActivationStatusTask.h in Headers */ = {isa = PBXBuildFile; fileRef = BFCEE09A216E280600B41201 /* PA2GetActivationStatusTask.h */; };
 		BFCEE09D216E280600B41201 /* PA2GetActivationStatusTask.m in Sources */ = {isa = PBXBuildFile; fileRef = BFCEE09B216E280600B41201 /* PA2GetActivationStatusTask.m */; };
 		BFD386621F2B528600F74FF9 /* TestConfig in Resources */ = {isa = PBXBuildFile; fileRef = BFD386611F2B528600F74FF9 /* TestConfig */; };
@@ -689,6 +693,8 @@
 		BFC192A927FC951F001455C1 /* PA2TokenDataLock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PA2TokenDataLock.h; sourceTree = "<group>"; };
 		BFC892492E55DAB8009169A9 /* PowerAuthSDKSharedBaseTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PowerAuthSDKSharedBaseTests.h; sourceTree = "<group>"; };
 		BFC8924B2E55DC1C009169A9 /* PowerAuthSDKDerivedTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PowerAuthSDKDerivedTests.m; sourceTree = "<group>"; };
+		BFC9A73B2F60512B00BCC6F6 /* PowerAuthBiometricStatus.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PowerAuthBiometricStatus.h; sourceTree = "<group>"; };
+		BFC9A73C2F60512B00BCC6F6 /* PowerAuthBiometricStatus.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PowerAuthBiometricStatus.m; sourceTree = "<group>"; };
 		BFCEE09A216E280600B41201 /* PA2GetActivationStatusTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PA2GetActivationStatusTask.h; sourceTree = "<group>"; };
 		BFCEE09B216E280600B41201 /* PA2GetActivationStatusTask.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PA2GetActivationStatusTask.m; sourceTree = "<group>"; };
 		BFD386611F2B528600F74FF9 /* TestConfig */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TestConfig; path = PowerAuth2IntegrationTests/TestConfig; sourceTree = SOURCE_ROOT; };
@@ -901,6 +907,8 @@
 				BFBFA71F2E96674800907B39 /* PowerAuthSignatureTypes.m */,
 				BFA3E5332ED4866A0076C624 /* PowerAuthPasswordChangeData.h */,
 				BFA3E5342ED4866A0076C624 /* PowerAuthPasswordChangeData.m */,
+				BFC9A73B2F60512B00BCC6F6 /* PowerAuthBiometricStatus.h */,
+				BFC9A73C2F60512B00BCC6F6 /* PowerAuthBiometricStatus.m */,
 			);
 			name = sdk;
 			sourceTree = "<group>";
@@ -1320,6 +1328,7 @@
 				BFA3E5412ED488570076C624 /* PowerAuthPasswordChangeData+Private.h in Headers */,
 				BF38903A2A97861100D7A18E /* PA2TimeSynchronizationService.h in Headers */,
 				BFFECE972636EC41001DA7A9 /* PowerAuthSessionStatusProvider.h in Headers */,
+				BFC9A73F2F60512B00BCC6F6 /* PowerAuthBiometricStatus.h in Headers */,
 				BFFECEB926383CF7001DA7A9 /* PowerAuthDeprecated.h in Headers */,
 				BFF6045C2D3FFCDC0053C3E6 /* PowerAuthBiometricConfiguration.h in Headers */,
 				BF5EB53124C85FE200F9DDB2 /* PowerAuthSDK.h in Headers */,
@@ -1344,6 +1353,7 @@
 				BFBFA7202E96674800907B39 /* PowerAuthSignatureTypes.h in Headers */,
 				BFFECF2526385BC8001DA7A9 /* PowerAuthActivationCode+Private.h in Headers */,
 				BF8CF4D62032EB41002A6B6E /* PowerAuthWCSessionManager.h in Headers */,
+				BFC9A73D2F60512B00BCC6F6 /* PowerAuthBiometricStatus.h in Headers */,
 				BF062BEB2E6B2692001436AD /* PA2CoreTaskWrapper.h in Headers */,
 				BF3890392A97861100D7A18E /* PA2TimeSynchronizationService.h in Headers */,
 				BF8CF4D82032EB41002A6B6E /* PowerAuthToken.h in Headers */,
@@ -1837,6 +1847,7 @@
 				BF28AA1A27EB1EDE00FBFCEB /* PA2SessionDataProvider.m in Sources */,
 				BF28AA2F27ECA34900FBFCEB /* PowerAuthExternalPendingOperation.m in Sources */,
 				BF5EB4C824C85FE200F9DDB2 /* PowerAuthBasicHttpAuthenticationRequestInterceptor.m in Sources */,
+				BFC9A7402F60512B00BCC6F6 /* PowerAuthBiometricStatus.m in Sources */,
 				BFBFA72F2E966C2300907B39 /* PowerAuthSecureVaultKey.m in Sources */,
 				BFF6045D2D3FFCDC0053C3E6 /* PowerAuthBiometricConfiguration.m in Sources */,
 				BF5EB4C924C85FE200F9DDB2 /* PowerAuthConfiguration.m in Sources */,
@@ -1977,6 +1988,7 @@
 				BF8CF4C32032EB41002A6B6E /* PowerAuthWCSessionManager_IOSServices.m in Sources */,
 				BFF6716C243376B0009279CA /* PowerAuthActivation.m in Sources */,
 				BF28C1AA29815D6900E2CD8E /* PowerAuthUserInfo.m in Sources */,
+				BFC9A73E2F60512B00BCC6F6 /* PowerAuthBiometricStatus.m in Sources */,
 				BF08251B2630514D00B34E24 /* PowerAuthErrorConstants.m in Sources */,
 				BF28AA1927EB1EDE00FBFCEB /* PA2SessionDataProvider.m in Sources */,
 				BF4BED352AA08D2D00A8A2D0 /* PA2CompositeTask.m in Sources */,

--- a/proj-xcode/PowerAuth2/PowerAuthBiometricStatus.h
+++ b/proj-xcode/PowerAuth2/PowerAuthBiometricStatus.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <PowerAuth2/PowerAuthKeychain.h>
+
+/// `PowerAuthBiometricStatus` represents the overall availability of biometric
+/// authentication in a `PowerAuthSDK` instance.
+@interface PowerAuthBiometricStatus : NSObject
+
+/// Default initialization is unavailable.
+- (nonnull instancetype) init NS_UNAVAILABLE;
+
+/// If `true`, biometric authentication is fully available and you can call methods
+/// that accept a `PowerAuthAuthentication` object configured for biometrics.
+///
+/// The value is calculated as:
+/// ```
+/// isBiometricFactorConfigured && biometricAuthenticationStatus == .available
+/// ```
+@property (nonatomic, readonly) BOOL isAuthenticationWithBiometricsAvailable;
+
+/// Indicates whether the `PowerAuthSDK` instance has a biometric factor configured.
+/// If `false`, the user must first set up biometrics via the appropriate registration method.
+@property (nonatomic, readonly) BOOL isBiometricFactorConfigured;
+
+/// The current biometric authentication status reported by the system.
+@property (nonatomic, readonly) PowerAuthBiometricAuthenticationStatus systemStatus;
+
+/// The type of biometric authentication available on the device (e.g. Face ID or Touch ID).
+@property (nonatomic, readonly) PowerAuthBiometricAuthenticationType biometryType;
+
+@end

--- a/proj-xcode/PowerAuth2/PowerAuthBiometricStatus.m
+++ b/proj-xcode/PowerAuth2/PowerAuthBiometricStatus.m
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "PowerAuthBiometricStatus.h"
+
+@implementation PowerAuthBiometricStatus
+
+- (instancetype) initWithBiometricInfo:(PowerAuthBiometricAuthenticationInfo)biometricInfo
+                             factorSet:(BOOL)factorSet
+{
+    self = [super init];
+    if (self) {
+        BOOL statusAvailable = biometricInfo.currentStatus == PowerAuthBiometricAuthenticationStatus_Available;
+        _systemStatus = biometricInfo.currentStatus;
+        _biometryType = biometricInfo.biometryType;
+        _isBiometricFactorConfigured = factorSet;
+        _isAuthenticationWithBiometricsAvailable = factorSet && statusAvailable;
+    }
+    return self;
+}
+
+@end

--- a/proj-xcode/PowerAuth2/PowerAuthSDK.h
+++ b/proj-xcode/PowerAuth2/PowerAuthSDK.h
@@ -23,6 +23,7 @@
 #import <PowerAuth2/PowerAuthClientConfiguration.h>
 #import <PowerAuth2/PowerAuthBiometricConfiguration.h>
 #import <PowerAuth2/PowerAuthKeychainConfiguration.h>
+#import <PowerAuth2/PowerAuthBiometricStatus.h>
 #import <PowerAuth2/PowerAuthToken.h>
 #import <PowerAuth2/PowerAuthToken+WatchSupport.h>
 #import <PowerAuth2/PowerAuthHttpHeader.h>
@@ -714,6 +715,13 @@
                             PA2_DEPRECATED(2.0.0);
 
 // Biometry key management
+
+/// If `true`, biometric authentication is fully available and you can call methods
+/// that accept a `PowerAuthAuthentication` object configured for biometrics.
+@property (nonatomic, readonly) BOOL isAuthenticationWithBiometricsAvailable;
+
+/// Contains information about the current state of the biometry.
+@property (nonatomic, strong, readonly, nonnull) PowerAuthBiometricStatus * biometricStatus;
 
 /** Regenerate a biometry related factor key.
  

--- a/proj-xcode/PowerAuth2/PowerAuthSDK.m
+++ b/proj-xcode/PowerAuth2/PowerAuthSDK.m
@@ -1404,6 +1404,17 @@ static PowerAuthSDK * s_inst;
 
 #pragma mark - Biometry
 
+- (BOOL) isAuthenticationWithBiometricsAvailable
+{
+    return self.biometricStatus.isAuthenticationWithBiometricsAvailable;
+}
+
+- (PowerAuthBiometricStatus*) biometricStatus
+{
+    PowerAuthBiometricAuthenticationInfo info = [PowerAuthKeychain biometricAuthenticationInfo];
+    return [[PowerAuthBiometricStatus alloc] initWithBiometricInfo:info factorSet:self.hasBiometryFactor];
+}
+
 - (id<PowerAuthOperationTask>) addBiometryFactorWithCorePassword:(PowerAuthCorePassword*)password
                                                         callback:(void(^)(NSError *error))callback
 {

--- a/proj-xcode/PowerAuth2/private/PowerAuthSDK+Private.h
+++ b/proj-xcode/PowerAuth2/private/PowerAuthSDK+Private.h
@@ -80,3 +80,8 @@
 @interface PowerAuthDevicePublicKeyData (Private)
 - (instancetype) initWithCoreDevicePublicKeyData:(PowerAuthCoreDevicePublicKeyData*)keyData;
 @end
+
+@interface PowerAuthBiometricStatus (Private)
+- (instancetype) initWithBiometricInfo:(PowerAuthBiometricAuthenticationInfo)biometricInfo
+                             factorSet:(BOOL)factorSet;
+@end

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKBaseTests.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKBaseTests.m
@@ -1305,7 +1305,7 @@
         return;
     }
     PowerAuthActivationStatus * status = [_helper fetchActivationStatus];
-    XCTAssertTrue([_sdk hasBiometryFactor]);
+    XCTAssertTrue(_sdk.isAuthenticationWithBiometricsAvailable);
     
     // Try to remove biometric factor, but the response is never received from the server.
     // The situation is that server has biometric factor removed, but client still has biometry turned ON
@@ -1319,11 +1319,11 @@
     // error is received
     XCTAssertNotNil(error);
     // outcome is that biometric factor is still ON
-    XCTAssertTrue([_sdk hasBiometryFactor]);
+    XCTAssertTrue(_sdk.isAuthenticationWithBiometricsAvailable);
     
     // Now try to fetch activation status. The operation silently remove the factor from local data and the keychain
     status = [_helper fetchActivationStatus];
-    XCTAssertFalse([_sdk hasBiometryFactor]);
+    XCTAssertFalse(_sdk.isAuthenticationWithBiometricsAvailable);
     
     // Now try to add biometric factor. If response from the server is never received, then the server thinks the factor is ON, but local data
     // has no factor set.
@@ -1353,7 +1353,7 @@
     // In the next attempt, everything should work and the biometric factor should be removed from the server.
     status = [_helper fetchActivationStatus];
     XCTAssertNotNil(status);
-    XCTAssertFalse([_sdk hasBiometryFactor]);
+    XCTAssertFalse(_sdk.isAuthenticationWithBiometricsAvailable);
     
     // In next attempt, remove is not called.
     [self simulateNetworkErrorOnSend:@"/pa/v4/biometry/remove"];
@@ -1387,6 +1387,45 @@
     PowerAuthHttpHeader * header = [_sdk authenticationHeaderForRequestWithBodyWithAuthentication:authentication method:@"POST" uriId:@"/some/uri/id" body:[NSData data] error:&error];
     XCTAssertNil(header);
     XCTAssertEqual(PowerAuthErrorCode_BiometryFailed, error.powerAuthErrorCode);
+}
+
+- (void) testBiometricStatus
+{
+    CHECK_TEST_CONFIG();
+    CHECK_BIOMETRY();
+    
+    PowerAuthBiometricStatus * biometricStatus = _sdk.biometricStatus;
+    XCTAssertEqual(PowerAuthKeychain.biometricAuthenticationInfo.currentStatus, biometricStatus.systemStatus);
+    XCTAssertEqual(PowerAuthKeychain.biometricAuthenticationInfo.biometryType, biometricStatus.biometryType);
+    XCTAssertFalse(biometricStatus.isAuthenticationWithBiometricsAvailable);
+    XCTAssertFalse(biometricStatus.isBiometricFactorConfigured);
+    XCTAssertFalse(_sdk.isAuthenticationWithBiometricsAvailable);
+    
+    PowerAuthSdkActivation * activation = [_helper createActivationWithFlags:TestActivationFlags_PersistWithBiometry activationOtp:nil];
+    if (!activation) {
+        return;
+    }
+    
+    biometricStatus = _sdk.biometricStatus;
+    XCTAssertEqual(PowerAuthKeychain.biometricAuthenticationInfo.currentStatus, biometricStatus.systemStatus);
+    XCTAssertEqual(PowerAuthKeychain.biometricAuthenticationInfo.biometryType, biometricStatus.biometryType);
+    XCTAssertTrue(biometricStatus.isAuthenticationWithBiometricsAvailable);
+    XCTAssertTrue(biometricStatus.isBiometricFactorConfigured);
+    XCTAssertTrue(_sdk.isAuthenticationWithBiometricsAvailable);
+    
+    NSError * failure = [AsyncHelper synchronizeAsynchronousBlock:^(AsyncHelper *waiting) {
+        [_sdk removeBiometryFactorWithCallback:^(NSError * _Nullable error) {
+            [waiting reportCompletion:error];
+        }];
+    }];
+    XCTAssertNil(failure);
+    
+    biometricStatus = _sdk.biometricStatus;
+    XCTAssertEqual(PowerAuthKeychain.biometricAuthenticationInfo.currentStatus, biometricStatus.systemStatus);
+    XCTAssertEqual(PowerAuthKeychain.biometricAuthenticationInfo.biometryType, biometricStatus.biometryType);
+    XCTAssertFalse(biometricStatus.isAuthenticationWithBiometricsAvailable);
+    XCTAssertFalse(biometricStatus.isBiometricFactorConfigured);
+    XCTAssertFalse(_sdk.isAuthenticationWithBiometricsAvailable);
 }
 
 #endif // PA2_BIOMETRY_SUPPORT


### PR DESCRIPTION
This PR simplifies determining the state of biometric authentication on both platforms:

- Added new `PowerAuthBiometricStatus` object
- Added a simplified check whether biometric authentication is available at the system and at the activation level

Other changes:

- Added temporary folders used by claude.ai to `.gitignore`
- Fixed headers level in Changelog.md