### PR TITLE
Context::resetState fix

### DIFF
--- a/proj-xcode/PowerAuthCore.xcodeproj/project.pbxproj
+++ b/proj-xcode/PowerAuthCore.xcodeproj/project.pbxproj
@@ -251,6 +251,8 @@
 		BFCA38402E255A18002F595F /* KeyProviderV3.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BFCA383E2E255A18002F595F /* KeyProviderV3.cpp */; };
 		BFCA38442E26C03C002F595F /* KeyProviderV3Tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BFCA38432E26C03C002F595F /* KeyProviderV3Tests.cpp */; };
 		BFCA38452E26C03C002F595F /* KeyProviderV3Tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BFCA38432E26C03C002F595F /* KeyProviderV3Tests.cpp */; };
+		5E5510022E26C03C00A1B2C3 /* SessionResetStateTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5E5510012E26C03C00A1B2C3 /* SessionResetStateTests.cpp */; };
+		5E5510032E26C03C00A1B2C3 /* SessionResetStateTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5E5510012E26C03C00A1B2C3 /* SessionResetStateTests.cpp */; };
 		BFCA38492E295176002F595F /* ActivationServiceV4.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BFCA38482E295176002F595F /* ActivationServiceV4.cpp */; };
 		BFCA384A2E295176002F595F /* ActivationServiceV4.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BFCA38482E295176002F595F /* ActivationServiceV4.cpp */; };
 		BFEEEBE12A3ADEA8007C6737 /* ByteUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BFEEEBDF2A3ADEA7007C6737 /* ByteUtils.cpp */; };
@@ -707,6 +709,7 @@
 		BFCA383D2E255A18002F595F /* KeyProviderV3.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KeyProviderV3.h; sourceTree = "<group>"; };
 		BFCA383E2E255A18002F595F /* KeyProviderV3.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = KeyProviderV3.cpp; sourceTree = "<group>"; };
 		BFCA38432E26C03C002F595F /* KeyProviderV3Tests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = KeyProviderV3Tests.cpp; sourceTree = "<group>"; };
+		5E5510012E26C03C00A1B2C3 /* SessionResetStateTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SessionResetStateTests.cpp; sourceTree = "<group>"; };
 		BFCA38462E293E13002F595F /* ActivationService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ActivationService.h; sourceTree = "<group>"; };
 		BFCA38472E295176002F595F /* ActivationServiceV4.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ActivationServiceV4.h; sourceTree = "<group>"; };
 		BFCA38482E295176002F595F /* ActivationServiceV4.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ActivationServiceV4.cpp; sourceTree = "<group>"; };
@@ -1146,6 +1149,7 @@
 				BF75F9CF2E0A931E00D1E4F0 /* HybridKeyPairTests.cpp */,
 				BF75F9D02E0A931E00D1E4F0 /* KeyProviderV4Tests.cpp */,
 				BFCA38432E26C03C002F595F /* KeyProviderV3Tests.cpp */,
+				5E5510012E26C03C00A1B2C3 /* SessionResetStateTests.cpp */,
 				BFB6E7782DD7574600F18982 /* SharedSecretTests.cpp */,
 				BFB6E7642DD5CAC600F18982 /* PowerAuthKDFTests.cpp */,
 				BFB6E76E2DD5ECF800F18982 /* PowerAuthAEADTests.cpp */,
@@ -1883,6 +1887,7 @@
 				BFB6E76F2DD5ECF800F18982 /* PowerAuthAEADTests.cpp in Sources */,
 				BF75F9D32E0A931E00D1E4F0 /* KeyProviderV4Tests.cpp in Sources */,
 				BFCA38442E26C03C002F595F /* KeyProviderV3Tests.cpp in Sources */,
+				5E5510022E26C03C00A1B2C3 /* SessionResetStateTests.cpp in Sources */,
 				BF75F9D42E0A931E00D1E4F0 /* HybridKeyPairTests.cpp in Sources */,
 				BF4D85382DDF22CF00D32F55 /* TimeServiceTests.cpp in Sources */,
 				BF4D86742DF852DC00D32F55 /* ClientEncryptorTests.cpp in Sources */,
@@ -1936,6 +1941,7 @@
 				BFB6E7702DD5ECF800F18982 /* PowerAuthAEADTests.cpp in Sources */,
 				BF75F9D12E0A931E00D1E4F0 /* KeyProviderV4Tests.cpp in Sources */,
 				BFCA38452E26C03C002F595F /* KeyProviderV3Tests.cpp in Sources */,
+				5E5510032E26C03C00A1B2C3 /* SessionResetStateTests.cpp in Sources */,
 				BF75F9D22E0A931E00D1E4F0 /* HybridKeyPairTests.cpp in Sources */,
 				BF4D85372DDF22CF00D32F55 /* TimeServiceTests.cpp in Sources */,
 				BF4D86732DF852DC00D32F55 /* ClientEncryptorTests.cpp in Sources */,

--- a/src/PowerAuth/Context.cpp
+++ b/src/PowerAuth/Context.cpp
@@ -272,15 +272,13 @@ std::shared_ptr<Context> Context::createTargetAlgorithmContext()
 
 void Context::resetState()
 {
+    // Clear activation data per-service.
+    clearActivationData();
+    
     if (_current_specification != _initial_specification) {
         // The specification is different than initial. We have to re-create all services.
         destroyServices();
         createServices(false, _initial_specification);
-    } else {
-        // Just clear activation data per-service
-        for (const auto& service : _services) {
-            service->clearActivationData();
-        }
     }
 }
 

