### PR TITLE
Expose encrypted request body and headers.

### DIFF
--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreEncryptedRequest.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/CoreEncryptedRequest.java
@@ -39,7 +39,7 @@ public class CoreEncryptedRequest {
      * @return Request body.
      */
     @NonNull
-    byte[] getRequestBody() {
+    public byte[] getRequestBody() {
         return requestBody;
     }
 
@@ -47,7 +47,7 @@ public class CoreEncryptedRequest {
      * @return Request headers.
      */
     @NonNull
-    CoreHttpHeader[] getRequestHeaders() {
+    public CoreHttpHeader[] getRequestHeaders() {
         return requestHeaders;
     }
 }


### PR DESCRIPTION
Request body and headers were not visible.