### PR TITLE
Support for temporary activation block

### DIFF
--- a/docs/PowerAuth-SDK-for-Android.md
+++ b/docs/PowerAuth-SDK-for-Android.md
@@ -629,6 +629,15 @@ if (powerAuthSDK.hasValidActivation()) {
             if (status.isProtocolUpgradeAvailable) {
                 // Upgrade to new protocol is available
             }
+            if (status.blockExpirationTime != null) {
+                // Activation is temporarily blocked. Use synchronized time to compare
+                // the timestamp received from the server.
+                val currentTime = powerAuthSDK.timeSynchronizationService.currentTime
+                val remainingBlockTime = status.blockExpirationTime - currentTime
+                if (remainingBlockTime > 0) {
+                    Log.i(TAG, "Milliseconds to activation unblock ${remainingBlockTime}")
+                }
+            }
         }
 
         override fun onActivationStatusFailed(t: Throwable) {

--- a/docs/PowerAuth-SDK-for-iOS.md
+++ b/docs/PowerAuth-SDK-for-iOS.md
@@ -554,7 +554,15 @@ if powerAuthSDK.hasValidActivation() {
             if status.isProtocolUpgradeAvailable {
                 // Upgrade to new protocol version is available
             }
-
+            if let unblockTime = status.blockExpirationTime {
+                // Activation is temporarily blocked. Use synchronized time to compare
+                // the timestamp received from the server.
+                let currentTime = powerAuthSDK.timeSynchronizationService.currentTime()
+                let remainingBlockTime = unblockTime.timeIntervalSince1970 - currentTime
+                if remainingBlockTime > 0 {
+                    print("Seconds to activation unblock \(remainingBlockTime)")
+                }
+            }
         } else {
             // Network error occurred, report it to the user
         }

--- a/include/PowerAuth/ActivationStatus.h
+++ b/include/PowerAuth/ActivationStatus.h
@@ -148,6 +148,9 @@ public:
     /// ```
     cc7::byte remainingAttempts() const noexcept;
     
+    /// If the activation is temporarily blocked, contains the time when it will be unblocked.
+    /// The value is in milliseconds since Unix epoch.
+    const std::optional<Timestamp>& blockExpirationTime() const noexcept;
     
     struct BinaryData
     {
@@ -180,11 +183,13 @@ public:
     ///   - activation_state: State of activation.
     ///   - counter_state: State of counter.
     ///   - data: Parsed blob structure.
+    ///   - block_expiration_time: If set, then contains Unix timestamp with milliseconds precision when the activation will be unblocked.
     ///   - custom_object: Custom object received together with the status blob.
     ActivationStatus(ProtocolVersion version,
                      ActivationState activation_state,
                      CounterState counter_state,
                      const BinaryData& data,
+                     std::optional<Timestamp> block_expiration_time,
                      const cc7::json::JsonValue& custom_object);
 private:
     
@@ -213,6 +218,7 @@ private:
     bool _is_protocol_upgrade_available;
     bool _is_remove_biometric_kek_recommended;
     
+    std::optional<Timestamp> _block_expiration_time;
     cc7::json::JsonValue _custom_object;
 };
 

--- a/include/PowerAuth/ActivationStatus.h
+++ b/include/PowerAuth/ActivationStatus.h
@@ -189,7 +189,7 @@ public:
                      ActivationState activation_state,
                      CounterState counter_state,
                      const BinaryData& data,
-                     std::optional<Timestamp> block_expiration_time,
+                     const std::optional<Timestamp>& block_expiration_time,
                      const cc7::json::JsonValue& custom_object);
 private:
     

--- a/include/PowerAuth/Types.h
+++ b/include/PowerAuth/Types.h
@@ -21,6 +21,7 @@
 #include <cc7/json/Json.h>
 #include <PowerAuth/Exception.h>
 #include <mutex>