--- a/src/PowerAuthTests/PowerAuthTestsList.cpp
+++ b/src/PowerAuthTests/PowerAuthTestsList.cpp
@@ -45,6 +45,9 @@ cc7::tests::UnitTestCreationInfoList GetPowerAuthTestCreationInfoList()
     // v3
     CC7_ADD_UNIT_TEST(KeyProviderV3Tests, list);
     
+    // Session
+    CC7_ADD_UNIT_TEST(SessionResetStateTests, list);
+    
     // legacy
     CC7_ADD_UNIT_TEST(pa2CryptoAESTests, list);
     CC7_ADD_UNIT_TEST(pa2CryptoHMACTests, list);

--- a/src/PowerAuthTests/SessionResetStateTests.cpp
+++ b/src/PowerAuthTests/SessionResetStateTests.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cc7tests/CC7Tests.h>
+#include <PowerAuth/Session.h>
+#include "ConfigurationGenerator.h"
+#include "../PowerAuth/Context.h"
+#include "../PowerAuth/model/Constants.h"
+
+using namespace cc7;
+using namespace cc7::tests;
+using namespace powerAuth;
+
+namespace powerAuthTests {
+
+class SessionResetStateTests : public UnitTest
+{
+public:
+    
+    SessionResetStateTests()
+    {
+        CC7_REGISTER_TEST_METHOD(test_ResetStateWithV3ActivationOnV4Config)
+        CC7_REGISTER_TEST_METHOD(test_ResetStateWithMatchingV3Config)
+    }
+    
+    /// Create serialized session state containing a valid V3 activation. The activation
+    /// is fabricated locally, with no server key-exchange involved.
+    cc7::ByteArray createSerializedV3ActivationState(ConfigurationGenerator& generator)
+    {
+        auto v3_config = Configuration::Builder(generator.sdkConfiguration, PowerAuthSpec::LEGACY_P256)
+                            .withDeviceSpecificData(generator.deviceSpecificData)
+                            .withInstanceId(generator.configuration->instanceId())
+                            .build();
+        auto context = Context::getInstance(v3_config);
+        
+        auto device_key_pair = context->getSigningKeyPairFactoryPtr()->generateKeyPair();
+        auto server_key_pair = context->getSigningKeyPairFactoryPtr()->generateKeyPair();
+        auto shared_secret = cc7::crypto::GetRandomData(16);
+        
+        auto rd = RegistrationData::create(Version_V3);
+        rd->v3() = {
+            cc7::crypto::GetRandomData(16).base64(),                                // activation ID
+            cc7::crypto::GetRandomData(v3::HASH_COUNTER_SIZE),                      // hash counter
+            server_key_pair->getPublicKey().exportKey(cc7::crypto::KEY_FORMAT_RAW), // server public (direct key data)
+            device_key_pair,                                                        // device pair
+            server_key_pair->getPublicKeyPtr(),                                     // server public
+            shared_secret
+        };
+        context->sessionData().setRegistrationData(rd);
+        
+        // "Commit" the activation. The key provider is responsible for the persistent
+        // data creation at the end of the operation.
+        auto creds = InitialCredentials::credentials(cc7::MakeRange("secret.password"));
+        auto secrets = context->keyProvider().unlockInitialSecretKeys(*creds, shared_secret);
+        context->keyProvider().lockSecretKeys(secrets);
+        ccstAssertTrue(context->sessionData().hasPersistentData());
+        
+        return context->sessionData().serialize();
+    }
+    
+    void test_ResetStateWithV3ActivationOnV4Config()
+    {
+        ConfigurationGenerator generator(PowerAuthSpec::EC_P384_ML_L3);
+        auto serialized_state = createSerializedV3ActivationState(generator);
+        
+        // Create session with V4-capable configuration and load state with V3 activation.
+        // This simulates an application configured for V4 with an older V3 activation.
+        auto session = Session::createInstance(generator.configuration);
+        session->loadState(serialized_state);
+        ccstAssertTrue(session->hasValidActivationData());
+        ccstAssertEqual(Version_V3, session->getProtocolVersion());
+        
+        // Reset must remove the activation data even though the current specification
+        // differs from the initial one.
+        session->resetState();
+        ccstAssertFalse(session->hasValidActivationData());
+        ccstAssertTrue(session->canCreateActivation());
+        ccstAssertEqual(Version_V4, session->getProtocolVersion());
+        
+        // The removed activation must not survive the save & restore roundtrip.
+        auto saved_state = session->saveState();
+        auto restored_session = Session::createInstance(generator.configuration);
+        restored_session->loadState(saved_state);
+        ccstAssertFalse(restored_session->hasValidActivationData());
+        ccstAssertTrue(restored_session->canCreateActivation());
+    }
+    
+    void test_ResetStateWithMatchingV3Config()
+    {
+        ConfigurationGenerator generator(PowerAuthSpec::LEGACY_P256);
+        auto serialized_state = createSerializedV3ActivationState(generator);
+        
+        // Create session with V3 configuration matching the protocol version of the activation.
+        auto session = Session::createInstance(generator.configuration);
+        session->loadState(serialized_state);
+        ccstAssertTrue(session->hasValidActivationData());
+        ccstAssertEqual(Version_V3, session->getProtocolVersion());
+        
+        session->resetState();
+        ccstAssertFalse(session->hasValidActivationData());
+        ccstAssertTrue(session->canCreateActivation());
+    }
+};
+
+CC7_CREATE_UNIT_TEST(SessionResetStateTests, "pa2")
+
+} // namespace powerAuthTests


### PR DESCRIPTION
Fixed #917: "resetState" bug.

When there was a pending upgrade, the activation could not be removed locally because the data were never cleaned, and services were just recreated.

I also added tests to cover it. When you remove the change in the Context class, the test fails...
