### PR TITLE
Deployment script improvements

### DIFF
--- a/scripts/android-publish-build.sh
+++ b/scripts/android-publish-build.sh
@@ -208,14 +208,19 @@ DEBUG_LOG "Gradle command line >> ./gradlew $GRADLE_CMD_LINE"
 POP_DIR
 
 if [ $DO_REPO == 'central' ]; then
-    # Publishing to "central" requires one more step
-    LOG_LINE -a
-    LOG "Publishing with staging API"
-    LOG_LINE
-    curl --silent --fail-with-body          \
-        -X POST                             \
-        -u ${NEXUS_USER}:${NEXUS_PASSWORD}  \
-        https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/com.wultra
+    if [ x$VERSION_PRE_RELEASE == x0 ]; then
+        # Publishing to "central" requires one more step
+        LOG_LINE -a
+        LOG "Publishing with staging API"
+        LOG_LINE
+        curl --silent --fail-with-body          \
+            -X POST                             \
+            -u ${NEXUS_USER}:${NEXUS_PASSWORD}  \
+            https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/com.wultra
+    else
+        LOG_LINE -a
+        LOG "Snapshot build doesn't require staging API step."
+    fi
 fi
 
 EXIT_SUCCESS -l

--- a/scripts/android-publish-build.sh
+++ b/scripts/android-publish-build.sh
@@ -213,9 +213,9 @@ if [ $DO_REPO == 'central' ]; then
         LOG_LINE -a
         LOG "Publishing with staging API"
         LOG_LINE
-        curl --silent --fail-with-body          \
-            -X POST                             \
-            -u ${NEXUS_USER}:${NEXUS_PASSWORD}  \
+        curl --silent --fail-with-body              \
+            -X POST                                 \
+            -u "${NEXUS_USER}:${NEXUS_PASSWORD}"    \
             https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/com.wultra
     else
         LOG_LINE -a

--- a/scripts/common-functions.sh
+++ b/scripts/common-functions.sh
@@ -12,11 +12,11 @@
 #  $VERBOSE_FOR_SCRIPT
 #     contains exact string as provided to SET_VERBOSE_LEVEL_FROM_SWITCH
 #  $VERBOSE_VARIANT1
-#     contains '-v' if VERBOSE==2, othherwise empty string
+#     contains '-v' if VERBOSE==2, otherwise empty string
 #  $VERBOSE_VARIANT2
-#     contains '-verbose' if VERBOSE==2, othherwise empty string
+#     contains '-verbose' if VERBOSE==2, otherwise empty string
 #  $VERBOSE_VARIANT3
-#     contains '--verbose' if VERBOSE==2, othherwise empty string
+#     contains '--verbose' if VERBOSE==2, otherwise empty string
 # -----------------------------------------------------------------------------
 set -e
 set +v
@@ -79,6 +79,8 @@ function WARNING
 #    prints dashed line to stdout if VERBOSE is greater than 0
 #    Function also prevents that two lines will never be displayed subsequently
 #    if -a parameter is provided, then always prints dashed line 
+# LOG_CLEAR_LINE_FLAG
+#    Clears internal flag indicating that last log was line.
 # DEBUG_LOG 
 #    Prints all parameters to stdout if VERBOSE is greater than 1
 # EXIT_SUCCESS
@@ -114,6 +116,10 @@ function EXIT_SUCCESS
     LOG "Success"
     exit 0
 }
+function LOG_CLEAR_LINE_FLAG
+{
+    LAST_LOG_IS_LINE=0
+}
 # -----------------------------------------------------------------------------
 # PROMPT_YES_FOR_CONTINUE asks user whether script should continue
 #
@@ -137,6 +143,48 @@ function PROMPT_YES_FOR_CONTINUE
             FAILURE "Aborted by user."
             ;;
     esac
