### PR TITLE
Fix for broken Android biometry

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -10,7 +10,7 @@
 
 ### Both platforms
 
-- OpenSSL upgraded to version `3.5.5`
+- OpenSSL upgraded to version `3.5.6`
 - PowerAuth protocol version 4.0 introduces major cryptographic upgrades to strengthen long-term security and add post-quantum protection. Signature and key agreement mechanisms now use larger elliptic curves (P-384) and optionally operate in hybrid mode with quantum-resistant ML-DSA and ML-KEM algorithms. The end-to-end encryption scheme transitions from ECIES with AES-128/CBC and HMAC-SHA-256 to an AEAD design using AES-256/CTR with KMAC-256, providing stronger integrity and confidentiality guarantees. Overall, version 4.0 modernizes the protocol to align with emerging cryptographic standards and resist future quantum attacks.
 - Existing activations can be upgraded to the new PowerAuth protocol version 4.0 using the authenticated protocol upgrade procedure.
 - You can select a level of security that suits your business needs. See the `PowerAuthConfiguration` documentation for more details.

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -27,11 +27,16 @@
 
 - NPE in BiometricAuthentication when keys invalidated by biometric enrollment ([795](https://github.com/wultra/powerauth-mobile-sdk/issues/795))
 - Biometric authentication offloaded to the background thread ([677](https://github.com/wultra/powerauth-mobile-sdk/issues/677))
+- Change biometric key protection to HMAC-KDF ([888](https://github.com/wultra/powerauth-mobile-sdk/issues/888))
+- Transitive dependency breaks biometry support ([886](https://github.com/wultra/powerauth-mobile-sdk/issues/886))
 
 ### Apple
 
 - Hide symbols from transient dependencies ([688](https://github.com/wultra/powerauth-mobile-sdk/issues/688))
-
+- Synchronize time with PowerAuth Mobile SDK for watchOS ([551](https://github.com/wultra/powerauth-mobile-sdk/issues/551))
+- Missing nullable annotation in `PowerAuthRestApiErrorResponse` ([696](https://github.com/wultra/powerauth-mobile-sdk/issues/696))
+- Direct support for Swift Package Manager ([310](https://github.com/wultra/powerauth-mobile-sdk/issues/310))
+ 
 
 <!--------------------------------------------------->
 ## 1.9.6 (October 2025)

--- a/docs/PowerAuth-SDK-for-Android.md
+++ b/docs/PowerAuth-SDK-for-Android.md
@@ -53,11 +53,11 @@ repositories {
 }
 
 dependencies {
-    compile 'com.wultra.android.powerauth:powerauth-sdk:1.x.y'
+    implementation 'com.wultra.android.powerauth:powerauth-sdk:2.x.y'
 }
 ```
 
-Note that this documentation is using version `1.x.y` as an example. You can find the latest version in our [List of Releases](https://github.com/wultra/powerauth-crypto/blob/develop/docs/Releases.md). The Android Studio IDE can also find and offer updates for your application's dependencies.
+Note that this documentation is using version `2.x.y` as an example. You can find the latest version in our [List of Releases](https://github.com/wultra/powerauth-crypto/blob/develop/docs/Releases.md). The Android Studio IDE can also find and offer updates for your application's dependencies.
 
 From now on, you can use `PowerAuthSDK` class in your project.
 

--- a/docs/Supported-Versions.md
+++ b/docs/Supported-Versions.md
@@ -6,7 +6,7 @@ We currently support the following versions of mobile OS:
 - tvOS: 13.0
 - watchOS 4.0
 - macOS Catalyst: 13.5
-- Android 5.0 (API level 21)
+- Android 6.0 (API level 23)
 
 ## Feature Limitations
 

--- a/proj-android/PowerAuthLibrary/build.gradle
+++ b/proj-android/PowerAuthLibrary/build.gradle
@@ -75,11 +75,11 @@ android {
 
     dependencies {
         implementation 'io.getlime.core:rest-model-base:1.12.0'
-        implementation 'androidx.annotation:annotation:1.9.1'
+        implementation 'androidx.annotation:annotation:1.10.0'
         implementation 'androidx.appcompat:appcompat:1.7.1'
         implementation 'androidx.fragment:fragment:1.8.9'
-        implementation 'androidx.biometric:biometric:1.1.0'
-        implementation 'com.google.code.gson:gson:2.13.2'
+        implementation 'androidx.biometric:biometric:1.4.0-alpha07'
+        implementation 'com.google.code.gson:gson:2.14.0'
 
         // testing
         androidTestImplementation 'androidx.test:core:1.7.0'
@@ -87,7 +87,7 @@ android {
         androidTestImplementation 'androidx.test:rules:1.7.0'
         androidTestImplementation 'androidx.test.ext:junit:1.3.0'
         androidTestImplementation 'io.getlime.core:rest-model-base:1.12.0'
-        androidTestImplementation 'com.google.code.gson:gson:2.13.2'
+        androidTestImplementation 'com.google.code.gson:gson:2.14.0'
 
         constraints {
             def kotlinVersion = "1.8.20" // brought transitively from dependencies

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricAuthentication.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricAuthentication.java
@@ -34,7 +34,6 @@ import io.getlime.security.powerauth.biometry.impl.IBiometricAuthenticator;
 import io.getlime.security.powerauth.biometry.impl.IBiometricKeyEncryptorProvider;
 import io.getlime.security.powerauth.biometry.impl.PrivateRequestData;
 import io.getlime.security.powerauth.biometry.impl.dummy.DummyBiometricAuthenticator;
-import io.getlime.security.powerauth.biometry.impl.dummy.DummyBiometricKeystore;
 import io.getlime.security.powerauth.exception.PowerAuthErrorCodes;
 import io.getlime.security.powerauth.exception.PowerAuthErrorException;
 import io.getlime.security.powerauth.networking.interfaces.ICancelable;
@@ -62,10 +61,7 @@ public class BiometricAuthentication {
      * @return Object implementing {@link IBiometricKeystore} interface.
      */
     public static @NonNull IBiometricKeystore getBiometricKeystore() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            return new BiometricKeystore();
-        }
-        return new DummyBiometricKeystore();
+        return new BiometricKeystore();
     }
 
 
@@ -437,12 +433,9 @@ public class BiometricAuthentication {
             if (authenticator != null) {
                 return authenticator;
             }
-            // If Android 6.0 "Marshmallow" and newer, then try to build authenticator using BiometricPrompt from support lib.
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                final IBiometricAuthenticator newAuthenticator = BiometricAuthenticator.createAuthenticator(context, getBiometricKeystore());
-                if (newAuthenticator != null) {
-                    return newAuthenticator;
-                }
+            final IBiometricAuthenticator newAuthenticator = BiometricAuthenticator.createAuthenticator(context, getBiometricKeystore());
+            if (newAuthenticator != null) {
+                return newAuthenticator;
             }
             // Otherwise return dummy authenticator, which provides no biometric functions.
             // In this case, we can cache the authenticator.

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricAuthentication.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/BiometricAuthentication.java
@@ -54,9 +54,7 @@ import io.getlime.security.powerauth.system.PowerAuthLog;
 public class BiometricAuthentication {
 
   /**
-     * Returns object representing a Keystore used to store biometry related key. If the biometric
-     * authentication is not available on the authenticator, then returns a dummy implementation where
-     * all interface methods fails, or does not provide the required information.
+     * Returns object representing a Keystore used to store biometry related key.
      *
      * @return Object implementing {@link IBiometricKeystore} interface.
      */

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricAuthenticator.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricAuthenticator.java
@@ -46,7 +46,6 @@ import io.getlime.security.powerauth.system.PowerAuthLog;
  * {@link BiometricPrompt} support library. This implementation is automatically used on devices with
  * Android 6.0 and newer.
  */
-@RequiresApi(api = Build.VERSION_CODES.M)
 public class BiometricAuthenticator implements IBiometricAuthenticator {
 
     private final @NonNull Context context;
@@ -129,6 +128,7 @@ public class BiometricAuthenticator implements IBiometricAuthenticator {
 
             case BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE:
             case BiometricManager.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED:
+            case BiometricManager.BIOMETRIC_ERROR_IDENTITY_CHECK_NOT_ACTIVE:
                 return BiometricStatus.NOT_AVAILABLE;
 
             case BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED:

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorAes.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorAes.java
@@ -52,7 +52,6 @@ import io.getlime.security.powerauth.system.PowerAuthLog;
  * <p>
  * The cipher configuration is compatible with previous versions of PowerAuth SDK (1.4.3 and older).
  */
-@RequiresApi(api = Build.VERSION_CODES.M)
 public class BiometricKeyEncryptorAes implements IBiometricKeyEncryptor {
 
     /**

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorMac.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorMac.java
@@ -45,7 +45,6 @@ import io.getlime.security.powerauth.system.PowerAuthLog;
  * protection of PowerAuth biometric factor with using symmetric HMAC KDF. The key is stored in
  * Android KeyStore and the biometric authentication is required for key creation and use.
  */
-@RequiresApi(api = Build.VERSION_CODES.M)
 public class BiometricKeyEncryptorMac implements IBiometricKeyEncryptor {
 
     /**

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorRsa.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeyEncryptorRsa.java
@@ -56,7 +56,6 @@ import io.getlime.security.powerauth.system.PowerAuthLog;
  * is stored in Android KeyStore and the biometric authentication is required only for data
  * decryption.
  */
-@RequiresApi(api = Build.VERSION_CODES.M)
 public class BiometricKeyEncryptorRsa implements IBiometricKeyEncryptor {
 
     /**

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeystore.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/biometry/impl/BiometricKeystore.java
@@ -43,7 +43,6 @@ import io.getlime.security.powerauth.system.PowerAuthLog;
 /**
  * Class representing a Keystore used to store biometry related key.
  */
-@RequiresApi(api = Build.VERSION_CODES.M)
 public class BiometricKeystore implements IBiometricKeystore {
 
     private static final String KEY_NAME_PREFIX = "com.wultra.powerauth.biometricKey.";

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/keychain/KeychainFactory.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/keychain/KeychainFactory.java
@@ -155,43 +155,34 @@ public class KeychainFactory {
     @NonNull
     private static Keychain createKeychain(@NonNull Context context, @NonNull SharedData sharedData, @NonNull String identifier) {
         final SharedPreferences preferences = context.getSharedPreferences(identifier, Context.MODE_PRIVATE);
-        final boolean isAlreadyEncrypted;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            isAlreadyEncrypted = EncryptedKeychain.isEncryptedContentInSharedPreferences(preferences);
-        } else {
-            isAlreadyEncrypted = false;
-        }
+        final boolean isAlreadyEncrypted = EncryptedKeychain.isEncryptedContentInSharedPreferences(preferences);
         final int keychainProtection = sharedData.getKeychainProtection(context);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            if (keychainProtection != KeychainProtection.NONE || isAlreadyEncrypted) {
-                // If Android "M" and later, then create a secret key provider and try to create an encrypted keychain.
-                final SymmetricKeyProvider masterKeyProvider = sharedData.getMasterEncryptionKeyProvider(context);
-                final SymmetricKeyProvider backupKeyProvider = sharedData.getBackupEncryptionKeyProvider(context);
-                if (masterKeyProvider != null) {
-                    final EncryptedKeychain encryptedKeychain = new EncryptedKeychain(context, identifier, masterKeyProvider, backupKeyProvider);
-                    if (isAlreadyEncrypted) {
-                        // If keychain is already encrypted, then just validate encryption support.
-                        // The update function may fail in case that re-encryption did not end well,
-                        // and the previously encrypted content was stored back to the legacy keychain.
-                        if (encryptedKeychain.updateEncryptionSupport(preferences)) {
-                            return encryptedKeychain;
-                        }
-                    } else if (encryptedKeychain.importFromLegacyKeychain(preferences)) {
-                        // Import from legacy keychain succeeded, so return encrypted keychain.
+        if (keychainProtection != KeychainProtection.NONE || isAlreadyEncrypted) {
+            // Create a secret key provider and try to create an encrypted keychain.
+            final SymmetricKeyProvider masterKeyProvider = sharedData.getMasterEncryptionKeyProvider(context);
+            final SymmetricKeyProvider backupKeyProvider = sharedData.getBackupEncryptionKeyProvider(context);
+            if (masterKeyProvider != null) {
+                final EncryptedKeychain encryptedKeychain = new EncryptedKeychain(context, identifier, masterKeyProvider, backupKeyProvider);
+                if (isAlreadyEncrypted) {
+                    // If keychain is already encrypted, then just validate encryption support.
+                    // The update function may fail in case that re-encryption did not end well,
+                    // and the previously encrypted content was stored back to the legacy keychain.
+                    if (encryptedKeychain.updateEncryptionSupport(preferences)) {
                         return encryptedKeychain;
                     }
+                } else if (encryptedKeychain.importFromLegacyKeychain(preferences)) {
+                    // Import from legacy keychain succeeded, so return encrypted keychain.
+                    return encryptedKeychain;
                 }
             }
         }
 
         // Otherwise just return the legacy keychain.
         final Keychain keychain =  new LegacyKeychain(context, identifier);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            if (EncryptedKeychain.isEncryptedContentInSharedPreferences(preferences)) {
-                // Print error in case that keychain was previously encrypted and now it's not.
-                PowerAuthLog.e("KeychainFactory: " + identifier + ": The content was previously encrypted but the encryption is no longer available.");
-                keychain.removeAll();
-            }
+        if (EncryptedKeychain.isEncryptedContentInSharedPreferences(preferences)) {
+            // Print error in case that keychain was previously encrypted and now it's not.
+            PowerAuthLog.e("KeychainFactory: " + identifier + ": The content was previously encrypted but the encryption is no longer available.");
+            keychain.removeAll();
         }
         return keychain;
     }
@@ -300,7 +291,6 @@ public class KeychainFactory {
          * @return Instance of {@link SymmetricKeyProvider} configured for AES-GCM with 256bit key.
          */
         @Nullable
-        @RequiresApi(api = Build.VERSION_CODES.M)
         SymmetricKeyProvider getMasterEncryptionKeyProvider(@NonNull Context context) {
             if (masterEncryptionKeyProvider == null) {
                 masterEncryptionKeyProvider = SymmetricKeyProvider.getAesGcmKeyProvider(MASTER_KEY_ALIAS, true, getStrongBoxSupport(context), MASTER_KEY_SIZE, true,null);
@@ -318,7 +308,6 @@ public class KeychainFactory {
          * @return Instance of backup {@link SymmetricKeyProvider} configured for AES-GCM with 256bit key.
          */
         @Nullable
-        @RequiresApi(api = Build.VERSION_CODES.M)
         SymmetricKeyProvider getBackupEncryptionKeyProvider(@NonNull Context context) {
             if (backupEncryptionKeyProvider == null) {
                 final KeychainProtectionSupport keychainProtectionSupport = getStrongBoxSupport(context);
@@ -340,41 +329,39 @@ public class KeychainFactory {
         @KeychainProtection int getKeychainProtection(@NonNull Context context) {
             if (keychainProtection == 0) {
                 // Protection level is not determined yet (e.g. value is equal to `0`)
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    final SymmetricKeyProvider keyProvider = EncryptedKeychain.determineEffectiveSymmetricKeyProvider(
-                            getMasterEncryptionKeyProvider(context),
-                            getBackupEncryptionKeyProvider(context));
-                    final SecretKey secretKey = keyProvider != null ? keyProvider.getOrCreateSecretKey(context, false) : null;
-                    final KeyInfo secretKeyInfo = keyProvider != null ? keyProvider.getSecretKeyInfo(context) : null;
-                    if (secretKey != null && secretKeyInfo != null) {
-                        final KeychainProtectionSupport keychainProtectionSupport = keyProvider.getKeychainProtectionSupport();
-                        if (keychainProtectionSupport.isKeyStoreEncryptionEnabled()) {
-                            if (EncryptedKeychain.verifyKeystoreEncryption(context, keyProvider)) {
-                                // We can trust KeyStore, just determine the level of protection
-                                if (secretKeyInfo.isInsideSecureHardware()) {
-                                    if (keychainProtectionSupport.isStrongBoxSupported()) {
-                                        if (keychainProtectionSupport.isStrongBoxEnabled()) {
-                                            // Keychain encryption key is stored in StrongBox.
-                                            keychainProtection = KeychainProtection.STRONGBOX;
-                                        } else {
-                                            // Keychain encryption key should not be stored in StrongBox due to its poor reliability.
-                                            PowerAuthLog.e("KeychainFactory: StrongBox is supported but not enabled on this device.");
-                                            keychainProtection = KeychainProtection.HARDWARE;
-                                        }
+                final SymmetricKeyProvider keyProvider = EncryptedKeychain.determineEffectiveSymmetricKeyProvider(
+                        getMasterEncryptionKeyProvider(context),
+                        getBackupEncryptionKeyProvider(context));
+                final SecretKey secretKey = keyProvider != null ? keyProvider.getOrCreateSecretKey(context, false) : null;
+                final KeyInfo secretKeyInfo = keyProvider != null ? keyProvider.getSecretKeyInfo(context) : null;
+                if (secretKey != null && secretKeyInfo != null) {
+                    final KeychainProtectionSupport keychainProtectionSupport = keyProvider.getKeychainProtectionSupport();
+                    if (keychainProtectionSupport.isKeyStoreEncryptionEnabled()) {
+                        if (EncryptedKeychain.verifyKeystoreEncryption(context, keyProvider)) {
+                            // We can trust KeyStore, just determine the level of protection
+                            if (secretKeyInfo.isInsideSecureHardware()) {
+                                if (keychainProtectionSupport.isStrongBoxSupported()) {
+                                    if (keychainProtectionSupport.isStrongBoxEnabled()) {
+                                        // Keychain encryption key is stored in StrongBox.
+                                        keychainProtection = KeychainProtection.STRONGBOX;
                                     } else {
-                                        // Keychain encryption key is stored in the dedicated secure hardware, but is not StrongBox backed.
+                                        // Keychain encryption key should not be stored in StrongBox due to its poor reliability.
+                                        PowerAuthLog.e("KeychainFactory: StrongBox is supported but not enabled on this device.");
                                         keychainProtection = KeychainProtection.HARDWARE;
                                     }
                                 } else {
-                                    // Keychain encryption key is not stored in the dedicated secure hardware.
-                                    keychainProtection = KeychainProtection.SOFTWARE;
+                                    // Keychain encryption key is stored in the dedicated secure hardware, but is not StrongBox backed.
+                                    keychainProtection = KeychainProtection.HARDWARE;
                                 }
+                            } else {
+                                // Keychain encryption key is not stored in the dedicated secure hardware.
+                                keychainProtection = KeychainProtection.SOFTWARE;
                             }
-                        } else if (keychainProtectionSupport.isKeyStoreEncryptionSupported()) {
-                            // Keychain encryption is supported but not enabled for this device de to poor KeyStore reliability.
-                            PowerAuthLog.e("KeychainFactory: Android KeyStore is supported but not enabled on this device.");
-                            keychainProtection = KeychainProtection.NONE;
                         }
+                    } else if (keychainProtectionSupport.isKeyStoreEncryptionSupported()) {
+                        // Keychain encryption is supported but not enabled for this device de to poor KeyStore reliability.
+                        PowerAuthLog.e("KeychainFactory: Android KeyStore is supported but not enabled on this device.");
+                        keychainProtection = KeychainProtection.NONE;
                     }
                 }
                 // If keychain protection is still undetermined, then it means that some operation

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/keychain/KeychainFactory.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/keychain/KeychainFactory.java
@@ -359,7 +359,7 @@ public class KeychainFactory {
                             }
                         }
                     } else if (keychainProtectionSupport.isKeyStoreEncryptionSupported()) {
-                        // Keychain encryption is supported but not enabled for this device de to poor KeyStore reliability.
+                        // Keychain encryption is supported but not enabled for this device due to poor KeyStore reliability.
                         PowerAuthLog.e("KeychainFactory: Android KeyStore is supported but not enabled on this device.");
                         keychainProtection = KeychainProtection.NONE;
                     }

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/keychain/SymmetricKeyProvider.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/keychain/SymmetricKeyProvider.java
@@ -49,7 +49,6 @@ import io.getlime.security.powerauth.system.PowerAuthLog;
 /**
  * The {@code SymmetricKeyProvider} class manages symmetric encryption key stored in Android KeyStore.
  */
-@RequiresApi(api = Build.VERSION_CODES.M)
 public class SymmetricKeyProvider {
 
     public static final String ANDROID_KEY_STORE = "AndroidKeyStore";

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/keychain/impl/DefaultKeychainProtectionSupport.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/keychain/impl/DefaultKeychainProtectionSupport.java
@@ -88,14 +88,11 @@ public class DefaultKeychainProtectionSupport implements KeychainProtectionSuppo
      * @return {@code true} if KeyStore backed keys are available on the current device.
      */
     private static boolean getKeyStoreEncryptionIsSupported(@NonNull Context context) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            try {
-                return KeyStore.getInstance(SymmetricKeyProvider.ANDROID_KEY_STORE) != null;
-            } catch (KeyStoreException e) {
-                return false;
-            }
+        try {
+            return KeyStore.getInstance(SymmetricKeyProvider.ANDROID_KEY_STORE) != null;
+        } catch (KeyStoreException e) {
+            return false;
         }
-        return false;
     }
 
     /**

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/keychain/impl/EncryptedKeychain.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/keychain/impl/EncryptedKeychain.java
@@ -47,7 +47,6 @@ import io.getlime.security.powerauth.system.PowerAuthLog;
  * <p>
  * The "AES/GCM/NoPadding" scheme is used for encryption and decryption.
  */
-@RequiresApi(api = Build.VERSION_CODES.M)
 public class EncryptedKeychain implements Keychain {
 
     /**

--- a/proj-android/build.gradle
+++ b/proj-android/build.gradle
@@ -35,7 +35,7 @@ plugins {
 ext {
     compileSdkVersion = 36
     targetSdkVersion = 36
-    minSdkVersion = 21
+    minSdkVersion = 23
     buildToolsVersion = "36.1.0"
     // NDK, check https://developer.android.com/ndk/downloads for updates
     ndkVersion = "27.3.13750724" // LTS r27d


### PR DESCRIPTION
This PR updates library dependencies, most notably `androidx.biometric:biometric:1.4.0-alpha07`. The primary purpose of this update is to avoid possible compatibility issues if the application is using `androidx.core:core-ktx:1.18.0` and newer.

As a side effect of this change, the minSdk is raised to 23 and therefore the change also removes dead code for no longer supported Android versions.