### PR TITLE
Android: Fix #719: Publish to sonatype's central publishing portal

### DIFF
--- a/proj-android/PowerAuthLibrary/android-release-aar.gradle
+++ b/proj-android/PowerAuthLibrary/android-release-aar.gradle
@@ -129,8 +129,8 @@ publishing {
         maven {
             name = 'sonatype'
 
-            def releasesRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-            def snapshotsRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+            def releasesRepoUrl = "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/"
+            def snapshotsRepoUrl = "https://central.sonatype.com/repository/maven-snapshots/"
             url = isReleaseBuild() ? releasesRepoUrl : snapshotsRepoUrl
 
             credentials {
@@ -157,8 +157,8 @@ nexusPublishing {
             stagingProfileId = NEXUS_STAGING_PROFILE
             username = NEXUS_USERNAME
             password = NEXUS_PASSWORD
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
 }

--- a/scripts/android-publish-build.sh
+++ b/scripts/android-publish-build.sh
@@ -207,4 +207,15 @@ DEBUG_LOG "Gradle command line >> ./gradlew $GRADLE_CMD_LINE"
 ####
 POP_DIR
 
+if [ $DO_REPO == 'central' ]; then
+    # Publishing to "central" require one more step
+    LOG_LINE -a
+    LOG "Publishing with staging API"
+    LOG_LINE
+    curl --silent --fail-with-body          \
+        -X POST                             \
+        -u ${NEXUS_USER}:${NEXUS_PASSWORD}  \
+        https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/com.wultra
+fi
+
 EXIT_SUCCESS -l

--- a/scripts/android-publish-build.sh
+++ b/scripts/android-publish-build.sh
@@ -208,7 +208,7 @@ DEBUG_LOG "Gradle command line >> ./gradlew $GRADLE_CMD_LINE"
 POP_DIR
 
 if [ $DO_REPO == 'central' ]; then
-    # Publishing to "central" require one more step
+    # Publishing to "central" requires one more step
     LOG_LINE -a
     LOG "Publishing with staging API"
     LOG_LINE

--- a/scripts/deploy-build.sh
+++ b/scripts/deploy-build.sh
@@ -214,7 +214,7 @@ function DEPLOY_BUILD
     LOG "We're still need to wait for PowerAuthCore.podspec publication."
     LOG "              Meanwhile, you can to go to"
     LOG ""
-    LOG "          --> https://s01.oss.sonatype.org <--"
+    LOG "  --> https://central.sonatype.com/publishing/deployments <--"
     LOG ""
     LOG "    and switch Android build to the production manually."
     LOG_LINE


### PR DESCRIPTION
This PR fixes publishing to Maven Central for the current `develop` branch. It's equal change to PR #720