+}
+
+# -----------------------------------------------------------------------------
+# PROMPT_CENTER_TEXT given prints text with leading and trailing spaces to
+# appear vertically centered on the screen.
+#
+# Parameters:
+# - $1 line width
+# - $2 text to center in line
+# -----------------------------------------------------------------------------
+function PROMPT_CENTER_TEXT
+{
+    local line=$1
+    local text="$2"
+    local width=${#text}
+    local leading=$(((line - width) / 2))
+    local trailing=$((line - width - leading))
+    local lead=$(printf "%*s" $leading)
+    local trail=$(printf "%*s" $trailing)
+    echo "$lead$text$trail"
+}
+# -----------------------------------------------------------------------------
+# PROMPT_PRINT prints box with information. You should use this function only
+# in scripts that require user's interaction.
+#
+# Parameters:
+# - $@ prompt to display and highlight. Treat each parameter as a whole line.
+# -----------------------------------------------------------------------------
+function PROMPT_PRINT
+{
+    if [ $VERBOSE -gt 0 ]; then
+        echo "$CMD:  ----------------------------------------------------------------------------"
+        echo "$CMD: |                                                                            |"
+        while [[ $# -gt 0 ]]; do
+            local text=$(PROMPT_CENTER_TEXT 76 "$1")
+            echo "$CMD: |$text|"
+            shift
+        done
+        echo "$CMD: |                                                                            |"
+        echo "$CMD:  ----------------------------------------------------------------------------"
+        LAST_LOG_IS_LINE=1
+    fi
 }
 # -----------------------------------------------------------------------------
 # REQUIRE_COMMAND uses "which" buildin command to test existence of requested
@@ -221,23 +269,34 @@ function UPDATE_VERBOSE_COMMANDS
     fi
 }
 # -----------------------------------------------------------------------------
-# Validate if $1 as VERSION has valid format: x.y.z
-# Also sets global VERSION to $1 if VERSION string is empty.
+# Validate if $1 as VERSION has valid format: 
+#  - x.y.z (production version)
+#  - x.y.z-alphaN (alpha version)
+#  - x.y.z-betaN (beta version)
+#  - x.y.z-rcN (release candidate version)
+# Also sets global VERSION to $1 and VERSION_PRE_RELEASE to 0 or 1, depending
+# on whether version string is for production or pre-release.
 # -----------------------------------------------------------------------------
 function VALIDATE_AND_SET_VERSION_STRING
 {
     if [ -z "$1" ]; then
         FAILURE "Version string is empty"
     fi
-    local rx='^([0-9]+\.){2}(\*|[0-9]+)$'
+    local rx='^([0-9]+)\.([0-9]+)\.([0-9]+)(-(alpha|beta|rc)([0-9]+))?$'
     if [[ ! "$1" =~ $rx ]]; then
         FAILURE "Version string is invalid: '$1'"
     fi
-    if [ -z "$VERSION" ]; then
-        VERSION=$1
-        DEBUG_LOG "Changing version to $VERSION"
+    if [ ! -z "$VERSION" ]; then
+        WARNING "Global Version string is already set to $VERSION"
+    fi
+    VERSION=$1
+    rx='^[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc)[0-9]*$'
+    if [[ "$1" =~ $rx ]]; then
+        VERSION_PRE_RELEASE=1
+        DEBUG_LOG "Changing global version to $VERSION (pre-release)"
     else
-        FAILURE "Version string is already set to $VERSION"
+        VERSION_PRE_RELEASE=0
+        DEBUG_LOG "Changing global version to $VERSION (production)"
     fi
 }
 # -----------------------------------------------------------------------------
@@ -308,6 +367,88 @@ function SHA512
 {
     local HASH=( `shasum -a 512 "$1"` )
     echo ${HASH[0]}
+}
+function SHA1
+{
+    local HASH=( `shasum -a 1 "$1"` )
+    echo ${HASH[0]}
+}
+
+# -----------------------------------------------------------------------------
+# Hexadecimal utility functions:
+# HEX_TO_STR
+#    Converts hexadecimal characters into string (or raw bytes)
+# STR_TO_HEX
+#    Converts string (or raw bytes) into hexadecimal string
+# FILE_TO_HEX
+#    Converts content of file into hexadecimal string.
+# HEX_LENGTH
+#    Print number of bytes in hexadecimal string.
+# HEX_TO_SHORT
+#    Convert hexadecimal value into signed short.
+# -----------------------------------------------------------------------------
+function HEX_TO_STR
+{
+    echo "$1" | xxd -r -p
+}
+function STR_TO_HEX
+{
+    local val=$(printf %s "$1" | xxd -p)
+    STR_TO_UPPER ${val//$'\n'}
+}
+function FILE_TO_HEX
+{
+    local val=$(cat "$1" | xxd -p)
+    STR_TO_UPPER ${val//$'\n'}
+}
+function HEX_LENGTH
+{
+    local data=$1
+    local len=$((${#data} / 2))
+    local hexLen=$(echo "ibase=10;obase=16; ${len}" | bc)
+    if [ ${#hexLen} == 1 ]; then
+        echo 0$hexLen
+    else
+        echo $hexLen
+    fi
+}
+function HEX_TO_SHORT
+{
+    local value=$(echo "ibase=16; $1" | bc)
+    if (( value > 32767 )); then
+        value=$((value - 65536))
+    fi
+    echo $value
+}
+
+# -----------------------------------------------------------------------------
+# String utility functions
+# STR_TO_UPPER
+#    Make all characters in string uppercased
+# STR_TO_LOWER
+#    Make all characters in string lowercased
+# -----------------------------------------------------------------------------
+function STR_TO_UPPER
+{
+    echo $1 | tr '[:lower:]' '[:upper:]'
+}
+function STR_TO_LOWER
+{
+    echo $1 | tr '[:upper:]' '[:lower:]'
+}
+
+# -----------------------------------------------------------------------------
+# Path utility functions
+# REAL_PATH
+#    Get real path to file. Unlike builtin realpath function, this resolves the
+#    parent directory, so the target file may not exit.
+# -----------------------------------------------------------------------------
+function REAL_PATH
+{
+    local path=$1
+    local dir=$(realpath $(dirname "$path"))
+    local fname=$(basename "$path")
+    echo $dir/$fname
 }
 
 # -----------------------------------------------------------------------------

--- a/scripts/deploy-build.sh
+++ b/scripts/deploy-build.sh
@@ -186,9 +186,8 @@ function DEPLOY_BUILD
     LOG "   scripts/android-publish-build.sh central"
     LOG ""
     LOG_LINE
-    LOG "----- Publishing Android to Maven Central..."
-    pod $POD_VERBOSE trunk push ${PODSPEC}
 
+    LOG "----- Publishing Android to Maven Central..."
     "${TOP}/android-publish-build.sh" $SCRIPT_VERBOSE central
 
     if [ x$VERSION_PRE_RELEASE == x0 ]; then
@@ -205,6 +204,7 @@ function DEPLOY_BUILD
     # Publish Apple platform
 
     if [ x$VERSION_PRE_RELEASE == x0 ]; then
+        LOG ""
         LOG_LINE
         LOG "Going to publish ${PODSPEC} to CocoaPods. In case of failure"
         LOG "then please try to run the publishing manually: "
@@ -212,9 +212,11 @@ function DEPLOY_BUILD
         LOG "   pod trunk push ${PODSPEC}"
         LOG ""
         LOG_LINE
+
         LOG "----- Publishing ${PODSPEC} to CocoaPods..."
         pod $POD_VERBOSE trunk push ${PODSPEC}
     else
+        LOG ""
         LOG_LINE
         LOG "Pre-release version doesn't need to be published to CocoaPods."
         LOG "If you still want to publish this version, then run:"

--- a/scripts/deploy-build.sh
+++ b/scripts/deploy-build.sh
@@ -44,11 +44,7 @@ function USAGE
 ###############################################################################
 # Config
 PODSPEC="PowerAuth2.podspec"
-PODSPEC_COR="PowerAuthCore.podspec"
-PODSPEC_EXT="PowerAuth2ForExtensions.podspec"
-PODSPEC_WOS="PowerAuth2ForWatch.podspec"
 INFO_PLIST="proj-xcode/PowerAuth2/Info.plist"
-INFO_PLIST_COR="proj-xcode/PowerAuthCore/Info.plist"
 
 GRADLE_PROP="proj-android/PowerAuthLibrary/gradle.properties"
 MASTER_BRANCH="master"
@@ -108,27 +104,26 @@ function PREPARE_VERSIONING_FILES
 {
     PUSH_DIR "${SRC_ROOT}"
     ####
-
+    if [ x$VERSION_PRE_RELEASE == x1 ]; then
+        # All pre-release versions are marked as X.Y.Z-SNAPSHOT on Android
+        local VERSION_ANDROID="${VERSION%%-*}-SNAPSHOT"
+    else
+        local VERSION_ANDROID=$VERSION
+    fi
     # PowerAuth2
     LOG "----- Generating ${PODSPEC}..."
     sed -e "s/%DEPLOY_VERSION%/$VERSION/g" "${TOP}/templates/${PODSPEC}" > "$SRC_ROOT/${PODSPEC}" 
-    git add ${PODSPEC}
-    # PowerAuthCore
-    LOG "----- Generating ${PODSPEC_COR}..."
-    sed -e "s/%DEPLOY_VERSION%/$VERSION/g" "${TOP}/templates/${PODSPEC_COR}" > "$SRC_ROOT/${PODSPEC_COR}" 
-    git add ${PODSPEC_COR}
     # Info.plist files
     LOG "----- Generating ${INFO_PLIST}..."
     sed -e "s/%DEPLOY_VERSION%/$VERSION/g" "${TOP}/templates/PA2-Info.plist" > "$SRC_ROOT/${INFO_PLIST}"
-    LOG "----- Generating ${INFO_PLIST_COR}..."
-    sed -e "s/%DEPLOY_VERSION%/$VERSION/g" "${TOP}/templates/PAC-Info.plist" > "$SRC_ROOT/${INFO_PLIST_COR}"
-    git add ${INFO_PLIST} ${INFO_PLIST_COR}
-
+    # Gradle
     LOG "----- Generating gradle.properties..."
-    sed -e "s/%DEPLOY_VERSION%/$VERSION/g" "${TOP}/templates/gradle.properties" > "$SRC_ROOT/${GRADLE_PROP}" 
-    git add ${GRADLE_PROP}
+    sed -e "s/%DEPLOY_VERSION%/$VERSION_ANDROID/g" "${TOP}/templates/gradle.properties" > "$SRC_ROOT/${GRADLE_PROP}" 
     
-    local TAG_MESSAGE="ios+android version $VERSION"
+    LOG "----- Staging local changes..."
+    git add .
+    
+    local TAG_MESSAGE="version $VERSION"
 
     LOG "----- Commiting versioning files..."
     git commit -m "Deployment: Update versioning file[s] to ${VERSION}"
@@ -171,7 +166,7 @@ function PUSH_VERSIONING_FILES
 # -----------------------------------------------------------------------------
 function VALIDATE_BEFORE_PUBLISH
 {
-    "${TOP}/test-build.sh" $SCRIPT_VERBOSE lint
+    "${TOP}/test-build.sh" $SCRIPT_VERBOSE lint android
 }
 
 # -----------------------------------------------------------------------------
@@ -182,90 +177,55 @@ function DEPLOY_BUILD
     PUSH_DIR "${SRC_ROOT}"
     ####
     
-    # At first, publis PowerAuthCore.podspec, then we have to wait about
-    # 20 minutes to publish PowerAuth2.podspec
-    
-    # There's now way to test whether core has been really published.
-    # 
-    # We can use --synchronized option, but it will clone the gigantic
-    # git repository with all specs, so update will take the same time
-    # as a plain wait.
-    
-    LOG "----- Publishing ${PODSPEC_COR} to CocoaPods..."
-    pod $POD_VERBOSE trunk push ${PODSPEC_COR}
-
-    # Now publish extensions & watchOS libs
-    
-    # 1260 - 21 minutes
-    local WAIT_TIME=1260
-    local END_TIME=$((`date +%s` + $WAIT_TIME))
-    
-    LOG "----- Publishing ${PODSPEC_WOS} to CocoaPods..."
-    # TODO ...
-    LOG "----- Publishing ${PODSPEC_EXT} to CocoaPods..."
-    # TODO ...
-    
-    # Also publish Android library
-    
-    "${TOP}/android-publish-build.sh" $SCRIPT_VERBOSE central
-    
-    LOG ""
-    LOG_LINE
-    LOG "We're still need to wait for PowerAuthCore.podspec publication."
-    LOG "              Meanwhile, you can to go to"
-    LOG ""
-    LOG "  --> https://central.sonatype.com/publishing/deployments <--"
-    LOG ""
-    LOG "    and switch Android build to the production manually."
-    LOG_LINE
-    
-    LOG "Waiting for several minutes to propagate ${PODSPEC_COR} to trunk..."
-    while [ `date +%s` -lt $END_TIME ]
-    do
-        local remaining=$(( ($END_TIME - `date +%s`) / 60 ))
-        LOG " - $remaining minute(s) to go..."
-        sleep 60
-    done
-    
-    # Now finally try to publish
+    # Publish Android platform
     
     LOG_LINE
-    LOG "Going to publish ${PODSPEC} to CocoaPods. In case of failure"
-    LOG "then  please try to run the publishing manually: "
+    LOG "Going to publish Android to Maven Central. In case of failure"
+    LOG "then please try to run the publishing manually: "
     LOG ""
-    LOG "   pod trunk push ${PODSPEC}"
+    LOG "   scripts/android-publish-build.sh central"
     LOG ""
     LOG_LINE
-    LOG "----- Publishing ${PODSPEC} to CocoaPods..."
+    LOG "----- Publishing Android to Maven Central..."
     pod $POD_VERBOSE trunk push ${PODSPEC}
 
+    "${TOP}/android-publish-build.sh" $SCRIPT_VERBOSE central
+
+    if [ x$VERSION_PRE_RELEASE == x0 ]; then
+        LOG ""
+        LOG_LINE
+        LOG "    While Apple platform is being published, you can go to"
+        LOG ""
+        LOG " --> https://central.sonatype.com/publishing/deployments <--"
+        LOG ""
+        LOG "     and switch Android build to the production manually."
+        LOG_LINE
+    fi
+
+    # Publish Apple platform
+
+    if [ x$VERSION_PRE_RELEASE == x0 ]; then
+        LOG_LINE
+        LOG "Going to publish ${PODSPEC} to CocoaPods. In case of failure"
+        LOG "then please try to run the publishing manually: "
+        LOG ""
+        LOG "   pod trunk push ${PODSPEC}"
+        LOG ""
+        LOG_LINE
+        LOG "----- Publishing ${PODSPEC} to CocoaPods..."
+        pod $POD_VERBOSE trunk push ${PODSPEC}
+    else
+        LOG_LINE
+        LOG "Pre-release version doesn't need to be published to CocoaPods."
+        LOG "If you still want to publish this version, then run:"
+        LOG ""
+        LOG "   pod trunk push ${PODSPEC}"
+        LOG ""
+        LOG_LINE
+    fi
     ####
     POP_DIR
 }
-
-# -----------------------------------------------------------------------------
-# Merges recent changes to the 'master' branch
-# -----------------------------------------------------------------------------
-function MERGE_TO_MASTER
-{
-    if [ x$STANDARD_BRANCH == x0 ]; then
-        LOG "----- OK, but not merged to '${MASTER_BRANCH}'"
-    else
-        PUSH_DIR "${SRC_ROOT}"
-        ####
-        LOG "----- Merging to '${MASTER_BRANCH}'..."
-        git fetch origin
-        git checkout ${MASTER_BRANCH}
-        git rebase origin/${DEV_BRANCH}
-        git push
-        git checkout ${DEV_BRANCH}
-        ####
-        POP_DIR
-        LOG "----- OK"
-    fi
-    exit 0
-}
-
 
 ###############################################################################
 # Script's main execution starts here...
@@ -316,5 +276,5 @@ VALIDATE_GIT_STATUS
 VALIDATE_BEFORE_PUBLISH
 PUSH_VERSIONING_FILES
 DEPLOY_BUILD
-MERGE_TO_MASTER
 
+EXIT_SUCCESS -l


### PR DESCRIPTION
This PR enables snapshots deployment to Maven Central and fixes CocoaPods deploy script after changes made in #890. The change also contains update of `common-functions.sh` allowing semi-publishing of `-alphaN`, `-betaN` and `-rcN` releases.
