### PR TITLE
Fixed reset of C++ Session

### DIFF
--- a/proj-xcode/PowerAuthCore/PowerAuthCoreSession.mm
+++ b/proj-xcode/PowerAuthCore/PowerAuthCoreSession.mm
@@ -73,7 +73,11 @@ using namespace powerAuth;
 - (void) resetSession
 {
     [self requireWriteAccess:nil];
-    _session->resetState();
+    try {
+        _session->resetState();
+    } catch (...) {
+        // TODO: log failure
+    }
 }
 
 - (id<PowerAuthCoreSessionDelegate>) delegate

--- a/src/PowerAuth/Context.cpp
+++ b/src/PowerAuth/Context.cpp
@@ -270,7 +270,7 @@ std::shared_ptr<Context> Context::createTargetAlgorithmContext()
     return _target_context;
 }
 
-void Context::resetState() noexcept
+void Context::resetState()
 {
     if (_current_specification != _initial_specification) {
         // The specification is different than initial. We have to re-create all services.

--- a/src/PowerAuth/Context.cpp
+++ b/src/PowerAuth/Context.cpp
@@ -73,8 +73,8 @@ const Configuration& Context::configuration() const noexcept
 
 PowerAuthSpecPtr Context::specification() const noexcept
 {
-    CHECK_OBJ_PTR(_specification)
-    return _specification;
+    CHECK_OBJ_PTR(_current_specification)
+    return _current_specification;
 }
 
 
@@ -238,7 +238,8 @@ const cc7::crypto::KeyPairFactoryPtr& Context::getSigningKeyPairFactoryPtr() con
 Context::Context(PowerAuthSpecPtr specification, ConfigurationPtr configuration) :
     _shared_mutex(std::make_shared<std::recursive_mutex>()),
     _configuration(configuration),
-    _specification(specification)
+    _initial_specification(specification),
+    _current_specification(specification)
 {
 }
 
@@ -256,6 +257,7 @@ ContextPtr Context::getInstance(ConfigurationPtr configuration)
 Context::Context(const Context& primary_context) :
     _shared_mutex(primary_context.getSharedMutexPtr()),
     _configuration(primary_context.getConfigurationPtr()),
+    _initial_specification(primary_context._initial_specification),
     _time_service(primary_context.getTimeServicePtr()),
     _session_data(primary_context.getSessionDataPtr())
 {
@@ -270,8 +272,15 @@ std::shared_ptr<Context> Context::createTargetAlgorithmContext()
 
 void Context::resetState() noexcept
 {
-    for (const auto& service : _services) {
-        service->clearActivationData();
+    if (_current_specification != _initial_specification) {
+        // The specification is different than initial. We have to re-create all services.
+        destroyServices();
+        createServices(false, _initial_specification);
+    } else {
+        // Just clear activation data per-service
+        for (const auto& service : _services) {
+            service->clearActivationData();
+        }
     }
 }
 
@@ -300,11 +309,11 @@ void Context::createServices(bool initial_setup, ConstPowerAuthSpecPtr specifica
         _time_service = std::make_shared<TimeService>(self);
         _session_data = std::make_shared<SessionData>(specification);
     }
-    _specification = specification;
-    _signing_keys_factory = _specification->getSigningKeyPairFactory();
+    _current_specification = specification;
+    _signing_keys_factory = _current_specification->getSigningKeyPairFactory();
     if (version == Version_V4) {
         // V4
-        _shared_secret = ISharedSecret::getInstance(_specification->algorithm());
+        _shared_secret = ISharedSecret::getInstance(_current_specification->algorithm());
         _key_provider = std::make_shared<v4::KeyProviderV4>(self);
         _key_provider->asService()->restoreSensitiveData();
         _vault_service = std::make_shared<VaultService>(self, version);

--- a/src/PowerAuth/Context.h
+++ b/src/PowerAuth/Context.h
@@ -142,7 +142,8 @@ private:
 
     mutable SharedMutexPtr _shared_mutex;
     const ConfigurationPtr _configuration;
-    PowerAuthSpecPtr _specification;
+    const PowerAuthSpecPtr _initial_specification;
+    PowerAuthSpecPtr _current_specification;
     SessionDataPtr _session_data;
     cc7::crypto::KeyPairFactoryPtr _signing_keys_factory;
     

--- a/src/PowerAuth/Context.h
+++ b/src/PowerAuth/Context.h
@@ -62,8 +62,9 @@ public:
     std::shared_ptr<Context> createTargetAlgorithmContext();
     
     /// Reset context state. This is identical to remove activation locally.
-    void resetState() noexcept;
+    void resetState();
     
+    /// If there's target context, then reset the context and remove it.
     void destroyTargetAlgorithmContext();
     
     /// Returns the target algorithm context if exists.


### PR DESCRIPTION
This PR fixes reset of  C++ `Session` object in case the current protocol specification is different than specification from the configuration. The core of the problem was in caching the specification in `Context` and not rollback the value to the target specification, required by the application.

