### PR TITLE
Send current algorithm and protocol version to watchOS.

### DIFF
--- a/proj-xcode/PowerAuth2/PowerAuthErrorConstants.m
+++ b/proj-xcode/PowerAuth2/PowerAuthErrorConstants.m
@@ -132,6 +132,15 @@ NSError * PA2MakeError(NSInteger errorCode, NSString * message)
     return [NSError errorWithDomain:PowerAuthErrorDomain code:errorCode userInfo:info];
 }
 
+NSError * PA2MakeErrorWithReason(PowerAuthErrorCode errorCode, NSString * message, NSError * reason)
+{
+    NSDictionary * info = @{
+        NSLocalizedDescriptionKey: PA2MakeDefaultErrorDescription(errorCode, message),
+        NSUnderlyingErrorKey: reason
+    };
+    return [NSError errorWithDomain:PowerAuthErrorDomain code:errorCode userInfo:info];
+}
+
 NSError * PA2MakeErrorInfo(NSInteger errorCode, NSString * message, NSDictionary * info)
 {
     NSMutableDictionary * mutableInfo = info ? [info mutableCopy] : [NSMutableDictionary dictionary];

--- a/proj-xcode/PowerAuth2/PowerAuthErrorConstants.m
+++ b/proj-xcode/PowerAuth2/PowerAuthErrorConstants.m
@@ -45,7 +45,7 @@ NSString * PA2MakeDefaultErrorDescription(NSInteger errorCode, NSString * messag
         _CODE_DESC(PowerAuthErrorCode_ActivationPending, @"Pending activation")
         _CODE_DESC(PowerAuthErrorCode_BiometryNotAvailable, @"Biometry is not supported or is unavailable")
         _CODE_DESC(PowerAuthErrorCode_BiometryCancel, @"User did cancel biometry authentication dialog")
-        _CODE_DESC(PowerAuthErrorCode_BiometryFallback, @"Used did press fallback at biometry authentication dialog")
+        _CODE_DESC(PowerAuthErrorCode_BiometryFallback, @"User did press fallback at biometry authentication dialog")
         _CODE_DESC(PowerAuthErrorCode_BiometryFailed, @"Biometry authentication failed")
         _CODE_DESC(PowerAuthErrorCode_OperationCancelled, @"Operation was cancelled by SDK")
         _CODE_DESC(PowerAuthErrorCode_Encryption, @"General encryption failure")

--- a/proj-xcode/PowerAuth2/PowerAuthSDK+WatchSupport.m
+++ b/proj-xcode/PowerAuth2/PowerAuthSDK+WatchSupport.m
@@ -32,13 +32,73 @@
 
 @implementation PowerAuthSDK (WatchSupport)
 
+/// Convert `PowerAuthCoreAlgorithm` enumeration value into string representation.
+/// - Parameter algorithm: Algorithm to convert to the string representation.
+/// - Returns: String representation of selected algorithm, or `nil` in case the algorithm is not supported.
+static NSString * _AlgorithmToString(PowerAuthCoreAlgorithm algorithm)
+{
+    switch (algorithm) {
+        case PowerAuthCoreAlgorithm_EC_P384:
+            return @"EC_P384";
+        case PowerAuthCoreAlgorithm_EC_P384_ML_L3:
+            return @"EC_P384_ML_L3";
+        case PowerAuthCoreAlgorithm_EC_P384_ML_L5:
+            return @"EC_P384_ML_L5";
+        case PowerAuthCoreAlgorithm_LEGACY_P256:
+            return @"LEGACY_P256";
+        default:
+            return nil;
+    }
+}
+
+/// Convert `PowerAuthCoreAlgorithm` enumeration into the current string representation
+/// of the protocol version.
+/// - Parameter algorithm: Algorithm to convert to the protocol version.
+/// - Returns: Protocol version or `nil` in case the algorithm is not supported.
+static NSString * _AlgorithmToProtocolVersion(PowerAuthCoreAlgorithm algorithm)
+{
+    switch (algorithm) {
+        case PowerAuthCoreAlgorithm_EC_P384_ML_L3:
+        case PowerAuthCoreAlgorithm_EC_P384_ML_L5:
+        case PowerAuthCoreAlgorithm_EC_P384:
+            return [PowerAuthCoreSession maxSupportedHttpProtocolVersion:PowerAuthCoreProtocolVersion_V4];
+        case PowerAuthCoreAlgorithm_LEGACY_P256:
+            return [PowerAuthCoreSession maxSupportedHttpProtocolVersion:PowerAuthCoreProtocolVersion_V3];
+        default:
+            return nil;
+    }
+}
+
 - (PA2WCSessionPacket*) prepareActivationStatusPacket
 {
-    NSString * activationIdentifier = self.sessionProvider.activationIdentifier;
     NSString * instanceIdentifier   = self.privateInstanceId;
-    
     if (!instanceIdentifier) {
         PowerAuthLog(@"PowerAuthSDK instance is not properly configured. PowerAuthConfiguration has no instanceId.");
+        return nil;
+    }
+    
+    // Extract both activation ID and the current algorithm in one locked block.
+    NSArray * sessionInfo = [self.sessionProvider readTaskWithSession:^NSArray* (PowerAuthCoreSession * session, NSError ** error) {
+        NSString * activationId = session.activationIdentifier;
+        NSNumber * algorithm = @(session.currentAlgorithm);
+        return activationId
+                ? @[ algorithm, activationId ]
+                : @[ algorithm ];
+    } error:nil];
+    if (!sessionInfo) {
+        // Lock failed
+        PowerAuthLog(@"PowerAuthSDK WatchConnectivity failed to acquire state of activation");
+        return nil;
+    }
+    
+    PowerAuthCoreAlgorithm algorithm = [sessionInfo[0] intValue];
+    BOOL hasActivation = sessionInfo.count > 1;
+    NSString * activationIdentifier = hasActivation ? sessionInfo[1] : nil;
+    NSString * powerAuthAlgorithm   = hasActivation ? _AlgorithmToString(algorithm) : nil;
+    NSString * powerAuthProtocol    = hasActivation ? _AlgorithmToProtocolVersion(algorithm) : nil;
+    
+    if (hasActivation && (!powerAuthAlgorithm || !powerAuthProtocol)) {
+        PowerAuthLog(@"PowerAuthSDK WatchConnectivity doesn't support PowerAuth algorithm %@", @(algorithm));
         return nil;
     }
     
@@ -46,6 +106,8 @@
 
     PA2WCSessionPacket_ActivationStatus * statusData = [[PA2WCSessionPacket_ActivationStatus alloc] init];
     statusData.activationId = activationIdentifier;
+    statusData.algorithm = powerAuthAlgorithm;
+    statusData.protocolVersion = powerAuthProtocol;
     statusData.command = PA2WCSessionPacket_CMD_SESSION_PUT;
     return [PA2WCSessionPacket packetWithData:statusData target:target];
 }

--- a/proj-xcode/PowerAuth2/PowerAuthSDK+WatchSupport.m
+++ b/proj-xcode/PowerAuth2/PowerAuthSDK+WatchSupport.m
@@ -69,25 +69,22 @@ static NSString * _AlgorithmToProtocolVersion(PowerAuthCoreAlgorithm algorithm)
     }
 }
 
