### PR TITLE
Better errors on iOS

### DIFF
--- a/proj-xcode/PowerAuth2/PowerAuthErrorConstants.m
+++ b/proj-xcode/PowerAuth2/PowerAuthErrorConstants.m
@@ -111,6 +111,9 @@ NSError * PA2WrapError(NSError * error, NSError** out_error)
                 errorCode = PowerAuthErrorCode_Other;
                 break;
         }
+    } else if ([domain isEqualToString:NSURLErrorDomain]) {
+        // Transport-level failure (e.g. timeout, no connection, TLS error)
+        errorCode = PowerAuthErrorCode_NetworkError;
     } else {
         errorCode = PowerAuthErrorCode_Other;
     }

--- a/proj-xcode/PowerAuth2/PowerAuthSDK.m
+++ b/proj-xcode/PowerAuth2/PowerAuthSDK.m
@@ -996,7 +996,7 @@ static PowerAuthSDK * s_inst;
         }
     }
     if (localError) {
-        callback(nil, localError);
+        callback(nil, PA2WrapError(localError, NULL));
         return nil;
     }
     

--- a/proj-xcode/PowerAuth2Private/PA2CoreHttpClient.m
+++ b/proj-xcode/PowerAuth2Private/PA2CoreHttpClient.m
@@ -245,6 +245,8 @@ static NSOperationQueue * _GetSharedConcurrentQueue(void)
         // Make sure the core request is set as failed before we call the completion.
         if (error) {
             [self setCoreRequestFinished:request failure:error urlTask:nil];
+            // Make sure that error reported back to the application has PowerAuthErrorDomain.
+            error = PA2WrapError(error, NULL);
         }
         completion(request, object, error);
     };