+#include <optional>
 
 namespace powerAuth {
 

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/model/ServerVersion.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/support/model/ServerVersion.java
@@ -39,6 +39,8 @@ public enum ServerVersion {
     V1_9_0("1.9", 1009000, ProtocolVersion.V3_3),
     V1_10_0("1.10", 1010000, ProtocolVersion.V3_3),
     V2_0_0("2.0", 2000000, ProtocolVersion.V4_0),
+    V2_1_0("2.1", 2010000, ProtocolVersion.V4_0),
+    V2_2_0("2.2", 2020000, ProtocolVersion.V4_0),
     ;
 
     /**
@@ -54,7 +56,7 @@ public enum ServerVersion {
     /**
      * Contains constant for the latest PowerAuth Server version.
      */
-    public static final ServerVersion LATEST = V2_0_0;
+    public static final ServerVersion LATEST = V2_2_0;
 
     /**
      * Server version represented as string.

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BaseSdkTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BaseSdkTest.java
@@ -586,6 +586,7 @@ public class BaseSdkTest extends BaseTest {
             return;
         }
         long remainingWait = expiration - powerAuthSDK.getTimeSynchronizationService().getCurrentTime();
+        assertTrue(remainingWait >= 0);
         if (remainingWait < 2000) {
             PowerAuthLog.d("Waiting for activation unblock " + remainingWait + "ms");
             Thread.sleep(remainingWait + 100);

--- a/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BaseSdkTest.java
+++ b/proj-android/PowerAuthLibrary/src/androidTest/java/io/getlime/security/powerauth/integration/tests/BaseSdkTest.java
@@ -44,6 +44,7 @@ import io.getlime.security.powerauth.sdk.PowerAuthAuthentication;
 import io.getlime.security.powerauth.sdk.PowerAuthConfiguration;
 import io.getlime.security.powerauth.sdk.PowerAuthKeychainConfiguration;
 import io.getlime.security.powerauth.sdk.PowerAuthSDK;
+import io.getlime.security.powerauth.system.PowerAuthLog;
 import io.getlime.security.powerauth.system.PowerAuthSystem;
 
 import static org.junit.Assert.*;
@@ -560,6 +561,44 @@ public class BaseSdkTest extends BaseTest {
             });
         });
         assertTrue(powerAuthSDK.hasValidActivation());
+    }
+
+    @Test
+    public void testTemporaryBlock() throws Exception {
+        if (getCurrentAlgorithm() == PowerAuthAlgorithm.LEGACY_P256) {
+            return;
+        }
+        activationHelper.createStandardActivation(true, null);
+        PowerAuthActivationStatus status = activationHelper.fetchActivationStatus();
+        for (int i = 0; i < status.getMaxFailCount(); i++) {
+            activationHelper.validateUserPassword(activationHelper.getInvalidPassword());
+            status = activationHelper.fetchActivationStatus();
+            assertEquals(i + 1, status.getFailCount());
+            if (status.getRemainingAttempts() == 0) {
+                assertEquals(PowerAuthActivationState.BLOCKED, status.getState());
+            } else {
+                assertEquals(PowerAuthActivationState.ACTIVE, status.getState());
+            }
+        }
+        Long expiration = status.getBlockExpirationTime();
+        if (expiration == null) {
+            PowerAuthLog.w("Temporary block feature is not turned on the server");
+            return;
+        }
+        long remainingWait = expiration - powerAuthSDK.getTimeSynchronizationService().getCurrentTime();
+        if (remainingWait < 2000) {
+            PowerAuthLog.d("Waiting for activation unblock " + remainingWait + "ms");
+            Thread.sleep(remainingWait + 100);
+            status = activationHelper.fetchActivationStatus();
+            assertEquals(PowerAuthActivationState.ACTIVE, status.getState());
+            assertEquals(1, status.getRemainingAttempts());
+            activationHelper.validateUserPassword(activationHelper.getInvalidPassword());
+            status = activationHelper.fetchActivationStatus();
+            assertEquals(PowerAuthActivationState.BLOCKED, status.getState());
+            assertNotNull(status.getBlockExpirationTime());
+        } else {
+            PowerAuthLog.d("We'll not wait for unblock the activation.");
+        }
     }
 
     // User Info

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/response/CoreActivationStatus.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/response/CoreActivationStatus.java
@@ -21,6 +21,7 @@ import androidx.annotation.Nullable;
 import java.util.Map;
 
 import io.getlime.security.powerauth.core.CoreActivationState;
+import jakarta.validation.constraints.Null;
 
 /**
  * The {@code CoreActivationStatus} object represents complete status of the activation.
@@ -36,6 +37,8 @@ public class CoreActivationStatus {
     private final boolean isSessionSerializationNeeded;
     private final boolean isRemoveBiometricKekRecommended;
     @Nullable
+    private final Long blockExpirationTime;
+    @Nullable
     private final Map<String, Object> customObject;
 
     /**
@@ -48,6 +51,7 @@ public class CoreActivationStatus {
      * @param isCounterSynchronizationRecommended Contains true if dummy authentication code calculation is recommended to prevent the counter's de-synchronization.
      * @param isSessionSerializationNeeded Contains true if session's state should be serialized after the successful activation status decryption.
      * @param isRemoveBiometricKekRecommended Contains true if biometric KEK should be removed from Android Keystore.
+     * @param blockExpirationTime If the activation is temporarily blocked, contains the time when it will be unblocked.
      * @param customObject Contains custom object returned from the server.
      */
     public CoreActivationStatus(int state,
@@ -58,6 +62,7 @@ public class CoreActivationStatus {
                                 boolean isCounterSynchronizationRecommended,
                                 boolean isSessionSerializationNeeded,
                                 boolean isRemoveBiometricKekRecommended,
+                                @Nullable Long blockExpirationTime,
                                 @Nullable Map<String, Object> customObject) {
         this.state = state;
         this.failCount = failCount;
@@ -67,6 +72,7 @@ public class CoreActivationStatus {
         this.isCounterSynchronizationRecommended = isCounterSynchronizationRecommended;
         this.isSessionSerializationNeeded = isSessionSerializationNeeded;
         this.isRemoveBiometricKekRecommended = isRemoveBiometricKekRecommended;
+        this.blockExpirationTime = blockExpirationTime;
         this.customObject = customObject;
     }
 
@@ -126,6 +132,14 @@ public class CoreActivationStatus {
      */
     public boolean isRemoveBiometricKekRecommended() {
         return isRemoveBiometricKekRecommended;
+    }
+
+    /**
+     * @return  If the activation is temporarily blocked, returns the time when it will be unblocked.
+     */
+    @Nullable
+    public Long getBlockExpirationTime() {
+        return blockExpirationTime;
     }
 
     /**

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/response/CoreActivationStatus.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/core/response/CoreActivationStatus.java
@@ -21,7 +21,6 @@ import androidx.annotation.Nullable;
 import java.util.Map;
 
 import io.getlime.security.powerauth.core.CoreActivationState;
-import jakarta.validation.constraints.Null;
 
 /**
  * The {@code CoreActivationStatus} object represents complete status of the activation.

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthActivationStatus.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthActivationStatus.java
@@ -17,6 +17,9 @@
 package io.getlime.security.powerauth.sdk;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.Map;
 
 import io.getlime.security.powerauth.core.response.CoreActivationStatus;
 
@@ -63,6 +66,18 @@ public class PowerAuthActivationStatus {
      */
     public int getRemainingAttempts() {
         return coreStatus.getRemainingAttempts();
+    }
+
+    /**
+     * If the activation is temporarily blocked, function returns the time when it will be unblocked.
+     * <p>
+     * Be aware that if you want to compare this date to the current date, you must use {@link IPowerAuthTimeSynchronizationService} to get the synchronized current time.
+     *
+     * @return The time when the temporarily blocked activation will be unblocked, otherwise {@code null}.
+     */
+    @Nullable
+    public Long getBlockExpirationTime() {
+        return coreStatus.getBlockExpirationTime();
     }
 
     /**

--- a/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthActivationStatus.java
+++ b/proj-android/PowerAuthLibrary/src/main/java/io/getlime/security/powerauth/sdk/PowerAuthActivationStatus.java
@@ -19,8 +19,6 @@ package io.getlime.security.powerauth.sdk;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import java.util.Map;
-
 import io.getlime.security.powerauth.core.response.CoreActivationStatus;
 
 /**

--- a/proj-xcode/PowerAuth2/PowerAuthActivationStatus.h
+++ b/proj-xcode/PowerAuth2/PowerAuthActivationStatus.h
@@ -70,6 +70,12 @@ typedef NS_ENUM(NSInteger, PowerAuthActivationState) {
  */
 @property (nonatomic, assign, readonly) UInt32 remainingAttempts;
 /**
+ If the activation is temporarily blocked, contains the time when it will be unblocked.
+ 
+ Be aware that if you want to compare this date to the current date, you must use `PowerAuthTimeSynchronizationService` to get the synchronized current time.
+ */
+@property (nonatomic, strong, nullable, readonly) NSDate* blockExpirationTime;
+/**
  Contains YES if upgrade to a newer protocol version is available.
  */
 @property (nonatomic, assign, readonly) BOOL isProtocolUpgradeAvailable;

--- a/proj-xcode/PowerAuth2/PowerAuthActivationStatus.m
+++ b/proj-xcode/PowerAuth2/PowerAuthActivationStatus.m
@@ -44,6 +44,11 @@
     return _status.remainingAttempts;
 }
 
+- (NSDate*) blockExpirationTime
+{
+    return _status.blockExpirationTime;
+}
+
 - (BOOL) isProtocolUpgradeAvailable
 {
     return _status.isProtocolUpgradeAvailable;

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKBaseTests.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKBaseTests.m
@@ -536,6 +536,7 @@
     
     status = [_helper fetchActivationStatus];
     XCTAssertEqual(status.state, PowerAuthActivationState_Blocked);
+    XCTAssertNil(status.blockExpirationTime);   // activation was manually blocked
 
     // 3) Unblock activation & fetch status
     serverStatus = [testServerApi unblockActivation:activation.activationId];
@@ -709,6 +710,59 @@
             // blocked
             XCTAssertTrue(after.state == PowerAuthActivationState_Blocked, @"Activation should be blocked");
         }
+    }
+}
+
+- (void) testTemporaryBlock
+{
+    CHECK_TEST_CONFIG();
+    
+    //
+    // This test checks whether time of temporary block expiration is propagated to application.
+    // The test requires protocol V4 and temporary block feature turned on on the server.
+    //
+    
+    if ([self powerAuthAlgorithm] == PowerAuthAlgorithm_LEGACY_P256) {
+        return;
+    }
+    
+    PowerAuthSdkActivation * activation = [_helper createActivation:YES];
+    if (!activation) {
+        return;
+    }
+    
+    PowerAuthActivationStatus * status = [_helper fetchActivationStatus];
+    for (UInt32 i = 0; i < status.maxFailCount; i++) {
+        XCTAssertFalse([_helper checkForPassword:@"MustBeWrong"]);
+        status = [_helper fetchActivationStatus];
+        XCTAssertEqual(status.failCount, i + 1);
+        if (status.failCount == status.maxFailCount) {
+            XCTAssertEqual(PowerAuthActivationState_Blocked, status.state);
+        } else {
+            XCTAssertEqual(PowerAuthActivationState_Active, status.state);
+        }
+    }
+    
+    NSDate * expiration = status.blockExpirationTime;
+    if (!expiration) {
+        NSLog(@"WARNING: Temporary block feature is not turned on the server");
+        return;
+    }
+    
+    NSTimeInterval remainingWait = expiration.timeIntervalSince1970 - _sdk.timeSynchronizationService.currentTime;
+    if (remainingWait < 2) {
+        NSLog(@"Waiting for activation unblock: %@", @(remainingWait));
+        [NSThread sleepForTimeInterval:remainingWait + 0.1];
+        status = [_helper fetchActivationStatus];
+        XCTAssertEqual(PowerAuthActivationState_Active, status.state);
+        XCTAssertNil(status.blockExpirationTime);
+        XCTAssertEqual(1, status.remainingAttempts);
+        XCTAssertFalse([_helper checkForPassword:@"MustBeWrong"]);
+        status = [_helper fetchActivationStatus];
+        XCTAssertEqual(PowerAuthActivationState_Blocked, status.state);
+        XCTAssertNotNil(status.blockExpirationTime);
+    } else {
+        NSLog(@"We'll not wait for unblock the activation.");
     }
 }
 

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKBaseTests.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthSDKBaseTests.m
@@ -750,7 +750,8 @@
     }
     
     NSTimeInterval remainingWait = expiration.timeIntervalSince1970 - _sdk.timeSynchronizationService.currentTime;
-    if (remainingWait < 2) {
+    
+    if (remainingWait >= 0 && remainingWait < 2) {
         NSLog(@"Waiting for activation unblock: %@", @(remainingWait));
         [NSThread sleepForTimeInterval:remainingWait + 0.1];
         status = [_helper fetchActivationStatus];
@@ -762,6 +763,7 @@
         XCTAssertEqual(PowerAuthActivationState_Blocked, status.state);
         XCTAssertNotNil(status.blockExpirationTime);
     } else {
+        XCTAssertTrue(remainingWait >= 0);
         NSLog(@"We'll not wait for unblock the activation.");
     }
 }

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServer/PowerAuthTestServerConfig.h
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServer/PowerAuthTestServerConfig.h
@@ -34,6 +34,8 @@ typedef NS_ENUM(int, PowerAuthTestServerVersion) {
     PATS_V1_9   = 10900,    // V3.3 crypto + Activation OTP, applicationId as String, userInfo, temporary keys
     PATS_V1_10  = 11000,    // V3.3 crypto + Activation OTP, applicationId as String, userInfo, temporary keys
     PATS_V2_0   = 20000,    // V4.0 crypto
+    PATS_V2_1   = 20100,    // V4.0 crypto
+    PATS_V2_2   = 20200,    // V4.0 crypto + Temp. activation block
 };
 
 /**

--- a/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServer/PowerAuthTestServerConfig.m
+++ b/proj-xcode/PowerAuth2IntegrationTests/PowerAuthServer/PowerAuthTestServerConfig.m
@@ -67,7 +67,7 @@ PowerAuthProtocolVersion PATSProtoVer(PowerAuthTestServerVersion serverVer)
 
 static int s_KnownVersions[] = {
     PATS_V1_0, PATS_V1_1, PATS_V1_2, PATS_V1_2_5, PATS_V1_3, PATS_V1_4, PATS_V1_5, PATS_V1_6, PATS_V1_7, PATS_V1_8, PATS_V1_9, PATS_V1_10,
-    PATS_V2_0
+    PATS_V2_0, PATS_V2_1, PATS_V2_2
     ,
     0
 };

--- a/proj-xcode/PowerAuthCore/PowerAuthCoreActivationStatus.h
+++ b/proj-xcode/PowerAuthCore/PowerAuthCoreActivationStatus.h
@@ -45,6 +45,8 @@ typedef NS_ENUM(int, PowerAuthCoreActivationState) {
 /// Contains (maxFailCount - failCount) if state is `PowerAuthCoreActivationState_Active`,
 /// otherwise `0`.
 @property (nonatomic, assign, readonly) UInt32 remainingAttempts;
+/// If activation is temporarily blocked, then contains time when the activation will be unblocked.
+@property (nonatomic, strong, nullable, readonly) NSDate * blockExpirationTime;
 
 // SDK-private (application should not use such interface)
 

--- a/proj-xcode/PowerAuthCore/PowerAuthCoreActivationStatus.mm
+++ b/proj-xcode/PowerAuthCore/PowerAuthCoreActivationStatus.mm
@@ -17,6 +17,7 @@
 
 #import "PowerAuthCoreActivationStatus.h"
 #include <PowerAuth/ActivationStatus.h>
+#include <PowerAuth/TimeService.h>
 #include <cc7/objc/ObjcJson.h>
 
 @implementation PowerAuthCoreActivationStatus
@@ -30,6 +31,9 @@
     if (self) {
         _status = status;
         _customObject = cc7::objc::JsonValueToObjC(status->customObject());
+        if (status->blockExpirationTime().has_value()) {
+            _blockExpirationTime = [NSDate dateWithTimeIntervalSince1970:powerAuth::TimestampToTimeInterval(status->blockExpirationTime().value())];
+        }
     }
     return self;
 }

--- a/src/PowerAuth/ActivationStatus.cpp
+++ b/src/PowerAuth/ActivationStatus.cpp
@@ -33,7 +33,7 @@ ActivationStatus::ActivationStatus(ProtocolVersion version,
                                    ActivationState activation_state,
                                    CounterState counter_state,
                                    const BinaryData& data,
-                                   std::optional<Timestamp> block_expiration_time,
+                                   const std::optional<Timestamp>& block_expiration_time,
                                    const cc7::json::JsonValue& custom_object) :
     _protocol_version(version),
     _activation_state(activation_state),

--- a/src/PowerAuth/ActivationStatus.cpp
+++ b/src/PowerAuth/ActivationStatus.cpp
@@ -33,6 +33,7 @@ ActivationStatus::ActivationStatus(ProtocolVersion version,
                                    ActivationState activation_state,
                                    CounterState counter_state,
                                    const BinaryData& data,
+                                   std::optional<Timestamp> block_expiration_time,
                                    const cc7::json::JsonValue& custom_object) :
     _protocol_version(version),
     _activation_state(activation_state),
@@ -46,6 +47,7 @@ ActivationStatus::ActivationStatus(ProtocolVersion version,
     _is_protocol_upgrade_available(data.currentVersion < data.upgradeVersion),
     _is_pending_upgrade_confirm(data.statusFlags & STATUS_FLAG_UPGRADE_CONFIRM),
     _is_remove_biometric_kek_recommended(false),
+    _block_expiration_time(block_expiration_time),
     _custom_object(custom_object)
 {
     bool is_valid;
@@ -153,6 +155,11 @@ cc7::byte ActivationStatus::remainingAttempts() const noexcept
         return _max_fail_count - _fail_count;
     }
     return 0;
+}
+
+const std::optional<Timestamp>& ActivationStatus::blockExpirationTime() const noexcept
+{
+    return _block_expiration_time;
 }
 
 // MARK: - Parse

--- a/src/PowerAuth/v3/ActivationServiceV3.cpp
+++ b/src/PowerAuth/v3/ActivationServiceV3.cpp
@@ -256,7 +256,7 @@ ResponseObjectPtr ActivationServiceV3::processResponseActivationStatus(Context& 
     }
     
     // Check counter synchronization
-    auto activation_status = std::make_shared<ActivationStatus>(Version_V3, local_state, counter_state, binary_data, custom_object);
+    auto activation_status = std::make_shared<ActivationStatus>(Version_V3, local_state, counter_state, binary_data, std::nullopt, custom_object);
     _session_data->setActivationStatus(activation_status);
     return activation_status;
 }

--- a/src/PowerAuth/v4/ActivationServiceV4.cpp
+++ b/src/PowerAuth/v4/ActivationServiceV4.cpp
@@ -243,10 +243,20 @@ ResponseObjectPtr ActivationServiceV4::processResponseActivationStatus(Context &
     LOCK_GUARD();
     // Extract values
     auto status_blob = response["activationStatus"].asBase64();
-    auto custom_object = response.containsValueAtPath("customObject", cc7::json::JsonValue::Object) ? response["customObject"] : cc7::json::JsonValue::object();
+    auto custom_object = response.containsValueAtPath("customObject", cc7::json::JsonValue::Object)
+            ? response["customObject"]
+            : cc7::json::JsonValue::object();
+    auto unblock_timestamp = response.containsValueAtPath("timestampBlockExpire", cc7::json::JsonValue::Integer)
+            ? std::optional<Timestamp>(response["timestampBlockExpire"].asInteger())
+            : std::nullopt;
+    // Simple input validation
     if (status_blob.size() < v4::STATUS_BLOB_SIZE + v4::STATUS_MAC_SIZE) {
         throw Exception(EC_InvalidData, "Binary status blob is too short");
     }
+    if (unblock_timestamp.has_value() && unblock_timestamp.value() <= 0) {
+        throw Exception(EC_InvalidData, "Block expiration timestamp is invalid");
+    }
+    
     // Verify status MAC
     auto status_blob_data = status_blob.byteRange().subRangeTo(v4::STATUS_BLOB_SIZE);
     auto status_blob_mac  = status_blob.byteRange().subRangeFrom(v4::STATUS_BLOB_SIZE);
@@ -282,15 +292,18 @@ ResponseObjectPtr ActivationServiceV4::processResponseActivationStatus(Context &
         default:
             throw Exception(EC_InvalidData, "Unsupported activation state in binary status blob");
     }
-
     // try synchronize counter
     auto counter_state = trySynchronizeCounter(binary_data, key_mac_ctr_data);
     if (counter_state == ActivationStatus::CounterState_Invalid) {
         // force state to deadlock
         local_state = ActivationState::Deadlock;
     }
-    // Check counter synchronization
-    auto activation_status = std::make_shared<ActivationStatus>(Version_V4, local_state, counter_state, binary_data, custom_object);
+    // Validate unblock timestamp
+    if (unblock_timestamp.has_value() && binary_data.state != ActivationStatus::ServerState_Blocked) {
+        unblock_timestamp = std::nullopt;
+    }
+    // Build status object
+    auto activation_status = std::make_shared<ActivationStatus>(Version_V4, local_state, counter_state, binary_data, unblock_timestamp, custom_object);
     _session_data->setActivationStatus(activation_status);
     return activation_status;
 }

--- a/src/PowerAuthJni/ClassSpecs.h
+++ b/src/PowerAuthJni/ClassSpecs.h
@@ -129,11 +129,12 @@ struct ClassSpecs
             //              boolean isCounterSynchronizationRecommended,
             //              boolean isSessionSerializationNeeded,
             //              boolean isRemoveBiometricKekRecommended,
+            //              Long blockExpirationTime,
             //              Map<String, Object> customObject)
             cc7::jni::JniInitMethod init;
         };
         static constexpr JniMethodSpec methodSpecs[] = {
-                JniMethodSpec::constructor("(IIIIZZZZLjava/util/Map;)V", offsetof(Methods, init))
+                JniMethodSpec::constructor("(IIIIZZZZLjava/lang/Long;Ljava/util/Map;)V", offsetof(Methods, init))
         };
 
         jclass classRef;

--- a/src/PowerAuthJni/CoreSessionJNI.cpp
+++ b/src/PowerAuthJni/CoreSessionJNI.cpp
@@ -259,6 +259,12 @@ CC7_JNI_METHOD_PARAMS(jobject, createActivation, jobject L1Data, jobject L2Data)
 /// Build Java `CoreActivationStatus` from C++ ActivationStatus object.
 static jobject BuildActivationStatus(JNI& jni, const ClassSpecs& specs, const ActivationStatusPtr& status)
 {
+    jobject unblock_timestamp;
+    if (status->blockExpirationTime().has_value()) {
+        unblock_timestamp = jni.createObject(jni.commonSpecs().specLong.methods.initValue, status->blockExpirationTime().value());
+    } else {
+        unblock_timestamp = nullptr;
+    }
     // constructor (int state,
     //              int failCount,
     //              int maxFailCount,
@@ -267,6 +273,7 @@ static jobject BuildActivationStatus(JNI& jni, const ClassSpecs& specs, const Ac
     //              boolean isCounterSynchronizationRecommended,
     //              boolean isSessionSerializationNeeded,
     //              boolean isRemoveBiometricKekRecommended,
+    //              Long blockExpirationTime,
     //              Map<String, Object> customObject)
     return jni.createObject(specs.respActivationStatus.methods.init,
                             jni.toJava(specs.coreActivationState, status->activationState()),
@@ -277,6 +284,7 @@ static jobject BuildActivationStatus(JNI& jni, const ClassSpecs& specs, const Ac
                             status->isCounterSynchronizationRecommended(),
                             status->isSessionStateSerializationRecommended(),
                             status->isRemoveBiometricKekRecommended(),
+                            unblock_timestamp,
                             JsonValueToJava(jni, status->customObject()));
 }
 


### PR DESCRIPTION
This PR adds support for the temporary activation block, introduced in PowerAuth Server 2.2. The feature allows automatic activation unblock after a period of time. To support such a feature on the mobile side, the SDK now provides information about when the activation will be unblocked.

Other changes:
- Integration Tests now supports PowerAuth Server 2.2