### PR TITLE
Simplify error response extraction

### DIFF
--- a/docs/Migration-from-1.9-to-2.0.md
+++ b/docs/Migration-from-1.9-to-2.0.md
@@ -213,6 +213,7 @@ Notable changes on iOS:
     - `responseObject` property is now nullable instead of IUO (Implicitly Unwrapped Optional) in Swift.
   - `PowerAuthRestApiError` class:
     - All properties in the class are now nullable, instead IUO (Implicitly Unwrapped Optional) in Swift.
+    - The `currentRecoveryPukIndex` property was removed together with the recovery code support.
 
 - All static methods for accessing a various shared instances are now deprecated:
   - `PowerAuthSDK.initSharedInstance(...)` and `PowerAuthSDK.sharedInstance()` - To ensure better control and flexibility, manage the global instances within your application code.

--- a/docs/Migration-from-1.9-to-2.0.md
+++ b/docs/Migration-from-1.9-to-2.0.md
@@ -176,6 +176,7 @@ Notable changes on Android:
 Notable changes on iOS:
 
 - Added the `PowerAuthCoreData` object to `PowerAuthCore` module to enhance in-memory management of sensitive data.
+- Added `powerAuthRestApiErrorResponse` property to `NSError` to simplify access to the reason of the failure, received from the server.
 
 ### API changes
 
@@ -208,6 +209,10 @@ Notable changes on iOS:
     - `overridenPossessionKey` property is now deprecated with no replacement.
     - All construction methods that take a custom possession key are now deprecated. If you use such a method and provide a custom possession key, the created object will not pass validation when used in `PowerAuthSDK`. Please contact our support team for more details if this is important to you.
   - `PowerAuthAuthorizationHttpHeader` is deprecated and replaced with `PowerAuthHttpHeader`
+  - `PowerAuthRestApiErrorResponse` class:
+    - `responseObject` property is now nullable instead of IUO (Implicitly Unwrapped Optional) in Swift.
+  - `PowerAuthRestApiError` class:
+    - All properties in the class are now nullable, instead IUO (Implicitly Unwrapped Optional) in Swift.
 
 - All static methods for accessing a various shared instances are now deprecated:
   - `PowerAuthSDK.initSharedInstance(...)` and `PowerAuthSDK.sharedInstance()` - To ensure better control and flexibility, manage the global instances within your application code.

--- a/docs/PowerAuth-SDK-for-iOS.md
+++ b/docs/PowerAuth-SDK-for-iOS.md
@@ -2296,6 +2296,14 @@ if error == nil {
             
         case .networkError:
             print("Error code for error with network connectivity or download")
+            if let errorResponse = error.powerAuthRestApiErrorResponse {
+                // Error response is available only if actual response was received from the server.
+                let httpStatusCode = errorResponse.httpStatusCode
+                // Error code & message received from the server. If server is down and returns 500, then values
+                // may not be available.
+                let errorCode = errorResponse.responseObject?.code
+                let errorMessage = errorResponse.responseObject?.message
+            }
 
         case .signatureError:
             print("Error code for error in signature calculation")

--- a/proj-xcode/PowerAuth2/PowerAuthActivation.m
+++ b/proj-xcode/PowerAuth2/PowerAuthActivation.m
@@ -177,7 +177,6 @@
 
 #pragma mark - Debug
 
-#if DEBUG
 - (NSString*) description
 {
     NSMutableString * optional = [NSMutableString string];
@@ -197,6 +196,5 @@
     }
     return [NSString stringWithFormat:@"<PowerAuthActivation type=\"%@\", identity=%@%@>", _activationType, _identityAttributes, optional];
 }
-#endif
 
 @end

--- a/proj-xcode/PowerAuth2/PowerAuthActivationResult.m
+++ b/proj-xcode/PowerAuth2/PowerAuthActivationResult.m
@@ -31,13 +31,11 @@
     return self;
 }
 
-#ifdef DEBUG
 - (NSString*) description
 {
     NSString * fingerprint = _activationFingerprint ? _activationFingerprint : @"<null>";
     NSString * attrs = _customAttributes ? [@", attributes=" stringByAppendingString:[_customAttributes description]] : @"";
     return [NSString stringWithFormat:@"<PowerAuthActivationResult fingerprint=%@%@>", fingerprint, attrs];
 }
-#endif
 
 @end

--- a/proj-xcode/PowerAuth2/PowerAuthAuthentication.m
+++ b/proj-xcode/PowerAuth2/PowerAuthAuthentication.m
@@ -83,7 +83,6 @@
     return nil;
 }
 
-#if DEBUG
 - (NSString*) description
 {
     NSString * usage_str;
@@ -121,7 +120,6 @@
     NSString * info_str = info.count == 0 ? @"" : [@", " stringByAppendingString:[info componentsJoinedByString:@" "]];
     return [NSString stringWithFormat:@"<PowerAuthAuthentication %@: %@%@>", usage_str, factors_str, info_str];
 }
-#endif
 
 @end
 