--- a/proj-xcode/PowerAuth2Private/PA2CoreTaskWrapper.m
+++ b/proj-xcode/PowerAuth2Private/PA2CoreTaskWrapper.m
@@ -67,9 +67,11 @@
 
 - (void) setFinished:(id)result error:(NSError*)error
 {
+    // Make sure that error reported back to the application has PowerAuthErrorDomain.
+    NSError * wrappedError = error ? PA2WrapError(error, NULL) : nil;
     dispatch_async(dispatch_get_main_queue(), ^{
         if (!_task.isCanceled && _completion) {
-            _completion(_task, result, error);
+            _completion(_task, result, wrappedError);
             _current_async_operation = nil;
             _completion = nil;
             _task = nil;

--- a/proj-xcode/PowerAuth2Private/PA2PrivateConstants.h
+++ b/proj-xcode/PowerAuth2Private/PA2PrivateConstants.h
@@ -25,7 +25,6 @@
 #define PA2Def_PowerAuthErrorDomain                 @"PowerAuthErrorDomain"
 #define PA2Def_PowerAuthErrorInfoKey_AdditionalInfo @"PowerAuthErrorInfoKey_AdditionalInfo"
 #define PA2Def_PowerAuthErrorInfoKey_ResponseData   @"PowerAuthErrorInfoKey_ResponseData"
-#define PA2Def_PowerAuthErrorInfoKey_ResponseData   @"PowerAuthErrorInfoKey_ResponseData"
 #define PA2Def_PowerAuthErrorInfoKey_ExtPendingApp  @"PowerAuthErrorInfoKey_ExternalPendingApplication"
 
 // Keychain constants, must keep PA2* naming to maintaing a compatibility with older SDK versions

--- a/proj-xcode/PowerAuthCore/PowerAuthCoreError.h
+++ b/proj-xcode/PowerAuthCore/PowerAuthCoreError.h
@@ -23,6 +23,10 @@ POWERAUTH_EXTERN_C NSString * __nonnull const PowerAuthCoreErrorDomain;
 /// information about error is stored.
 POWERAUTH_EXTERN_C NSString * __nonnull const PowerAuthCoreErrorInfoKey_AdditionalErrors;
 
+/// A key to `NSError.userInfo` dictionary where the optional `NSError` object re-created
+/// from the underlying C++ core failure is stored.
+POWERAUTH_EXTERN_C NSString * __nonnull const PowerAuthCoreErrorInfoKey_CoreError;
+
 /// Error codes returned for `PowerAuthCoreErrorDomain` errors.
 typedef NS_ENUM(NSInteger, PowerAuthCoreError) {
     PowerAuthCoreError_NA,

--- a/proj-xcode/PowerAuthCore/PowerAuthCoreError.mm
+++ b/proj-xcode/PowerAuthCore/PowerAuthCoreError.mm
@@ -22,6 +22,7 @@
 
 NSString * const PowerAuthCoreErrorDomain                   = @"PowerAuthCoreErrorDomain";
 NSString * const PowerAuthCoreErrorInfoKey_AdditionalErrors = @"PowerAuthCoreErrorInfoKey_AdditionalErrors";
+NSString * const PowerAuthCoreErrorInfoKey_CoreError        = @"PowerAuthCoreErrorInfoKey_CoreError";
 
 @implementation NSError (PowerAuthCoreError)
 

--- a/proj-xcode/PowerAuthCore/PowerAuthCoreTask.mm
+++ b/proj-xcode/PowerAuthCore/PowerAuthCoreTask.mm
@@ -24,6 +24,7 @@
     BOOL _responseCaptured;
     id _responseObject;
     id _responseJson;
+    PowerAuthCoreRequest * _lastRequest;
 }
 
 - (id) initWithTask:(powerAuth::TaskPtr&)task
@@ -111,9 +112,25 @@
 {
     try {
         auto request = _task->getNextRequest();
-        return request ? [[PowerAuthCoreRequest alloc] initWithRequest:request] : nil;
+        _lastRequest = request ? [[PowerAuthCoreRequest alloc] initWithRequest:request] : nil;
+        return _lastRequest;
     } catch (...) {
-        _failure = powerAuth::BuildNSErrorFromException();
+        // The error re-created from the C++ exception contains only the error code and message.
+        // If the failure was caused by the last executed request, then prefer its original
+        // failure, because it may contain additional information, such as the REST API error
+        // response received from the server. To not lose any information, the re-created error
+        // is attached to the failure's userInfo under the `PowerAuthCoreErrorInfoKey_CoreError` key.
+        NSError * coreError = powerAuth::BuildNSErrorFromException();
+        NSError * lastRequestFailure = _lastRequest.failure;
+        if (lastRequestFailure) {
+            NSMutableDictionary * userInfo = [lastRequestFailure.userInfo mutableCopy];
+            userInfo[PowerAuthCoreErrorInfoKey_CoreError] = coreError;
+            _failure = [NSError errorWithDomain:lastRequestFailure.domain
+                                           code:lastRequestFailure.code
+                                       userInfo:userInfo];
+        } else {
+            _failure = coreError;
+        }
         if (error) {
             *error = _failure;
         }

--- a/proj-xcode/PowerAuthCore/PowerAuthCoreTask.mm
+++ b/proj-xcode/PowerAuthCore/PowerAuthCoreTask.mm
@@ -123,7 +123,7 @@
         NSError * coreError = powerAuth::BuildNSErrorFromException();
         NSError * lastRequestFailure = _lastRequest.failure;
         if (lastRequestFailure) {
-            NSMutableDictionary * userInfo = [lastRequestFailure.userInfo mutableCopy];
+            NSMutableDictionary * userInfo = [NSMutableDictionary dictionaryWithDictionary:lastRequestFailure.userInfo ?: @{}];
             userInfo[PowerAuthCoreErrorInfoKey_CoreError] = coreError;
             _failure = [NSError errorWithDomain:lastRequestFailure.domain
                                            code:lastRequestFailure.code


### PR DESCRIPTION
Fixes #908.

- `PowerAuthCoreTask` now throws/returns an original HTTP error instead of the recreated C++ error, which was lacking many attributes
- Wrapping all possible NSError via `PA2WrapError` to ensure consistency for the error handling.