-- (PA2WCSessionPacket*) prepareActivationStatusPacket
+- (PA2WCSessionPacket*) prepareActivationStatusPacket:(NSError**)error
 {
+    // Get instance identifier. It's always non-empty, due to validations in PowerAuthSDK object construction.
     NSString * instanceIdentifier   = self.privateInstanceId;
-    if (!instanceIdentifier) {
-        PowerAuthLog(@"PowerAuthSDK instance is not properly configured. PowerAuthConfiguration has no instanceId.");
-        return nil;
-    }
     
     // Extract both activation ID and the current algorithm in one locked block.
+    NSError * localError = nil;
     NSArray * sessionInfo = [self.sessionProvider readTaskWithSession:^NSArray* (PowerAuthCoreSession * session, NSError ** error) {
         NSString * activationId = session.activationIdentifier;
         NSNumber * algorithm = @(session.currentAlgorithm);
         return activationId
                 ? @[ algorithm, activationId ]
                 : @[ algorithm ];
-    } error:nil];
-    if (!sessionInfo) {
-        // Lock failed
-        PowerAuthLog(@"PowerAuthSDK WatchConnectivity failed to acquire state of activation");
+    } error:&localError];
+    if (localError) {
+        PA2SetErrorWithReason(error, PowerAuthErrorCode_WatchConnectivity, @"Failed to acquire lock to access the session data", localError);
         return nil;
     }
     
@@ -98,7 +95,9 @@ static NSString * _AlgorithmToProtocolVersion(PowerAuthCoreAlgorithm algorithm)
     NSString * powerAuthProtocol    = hasActivation ? _AlgorithmToProtocolVersion(algorithm) : nil;
     
     if (hasActivation && (!powerAuthAlgorithm || !powerAuthProtocol)) {
-        PowerAuthLog(@"PowerAuthSDK WatchConnectivity doesn't support PowerAuth algorithm %@", @(algorithm));
+        // Internal error, please update enum conversion routines.
+        NSString * message = [NSString stringWithFormat:@"PowerAuthSDK WatchConnectivity doesn't support PowerAuth algorithm %@", @(algorithm)];
+        PA2SetError(error, PowerAuthErrorCode_Other, message);
         return nil;
     }
     
@@ -119,8 +118,10 @@ static NSString * _AlgorithmToProtocolVersion(PowerAuthCoreAlgorithm algorithm)
     if (manager.validSession == nil) {
         return NO;
     }
-    PA2WCSessionPacket * packet = [self prepareActivationStatusPacket];
+    NSError * localError = nil;
+    PA2WCSessionPacket * packet = [self prepareActivationStatusPacket:&localError];
     if (!packet) {
+        PowerAuthLog(@"PowerAuthSDK WatchConnectivity failed to prepare packet: %@", localError);
         return NO;
     }
     [manager sendPacket:packet];