--- a/proj-xcode/PowerAuth2/PowerAuthErrorConstants.h
+++ b/proj-xcode/PowerAuth2/PowerAuthErrorConstants.h
@@ -20,6 +20,7 @@
 #import <PowerAuth2/PowerAuthMacros.h>
 
 @class PowerAuthExternalPendingOperation;
+@class PowerAuthRestApiErrorResponse;
 
 #pragma mark - Error codes
 
@@ -174,6 +175,11 @@ typedef NS_ENUM(NSInteger, PowerAuthErrorCode) {
  has different domain, then property contains `PowerAuthErrorCode_NA`.
  */
 @property (nonatomic, readonly) PowerAuthErrorCode powerAuthErrorCode;
+/**
+ Contains `PowerAuthRestApiErrorResponse` in case that error response has been received from the server. If error
+ object has different domain or no such response is included, then contain `nil`.
+ */
+@property (nonatomic, strong, nullable, readonly) PowerAuthRestApiErrorResponse * powerAuthRestApiErrorResponse;
 /**
  Contains `PowerAuthExternalPendingOperation` object in case that NSError object has `PowerAuthErrorDomain`
  and error code is `PowerAuthErrorCode_ExternalPendingOperation`.

--- a/proj-xcode/PowerAuth2/PowerAuthErrorConstants.h
+++ b/proj-xcode/PowerAuth2/PowerAuthErrorConstants.h
@@ -177,7 +177,7 @@ typedef NS_ENUM(NSInteger, PowerAuthErrorCode) {
 @property (nonatomic, readonly) PowerAuthErrorCode powerAuthErrorCode;
 /**
  Contains `PowerAuthRestApiErrorResponse` in case that error response has been received from the server. If error
- object has different domain or no such response is included, then contain `nil`.
+ object has different domain or no such response is included, then contains `nil`.
  */
 @property (nonatomic, strong, nullable, readonly) PowerAuthRestApiErrorResponse * powerAuthRestApiErrorResponse;
 /**

--- a/proj-xcode/PowerAuth2/PowerAuthErrorConstants.m
+++ b/proj-xcode/PowerAuth2/PowerAuthErrorConstants.m
@@ -18,7 +18,9 @@
 // PA2_SHARED_SOURCE PowerAuth2ForExtensions .
 
 #import <PowerAuth2/PowerAuthErrorConstants.h>
+#import <PowerAuth2/PowerAuthRestApiErrorResponse.h>
 #import "PA2PrivateConstants.h"
+#import "PA2PrivateMacros.h"
 
 @import PowerAuthCore;
 
@@ -158,6 +160,14 @@ NSError * PA2MakeErrorInfo(NSInteger errorCode, NSString * message, NSDictionary
         return (PowerAuthErrorCode)self.code;
     }
     return PowerAuthErrorCode_NA;
+}
+
+- (PowerAuthRestApiErrorResponse*) powerAuthRestApiErrorResponse
+{
+    if ([self.domain isEqualToString:PowerAuthErrorDomain]) {
+        return self.userInfo[PowerAuthErrorDomain];
+    }
+    return nil;
 }
 
 - (PowerAuthExternalPendingOperation*) powerAuthExternalPendingOperation

--- a/proj-xcode/PowerAuth2/PowerAuthErrorConstants.m
+++ b/proj-xcode/PowerAuth2/PowerAuthErrorConstants.m
@@ -20,7 +20,6 @@
 #import <PowerAuth2/PowerAuthErrorConstants.h>
 #import <PowerAuth2/PowerAuthRestApiErrorResponse.h>
 #import "PA2PrivateConstants.h"
-#import "PA2PrivateMacros.h"
 
 @import PowerAuthCore;
 

--- a/proj-xcode/PowerAuth2/PowerAuthRestApiError.h
+++ b/proj-xcode/PowerAuth2/PowerAuthRestApiError.h
@@ -23,28 +23,15 @@
 
 /** Error code
  */
-@property (nonatomic, strong) NSString *code;
+@property (nonatomic, strong, nullable) NSString *code;
 
 /** Error message
  */
-@property (nonatomic, strong) NSString *message;
+@property (nonatomic, strong, nullable) NSString *message;
 
 /**
  Contains additional information received together with error.
  */
-@property (nonatomic, strong) NSDictionary *additionalInfo;
-
-@end
-
-
-@interface PowerAuthRestApiError (RecoveryCode)
-
-/**
- Contains an index of valid PUK in case that recovery activation did fail and
- there's still some recovery PUK available.
- 
- The property contains -1 if the information is not available in the error response.
- */
-@property (nonatomic, readonly, assign) NSInteger currentRecoveryPukIndex;
+@property (nonatomic, strong, nullable) NSDictionary *additionalInfo;
 
 @end

--- a/proj-xcode/PowerAuth2/PowerAuthRestApiError.m
+++ b/proj-xcode/PowerAuth2/PowerAuthRestApiError.m
@@ -19,7 +19,6 @@
 
 @implementation PowerAuthRestApiError
 
-#ifdef DEBUG
 - (NSString*) description
 {
     NSString * info = _additionalInfo ? [@", info=" stringByAppendingString:[_additionalInfo description]] : @"";
@@ -27,7 +26,6 @@
     NSString * message = _message ? _message : @"<null>";
     return [NSString stringWithFormat:@"<PowerAuthRestApiError code=%@, message=%@%@>", code, message, info];
 }
-#endif
 
 @end
 
@@ -44,16 +42,6 @@
         _additionalInfo = info;
     }
     return self;
