### PR TITLE
Fix #910: Fix missing class lombok.Generated issue

### DIFF
--- a/proj-android/PowerAuthLibrary/proguard-rules.pro
+++ b/proj-android/PowerAuthLibrary/proguard-rules.pro
@@ -30,3 +30,4 @@
 }
 # necessary for R8 fullMode
 -keep, allowobfuscation class io.getlime.core.rest.model.base.**
+-dontwarn lombok.Generated


### PR DESCRIPTION
Fixes https://github.com/wultra/powerauth-mobile-sdk/issues/910

The described error originates from the `rest-model-base` dependency, specifically the `Error` class, which uses Lombok to generate boilerplate methods. Lombok then annotates its generated methods with `@lombok.Generated`. During the build, R8 attempts to resolve this annotation but fails, since the Lombok library itself was never added as a dependency.

Since `lombok.Generated` is not runtime annotation it seems safe to just suppress the unresolved reference. Alternatively, we have to add Lombok as a compile dependency, which would let R8 resolve the class properly, but suppressing the specific warning is simpler and has no functional downside here.