@@ -130,7 +131,8 @@ static NSString * _AlgorithmToProtocolVersion(PowerAuthCoreAlgorithm algorithm)
 
 - (void) sendActivationStatusToWatchWithCompletion:(void(^ _Nonnull)(NSError * _Nullable error))completion
 {
-    PA2WCSessionPacket * packet = [self prepareActivationStatusPacket];
+    NSError * localError = nil;
+    PA2WCSessionPacket * packet = [self prepareActivationStatusPacket:&localError];
     if (packet) {
         [[PowerAuthWCSessionManager sharedInstance] sendPacketWithResponse:packet responseClass:[PA2WCSessionPacket_Success class] completion:^(PA2WCSessionPacket *response, NSError *error) {
             if (completion) {
@@ -142,7 +144,7 @@ static NSString * _AlgorithmToProtocolVersion(PowerAuthCoreAlgorithm algorithm)
     } else {
         if (completion) {
             dispatch_async(dispatch_get_main_queue(), ^{
-                completion(PA2MakeError(PowerAuthErrorCode_WatchConnectivity,  @"PowerAuthSDK instance is not properly configured. PowerAuthConfiguration has no instanceId."));
+                completion(localError);
             });
         }
     }
@@ -199,7 +201,7 @@ static NSString * _AlgorithmToProtocolVersion(PowerAuthCoreAlgorithm algorithm)
 
 - (PA2WCSessionPacket*) processStatusResponse:(PA2WCSessionPacket*)packet
 {
-    NSString * errorMessage = nil;
+    NSError * localError = nil;
     PA2WCSessionPacket * response = nil;
     do {
         // Deserialize payload & instanceId
@@ -209,28 +211,32 @@ static NSString * _AlgorithmToProtocolVersion(PowerAuthCoreAlgorithm algorithm)
             NSString * command = status.command;
             if ([command isEqualToString:PA2WCSessionPacket_CMD_SESSION_GET]) {
                 // watch App requesting status of this object.
-                response = [self prepareActivationStatusPacket];
-                if (!packet.requestWithoutReplyHandler) {
-                    // Reply handler is present. The target should be modified.
-                    response.target = PA2WCSessionPacket_RESPONSE_TARGET;
-                } else {
-                    // Getting status without response handler. The target is already
-                    // valid from 'prepareActivationStatusPacket' method, so just send
-                    // that response back to watch.
-                    response.sendLazyResponseIfPossible = YES;
+                response = [self prepareActivationStatusPacket:&localError];
+                if (response) {
+                    if (!packet.requestWithoutReplyHandler) {
+                        // Reply handler is present. The target should be modified.
+                        response.target = PA2WCSessionPacket_RESPONSE_TARGET;
+                    } else {
+                        // Getting status without response handler. The target is already
+                        // valid from 'prepareActivationStatusPacket' method, so just send
+                        // that response back to watch.
+                        response.sendLazyResponseIfPossible = YES;
+                    }
                 }
                 //
             } else {
-                errorMessage = [NSString stringWithFormat:@"PowerAuthSDK+WatchSupport: Unsupported command '%@'. Target: %@", command, packet.target];
+                NSString * message = [NSString stringWithFormat:@"PowerAuthSDK+WatchSupport: Unsupported command '%@'. Target: %@", command, packet.target];
+                localError = PA2MakeError(PowerAuthErrorCode_WatchConnectivity, message);
             }
         } else {
-            errorMessage = [NSString stringWithFormat:@"PowerAuthSDK+WatchSupport: Received packet has invalid data. Target: %@", packet.target];
+            NSString * message = [NSString stringWithFormat:@"PowerAuthSDK+WatchSupport: Received packet has invalid data. Target: %@", packet.target];
+            localError = PA2MakeError(PowerAuthErrorCode_WatchConnectivity, message);
         }
     } while (false);
     
-    if (errorMessage) {
+    if (localError) {
         // Reply packet with error.
-        response = [PA2WCSessionPacket packetWithError:PA2MakeError(PowerAuthErrorCode_WatchConnectivity, errorMessage)];
+        response = [PA2WCSessionPacket packetWithError:localError];
     }
     return response;
 }

--- a/proj-xcode/PowerAuth2/PowerAuthWCSessionManager.h
+++ b/proj-xcode/PowerAuth2/PowerAuthWCSessionManager.h
@@ -49,7 +49,7 @@
  Processes a received message data and returns YES if message has been consumed (e.g. PowerAuth
  is the data recipient), NO otherwise. If YES is returned and the replyHandler is available, then the handler
  is called with a valid reply data. The replyHandler nullability must match behavior of the message. That means
- that if WCSessionDelegate method is called with a valid reply handler (e.g. counterpart is expecing response),
+ that if WCSessionDelegate method is called with a valid reply handler (e.g. counterpart is expecting response),
  then you have to always provide the reply handler to this method.
  */
 - (BOOL) processReceivedMessageData:(nonnull NSData *)data

--- a/proj-xcode/PowerAuth2/PowerAuthWCSessionManager.m
+++ b/proj-xcode/PowerAuth2/PowerAuthWCSessionManager.m
@@ -30,18 +30,6 @@
 #import "PA2WCSessionPacket.h"
 #import "PA2WeakArray.h"
 
-// Unguarded availability warning
-//
-// PA2WCSessionManager is correctly handling existence of WCSession on the system,
-// but it's difficult to wrap all parts of the code to silent the warning.
-// Currently, 'sendImpl' is the most problematic part of the code, so check
-// that method for details (there's comment at the beginning of the method)
-//
-// For future, we need to increase minimum supported version to iOS9.0
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunguarded-availability"
-
 @implementation PowerAuthWCSessionManager
 {
     dispatch_semaphore_t _lock;
@@ -128,8 +116,10 @@ static void _synchronizedVoid(PowerAuthWCSessionManager  * obj, void(^block)(voi
 
 #pragma mark - Helper functions
 
-static const unsigned char  _HeaderMagic[] = { 'P', 'A', 'w', 'c', '1' };
-#define _HeaderSize sizeof(_HeaderMagic)
+static const char  _HeaderMagic[] = { 'P', 'A', 'w', 'c' };
+static const char  _HeaderVersion = '2';
+#define _MagicSize   sizeof(_HeaderMagic)
+#define _HeaderSize  (_MagicSize + 1)
 
 static PA2WCSessionPacket * _DeserializePacket(NSData * data, Class payloadClass, BOOL *unknownData)
 {
@@ -139,9 +129,19 @@ static PA2WCSessionPacket * _DeserializePacket(NSData * data, Class payloadClass
         return nil;
     }
     // ... and the magic constant at the beginning
-    if (memcmp(data.bytes, _HeaderMagic, _HeaderSize)) {
+    const char * dataBytes = data.bytes;
+    if (memcmp(dataBytes, _HeaderMagic, _MagicSize)) {
         *unknownData = YES;
         return nil;
+    }
+    
+    // Compare versions
+    if (dataBytes[_MagicSize] != _HeaderVersion) {
+        // Reply with a special packet with identical version as we received. This guarantees that another side is able to process this error.
+        NSString * message = @"PA2WCSessionManager: PowerAuth Mobile SDK and Watch SDK are not compatible.";
+        PA2WCSessionPacket * packet = [PA2WCSessionPacket packetWithError:PA2MakeError(PowerAuthErrorCode_WatchConnectivity, message)];
+        packet.customPacketVersion = dataBytes[_MagicSize];
+        return packet;
     }
     
     // ... and if the rest of data contains valid JSON
@@ -182,8 +182,14 @@ static NSData * _SerializePacket(PA2WCSessionPacket * packet)
         PowerAuthLog(@"PA2WCSessionManager: Cannon serialize packet to JSON.");
         return nil;
     }
+    // Prepare the packet version. If not set, then use the default version.
+    char packetVersion = packet.customPacketVersion;
+    if (!packetVersion) {
+        packetVersion = _HeaderVersion;
+    }
     NSMutableData * data = [NSMutableData dataWithCapacity:_HeaderSize + JSONData.length];
-    [data appendBytes:_HeaderMagic length:_HeaderSize];
+    [data appendBytes:_HeaderMagic length:_MagicSize];
+    [data appendBytes:&packetVersion length:1];
     [data appendData:JSONData];
     return data;
 }
@@ -212,7 +218,7 @@ static NSData * _SerializePacket(PA2WCSessionPacket * packet)
         //
         NSString * target = packet.target;
         if ([target isEqualToString:PA2WCSessionPacket_RESPONSE_TARGET]) {
-            errorMessage = @"PA2WCSessionManager: Requests with reponse target are not allowed.";
+            errorMessage = @"PA2WCSessionManager: Requests with response target are not allowed.";
             break;
         }
         // Look for handler
@@ -491,8 +497,6 @@ static WCSession * _ValidateSession(WCSession * session)
 }
 
 #endif // !defined(PA2_WATCH_SDK)
-
-#pragma clang diagnostic pop    // pop "-Wunguarded-availability"
 
 // -----------------------------------------------------------------------
 #endif // defined(PA2_WATCH_SUPPORT)

--- a/proj-xcode/PowerAuth2/PowerAuthWCSessionManager.m
+++ b/proj-xcode/PowerAuth2/PowerAuthWCSessionManager.m
@@ -135,6 +135,9 @@ static PA2WCSessionPacket * _DeserializePacket(NSData * data, Class payloadClass
         return nil;
     }
     
+    // We can process the response after this point.
+    *unknownData = NO;
+    
     // Compare versions
     if (dataBytes[_MagicSize] != _HeaderVersion) {
         // Reply with a special packet with identical version as we received. This guarantees that another side is able to process this error.
@@ -144,30 +147,34 @@ static PA2WCSessionPacket * _DeserializePacket(NSData * data, Class payloadClass
         return packet;
     }
     
-    // ... and if the rest of data contains valid JSON
-    *unknownData = NO;
-    NSData * JSONData = [data subdataWithRange:NSMakeRange(_HeaderSize, data.length - _HeaderSize)];
-    NSDictionary * JSON = PA2ObjectAs([NSJSONSerialization JSONObjectWithData:JSONData options:0 error:NULL], NSDictionary);
-    if (!JSON) {
-        return nil;
+    // ... the rest of data should contains valid JSON
+    NSData * jsonData = [data subdataWithRange:NSMakeRange(_HeaderSize, data.length - _HeaderSize)];
+    NSError * error = nil;
+    NSDictionary * root = PA2ObjectAs([NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error], NSDictionary);
+    if (!root) {
+        return [PA2WCSessionPacket packetWithError:PA2MakeError(PowerAuthErrorCode_WatchConnectivity, @"PA2WCSessionManager: Invalid payload. Failed to deserialize JSON.")];
     }
-    PA2WCSessionPacket * packet = [[PA2WCSessionPacket alloc] initWithDictionary:JSON];
-    if (packet && payloadClass != Nil && !packet.error) {
-        // Process payload only when class is known and there's no error in the packet.
-        if ([payloadClass conformsToProtocol:@protocol(PA2WCSessionPacketData)]) {
-            id<PA2WCSessionPacketData> payload = [[payloadClass alloc] initWithDictionary:JSON];
-            if ([payload validatePacketData]) {
-                packet.payload = payload;
+    // Construct packet to further investigation
+    PA2WCSessionPacket * packet = [[PA2WCSessionPacket alloc] initWithDictionary:root];
+    if (packet) {
+        if (payloadClass != Nil && !packet.error) {
+            // Process payload only when class is known and there's no error in the packet.
+            if ([payloadClass conformsToProtocol:@protocol(PA2WCSessionPacketData)]) {
+                id<PA2WCSessionPacketData> payload = [[payloadClass alloc] initWithDictionary:root];
+                if ([payload validatePacketData]) {
+                    packet.payload = payload;
+                } else {
+                    NSString * message = [NSString stringWithFormat:@"PA2WCSessionManager: Invalid payload. %@ class is expected.", NSStringFromClass(payloadClass)];
+                    error = PA2MakeError(PowerAuthErrorCode_WatchConnectivity, message);
+                }
             } else {
-                NSString * message = [NSString stringWithFormat:@"PA2WCSessionManager: Invalid payload. %@ class is expected.", NSStringFromClass(payloadClass)];
-                packet = [PA2WCSessionPacket packetWithError:PA2MakeError(PowerAuthErrorCode_WatchConnectivity, message)];
+                error = PA2MakeError(PowerAuthErrorCode_WatchConnectivity, @"PA2WCSessionManager: Invalid class provided for payload response.");
             }
-        } else {
-            NSString * message = @"PA2WCSessionManager: Invalid class provided for payload response.";
-            packet = [PA2WCSessionPacket packetWithError:PA2MakeError(PowerAuthErrorCode_WatchConnectivity, message)];
         }
+    } else {
+        error = PA2MakeError(PowerAuthErrorCode_WatchConnectivity, @"PA2WCSessionManager: Invalid packet received.");
     }
-    return packet;
+    return !error ? packet : [PA2WCSessionPacket packetWithError:error];
 }
 
 static NSData * _SerializePacket(PA2WCSessionPacket * packet)

--- a/proj-xcode/PowerAuth2/PowerAuthWCSessionManager.m
+++ b/proj-xcode/PowerAuth2/PowerAuthWCSessionManager.m
@@ -121,26 +121,26 @@ static const char  _HeaderVersion = '2';
 #define _MagicSize   sizeof(_HeaderMagic)
 #define _HeaderSize  (_MagicSize + 1)
 
-static PA2WCSessionPacket * _DeserializePacket(NSData * data, Class payloadClass, BOOL *unknownData)
+static PA2WCSessionPacket * _DeserializePacket(NSData * data, Class payloadClass, BOOL* failure)
 {
     // Validate minimal length of data
     if (data.length < _HeaderSize + 12) {
-        *unknownData = YES;
+        *failure = NO;
         return nil;
     }
     // ... and the magic constant at the beginning
     const char * dataBytes = data.bytes;
     if (memcmp(dataBytes, _HeaderMagic, _MagicSize)) {
-        *unknownData = YES;
+        *failure = NO;
         return nil;
     }
     
     // We can process the response after this point.
-    *unknownData = NO;
     
     // Compare versions
     if (dataBytes[_MagicSize] != _HeaderVersion) {
         // Reply with a special packet with identical version as we received. This guarantees that another side is able to process this error.
+        *failure = YES;
         NSString * message = @"PA2WCSessionManager: PowerAuth Mobile SDK and Watch SDK are not compatible.";
         PA2WCSessionPacket * packet = [PA2WCSessionPacket packetWithError:PA2MakeError(PowerAuthErrorCode_WatchConnectivity, message)];
         packet.customPacketVersion = dataBytes[_MagicSize];
@@ -152,6 +152,7 @@ static PA2WCSessionPacket * _DeserializePacket(NSData * data, Class payloadClass
     NSError * error = nil;
     NSDictionary * root = PA2ObjectAs([NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error], NSDictionary);
     if (!root) {
+        *failure = YES;
         return [PA2WCSessionPacket packetWithError:PA2MakeError(PowerAuthErrorCode_WatchConnectivity, @"PA2WCSessionManager: Invalid payload. Failed to deserialize JSON.")];
     }
     // Construct packet to further investigation
@@ -174,7 +175,12 @@ static PA2WCSessionPacket * _DeserializePacket(NSData * data, Class payloadClass
     } else {
         error = PA2MakeError(PowerAuthErrorCode_WatchConnectivity, @"PA2WCSessionManager: Invalid packet received.");
     }
-    return !error ? packet : [PA2WCSessionPacket packetWithError:error];
+    if (error) {
+        *failure = YES;
+        return [PA2WCSessionPacket packetWithError:error];
+    }
+    *failure = NO;
+    return packet;
 }
 
 static NSData * _SerializePacket(PA2WCSessionPacket * packet)
@@ -210,16 +216,16 @@ static NSData * _SerializePacket(PA2WCSessionPacket * packet)
     PA2WCSessionPacket * response = nil;
     NSString * errorMessage = nil;
     do {
-        BOOL unknownData;
-        PA2WCSessionPacket * packet = _DeserializePacket(data, Nil, &unknownData);
+        BOOL failure;
+        PA2WCSessionPacket * packet = _DeserializePacket(data, Nil, &failure);
         if (!packet) {
-            if (unknownData) {
-                // Quick return, we don't understand this data
-                return NO;
-            }
-            // Data looks targetting us, but cannot be decoded.
-            // Check whether PowerAuth2 & PowerAuth2ForWatch versions match.
-            errorMessage = @"PA2WCSessionManager: Wrong packet received.";
+            // Quick return, we don't understand this data
+            return NO;
+        }
+        if (failure) {
+            // Incoming packet processing raised an error. This is already the response.
+            response = packet;
+            errorMessage = response.error.localizedDescription;
             break;
         }
         //
@@ -334,15 +340,6 @@ static NSData * _SerializePacket(PA2WCSessionPacket * packet)
     [self sendImpl:packet withResponse:YES responseClass:responseClass completion:completion];
 }
 
-
-// Unguarded availability warning
-//
-// We're targetting SDK to 8.0+, so it's expected that compiler will scream about
-// usage of WCSession, which is available sice 9.0. The problematic part of code
-// begins when we acquire WCSession from self.validSession but we can ignore that,
-// because that property already checks whether the session is available on the
-// current system.
-
 - (void) sendImpl:(PA2WCSessionPacket*)request
      withResponse:(BOOL)withResponse
     responseClass:(Class)responseClass
@@ -389,15 +386,11 @@ static NSData * _SerializePacket(PA2WCSessionPacket * packet)
         if (sessionIsReachable) {
             [session sendMessageData:requestData replyHandler:^(NSData * replyMessageData) {
                 //
-                BOOL unknownData = YES;
-                PA2WCSessionPacket * responsePacket = _DeserializePacket(replyMessageData, responseClass, &unknownData);
+                BOOL failure;
+                PA2WCSessionPacket * responsePacket = _DeserializePacket(replyMessageData, responseClass, &failure);
                 NSError * responseError = responsePacket.error;
                 if (!responsePacket) {
-                    if (unknownData) {
-                        responseError = PA2MakeError(PowerAuthErrorCode_WatchConnectivity, @"PA2WCSessionManager: Received response is in unknown data format.");
-                    } else {
-                        responseError = PA2MakeError(PowerAuthErrorCode_WatchConnectivity, @"PA2WCSessionManager: Cannot process received response.");
-                    }
+                    responseError = PA2MakeError(PowerAuthErrorCode_WatchConnectivity, @"PA2WCSessionManager: Received response is in unknown data format.");
                 }
                 if (responseError) {
                     responsePacket = nil;

--- a/proj-xcode/PowerAuth2/PowerAuthWCSessionManager.m
+++ b/proj-xcode/PowerAuth2/PowerAuthWCSessionManager.m
@@ -75,7 +75,7 @@ static WCSession * _ValidateSession(WCSession * session);
 #pragma mark - Thread safety
 
 /**
- Prepares runtime data required by this class. We're initializing that objects only
+ Prepares runtime data required by this class. We're initializing those objects only
  on demand, when the first token is being accessed.
  */
 static void _prepareInstance(PowerAuthWCSessionManager * obj)
@@ -147,7 +147,7 @@ static PA2WCSessionPacket * _DeserializePacket(NSData * data, Class payloadClass
         return packet;
     }
     
-    // ... the rest of data should contains valid JSON
+    // ... the rest of data should contain valid JSON
     NSData * jsonData = [data subdataWithRange:NSMakeRange(_HeaderSize, data.length - _HeaderSize)];
     NSError * error = nil;
     NSDictionary * root = PA2ObjectAs([NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error], NSDictionary);
@@ -155,7 +155,7 @@ static PA2WCSessionPacket * _DeserializePacket(NSData * data, Class payloadClass
         *failure = YES;
         return [PA2WCSessionPacket packetWithError:PA2MakeError(PowerAuthErrorCode_WatchConnectivity, @"PA2WCSessionManager: Invalid payload. Failed to deserialize JSON.")];
     }
-    // Construct packet to further investigation
+    // Construct packet for further investigation
     PA2WCSessionPacket * packet = [[PA2WCSessionPacket alloc] initWithDictionary:root];
     if (packet) {
         if (payloadClass != Nil && !packet.error) {
@@ -187,12 +187,12 @@ static NSData * _SerializePacket(PA2WCSessionPacket * packet)
 {
     NSDictionary * dict = [packet toDictionary];
     if (!dict) {
-        PowerAuthLog(@"PA2WCSessionManager: Cannon serialize packet to dictionary.");
+        PowerAuthLog(@"PA2WCSessionManager: Cannot serialize packet to dictionary.");
         return nil;
     }
     NSData * JSONData = [NSJSONSerialization dataWithJSONObject:dict options:0 error:NULL];
     if (!JSONData) {
-        PowerAuthLog(@"PA2WCSessionManager: Cannon serialize packet to JSON.");
+        PowerAuthLog(@"PA2WCSessionManager: Cannot serialize packet to JSON.");
         return nil;
     }
     // Prepare the packet version. If not set, then use the default version.
@@ -370,7 +370,7 @@ static NSData * _SerializePacket(PA2WCSessionPacket * packet)
     // Get a valid session
     WCSession * session = self.validSession;
     if (!session) {
-        // On IOS, switch to debug build and check log what's the reason of unavailability.
+        // On iOS, switch to debug build and check the log for the reason of unavailability.
         // On watchOS, the session is typically not activated
         PowerAuthLog(@"PA2WCSessionManager: WCSession is currently not available for messaging.");
         if (completion) {
@@ -444,7 +444,7 @@ static NSData * _SerializePacket(PA2WCSessionPacket * packet)
 
 static WCSession * _PrepareSession(void)
 {
-    // On watcOS, we can always return defaultSession.
+    // On watchOS, we can always return defaultSession.
     return [WCSession defaultSession];
 }
 

--- a/proj-xcode/PowerAuth2/private/PA2PrivateMacros.h
+++ b/proj-xcode/PowerAuth2/private/PA2PrivateMacros.h
@@ -61,6 +61,8 @@ PA2_EXTERN_C id PA2CastToProtoImpl(id object, Protocol * desiredProtocol);
 PA2_EXTERN_C NSError * PA2WrapError(NSError * error, NSError** out_error);
 /// Returns NSError with PA2ErrorDomain with given errorCode & message.
 PA2_EXTERN_C NSError * PA2MakeError(PowerAuthErrorCode errorCode, NSString * message);
+/// Returns NSError with PA2ErrorDomain with given errorCode & message and underlying reason of failure.
+PA2_EXTERN_C NSError * PA2MakeErrorWithReason(PowerAuthErrorCode errorCode, NSString * message, NSError * reason);
 /// Returns NSError with PA2ErrorDomain with given errorCode, message and additional info.
 PA2_EXTERN_C NSError * PA2MakeErrorInfo(NSInteger errorCode, NSString * message, NSDictionary * info);
 /// Returns the default textual representation for given error code.
@@ -74,6 +76,12 @@ PA2_EXTERN_C void PA2DictionarySafeSet(NSMutableDictionary * dict, NSString * ke
 #define PA2SetError(errorPtr, errorCode, message)       \
     if (errorPtr) {                                     \
         *errorPtr = PA2MakeError(errorCode, message);   \
+    }
+
+/// Create NSError with using PA2MakeErrorWithReason function and set it to optional errorPtr, which is type of `NSError**`.
+#define PA2SetErrorWithReason(errorPtr, errorCode, message, reason)     \
+    if (errorPtr) {                                                     \
+        *errorPtr = PA2MakeErrorWithReason(errorCode, message, reason); \
     }
 
 /// Set existing NSError into optional errorPtr, which is type of `NSError**`.

--- a/proj-xcode/PowerAuth2/private/PA2WCSessionPacket.h
+++ b/proj-xcode/PowerAuth2/private/PA2WCSessionPacket.h
@@ -86,6 +86,12 @@
  */
 @property (nonatomic, assign) BOOL sendLazyResponseIfPossible;
 
+/**
+ Contains `'\0'` by default and if set, then this is a packet response for unsupported
+ protocol version.
+ */
+@property (nonatomic, assign) char customPacketVersion;
+
 // Easy accessors
 
 /**

--- a/proj-xcode/PowerAuth2/private/PA2WCSessionPacket_ActivationStatus.h
+++ b/proj-xcode/PowerAuth2/private/PA2WCSessionPacket_ActivationStatus.h
@@ -37,5 +37,15 @@
  In this case, presence of activationId determining whether the session is activated or not.
  */
 @property (nonatomic, strong) NSString * activationId;
+/**
+ Optional and has meaning only when activationId is also present. The value contains the current
+ PowerAuth algorithm in the string representation (e.g. `"EC_P384_ML_L3"`).
+ */
+@property (nonatomic, strong) NSString * algorithm;
+/**
+ Optional and has meaning only when activationId is also present. The value contains the current
+ protocol version in string representation (e.g. `"3.3"`, `"4.0"`, etc.)
+ */
+@property (nonatomic, strong) NSString * protocolVersion;
 
 @end

--- a/proj-xcode/PowerAuth2/private/PA2WCSessionPacket_ActivationStatus.m
+++ b/proj-xcode/PowerAuth2/private/PA2WCSessionPacket_ActivationStatus.m
@@ -29,6 +29,12 @@
     if (_activationId) {
         dictionary[PA2WCSessionPacket_KEY_ACTIVATION_ID] = _activationId;
     }
+    if (_algorithm) {
+        dictionary[PA2WCSessionPacket_KEY_ALGORITHM_ID] = _algorithm;
+    }
+    if (_protocolVersion) {
+        dictionary[PA2WCSessionPacket_KEY_PROTO_VERSION] = _protocolVersion;
+    }
 }
 
 - (id) initWithDictionary:(NSDictionary *)dictionary
@@ -37,6 +43,8 @@
     if (self) {
         _command = PA2ObjectAs(dictionary[PA2WCSessionPacket_KEY_ACTIVATION_CMD], NSString);
         _activationId = PA2ObjectAs(dictionary[PA2WCSessionPacket_KEY_ACTIVATION_ID], NSString);
+        _algorithm = PA2ObjectAs(dictionary[PA2WCSessionPacket_KEY_ALGORITHM_ID], NSString);
+        _protocolVersion = PA2ObjectAs(dictionary[PA2WCSessionPacket_KEY_PROTO_VERSION], NSString);
     }
     return self;
 }

--- a/proj-xcode/PowerAuth2/private/PA2WCSessionPacket_Constants.h
+++ b/proj-xcode/PowerAuth2/private/PA2WCSessionPacket_Constants.h
@@ -38,6 +38,8 @@ PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_KEY_ERROR_MSG;
 // Constants for serializing activation status
 PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_KEY_ACTIVATION_CMD;
 PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_KEY_ACTIVATION_ID;
+PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_KEY_ALGORITHM_ID;
+PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_KEY_PROTO_VERSION;
 PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_CMD_SESSION_GET;
 PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_CMD_SESSION_PUT;
 

--- a/proj-xcode/PowerAuth2/private/PA2WCSessionPacket_Constants.m
+++ b/proj-xcode/PowerAuth2/private/PA2WCSessionPacket_Constants.m
@@ -18,7 +18,7 @@
 
 #import "PA2WCSessionPacket_Constants.h"
 
-PA2_NO_EXPORT NSString * const PA2WCSessionPacket_USER_INFO_KEY       = @"io.getlime.PowerAuth.PA2WCSessionPacket";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_USER_INFO_KEY       = @"com.wultra.PowerAuth.PA2WCSessionPacket";
 
 PA2_NO_EXPORT NSString * const PA2WCSessionPacket_RESPONSE_TARGET     = @"*";
 PA2_NO_EXPORT NSString * const PA2WCSessionPacket_SESSION_TARGET      = @"session:";
@@ -31,6 +31,8 @@ PA2_NO_EXPORT NSString * const PA2WCSessionPacket_KEY_ERROR_MSG       = @"errorM
 
 PA2_NO_EXPORT NSString * const PA2WCSessionPacket_KEY_ACTIVATION_CMD  = @"activationCmd";
 PA2_NO_EXPORT NSString * const PA2WCSessionPacket_KEY_ACTIVATION_ID   = @"activationId";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_KEY_ALGORITHM_ID    = @"activationAlg";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_KEY_PROTO_VERSION   = @"activationProto";
 PA2_NO_EXPORT NSString * const PA2WCSessionPacket_CMD_SESSION_GET     = @"get_session";
 PA2_NO_EXPORT NSString * const PA2WCSessionPacket_CMD_SESSION_PUT     = @"put_session";
 

--- a/proj-xcode/PowerAuthCore/PowerAuthCoreSession.h
+++ b/proj-xcode/PowerAuthCore/PowerAuthCoreSession.h
@@ -619,6 +619,7 @@
 
 /// Returns textual representation for given protocol version. For example, for `PowerAuthCoreProtocolVersion_V3`
 /// returns "3.3". You can use `PowerAuthCoreProtocolVersion_NA` to get the value for the latest supported version.
-+ (nonnull NSString*) maxSupportedHttpProtocolVersion:(PowerAuthCoreProtocolVersion)protocolVersion;
+/// If `nil` is returned, then protocol version is not supported.
++ (nullable NSString*) maxSupportedHttpProtocolVersion:(PowerAuthCoreProtocolVersion)protocolVersion;
 
 @end

--- a/proj-xcode/PowerAuthCore/PowerAuthCoreSession.mm
+++ b/proj-xcode/PowerAuthCore/PowerAuthCoreSession.mm
@@ -958,7 +958,11 @@ static void _ReportError(PowerAuthCoreError code, NSString * message, NSError **
 
 + (NSString*) maxSupportedHttpProtocolVersion:(PowerAuthCoreProtocolVersion)protocolVersion
 {
-    return cc7::objc::CopyToNSString(ProtocolVersion_GetHttpHeaderVersion(static_cast<ProtocolVersion>(protocolVersion)));
+    try {
+        return cc7::objc::CopyToNSString(ProtocolVersion_GetHttpHeaderVersion(static_cast<ProtocolVersion>(protocolVersion)));
+    } catch (...) {
+        return nil;
+    }
 }
 
 @end

--- a/proj-xcode/PowerAuthCore/PowerAuthCoreSession.mm
+++ b/proj-xcode/PowerAuthCore/PowerAuthCoreSession.mm
@@ -956,7 +956,7 @@ static void _ReportError(PowerAuthCoreError code, NSString * message, NSError **
     }
 }
 
-+ (NSString*) maxSupportedHttpProtocolVersion:(PowerAuthCoreProtocolVersion)protocolVersion
++ (nullable NSString*) maxSupportedHttpProtocolVersion:(PowerAuthCoreProtocolVersion)protocolVersion
 {
     try {
         return cc7::objc::CopyToNSString(ProtocolVersion_GetHttpHeaderVersion(static_cast<ProtocolVersion>(protocolVersion)));


### PR DESCRIPTION
This PR ensures that an additional information about an activation on iOS is sent to watchOS when the activation is present. The change also contains a communication protocol change that allows to handle the current and the future protocol version updates.

The communication protocol changes must be compatible with changes on watchOS side (PR wultra/powerauth-mobile-watch-sdk#10)