-}
-
-@end
-
-@implementation PowerAuthRestApiError (RecoveryCode)
-
-- (NSInteger) currentRecoveryPukIndex
-{
-    NSNumber * value = PA2ObjectAs(_additionalInfo[@"currentRecoveryPukIndex"], NSNumber);
-    return value ? [value integerValue] : -1;
 }
 
 @end

--- a/proj-xcode/PowerAuth2/PowerAuthRestApiErrorResponse.h
+++ b/proj-xcode/PowerAuth2/PowerAuthRestApiErrorResponse.h
@@ -31,6 +31,6 @@ typedef NS_ENUM(NSInteger, PowerAuthRestApiResponseStatus) {
 
 @property (nonatomic, assign) PowerAuthRestApiResponseStatus status;
 @property (nonatomic, assign) NSUInteger httpStatusCode;
-@property (nonatomic, strong) PowerAuthRestApiError* responseObject;
+@property (nonatomic, strong, nullable) PowerAuthRestApiError* responseObject;
 
 @end

--- a/proj-xcode/PowerAuth2/PowerAuthRestApiErrorResponse.m
+++ b/proj-xcode/PowerAuth2/PowerAuthRestApiErrorResponse.m
@@ -19,7 +19,6 @@
 
 @implementation PowerAuthRestApiErrorResponse
 
-#ifdef DEBUG
 - (NSString*) description
 {
     NSString * status_str = _status == PowerAuthRestApiResponseStatus_OK ? @"OK" : @"ERROR";
@@ -27,7 +26,6 @@
     NSString * ro = _responseObject ? [_responseObject description] : @"<null>";
     return [NSString stringWithFormat:@"<PowerAuthRestApiErrorResponse status=%@, httpStatusCode=%@, responseObject=%@>", status_str, code_str, ro];
 }
-#endif
 
 @end
 

--- a/proj-xcode/PowerAuth2/PowerAuthSignatureTypes.m
+++ b/proj-xcode/PowerAuth2/PowerAuthSignatureTypes.m
@@ -31,12 +31,10 @@
     return self;
 }
 
-#if DEBUG
 - (NSString*) description
 {
     NSString * keyType = _keyType == PowerAuthSignatureKeyType_EC ? @"EC" : @"ML-DSA";
     return [NSString stringWithFormat:@"<PowerAuthDevicePublicKeyData type=\"%@\", algorithm=\"%@\">", keyType, _keyAlgorithm];
 }
-#endif
 
 @end

--- a/proj-xcode/PowerAuth2/PowerAuthToken.m
+++ b/proj-xcode/PowerAuth2/PowerAuthToken.m
@@ -109,7 +109,6 @@
 
 #pragma mark - Debug
 
-#if defined(DEBUG)
 - (NSString*) description
 {
     return [NSString stringWithFormat:@"<PowerAuthToken name='%@' identifier='%@' canGenerateHeader=%@>",
@@ -117,6 +116,5 @@
             self.tokenIdentifier,
             @(self.canGenerateHeader)];
 }
-#endif // DEBUG
 
 @end

--- a/proj-xcode/PowerAuth2/PowerAuthUserInfo.m
+++ b/proj-xcode/PowerAuth2/PowerAuthUserInfo.m
@@ -95,12 +95,10 @@ CLAIMS_GETTER(zoneInfo, @"zoneinfo")
 CLAIMS_GETTER(locale, @"locale")
 CLAIMS_GETTER_TIMESTAMP(updatedAt, @"updated_at")
 
-#ifdef DEBUG
 - (NSString*) description
 {
     return [NSString stringWithFormat:@"<PowerAuthUserInfo: %@>", _allClaims];
 }
-#endif // DEBUG
 
 @end
 
@@ -126,11 +124,9 @@ CLAIMS_GETTER(region, @"region")
 CLAIMS_GETTER(postalCode, @"postal_code")
 CLAIMS_GETTER(country, @"country")
 
-#ifdef DEBUG
 - (NSString*) description
 {
     return [NSString stringWithFormat:@"<PowerAuthUserAddress: %@>", _allClaims];
 }
-#endif // DEBUG
 
 @end


### PR DESCRIPTION
This PR simplifies extraction and usage of `PowerAuthRestApiErrorResponse` from `NSError` object. It also fixes a missing nullability declaration in `PowerAuthRestApiErrorResponse ` and `PowerAuthRestApiError` objects.

Other notable changes:
- All debug `description` methods in public objects are now available also in the release build. This increases chance  to find the problem if the library is shipped as precompiled (Swift PM)